### PR TITLE
Add inventory item drop functionality

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
       "name": "@elizaos/plugin-hyperscape",
       "version": "1.0.6",
       "dependencies": {
-        "@elizaos/core": "^1.6.1",
+        "@elizaos/core": "^1.2.9",
         "@elizaos/plugin-sql": "^1.2.9",
         "@elizaos/server": "^1.2.9",
         "@hyperscape/shared": "workspace:*",
@@ -315,7 +315,7 @@
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "livekit-client": "^2.9.9",
-        "livekit-server-sdk": "^2.14.0",
+        "livekit-server-sdk": "^2.11.0",
         "lodash-es": "^4.17.21",
         "lucide-react": "^0.469.0",
         "moment": "^2.30.1",
@@ -387,9 +387,9 @@
     },
   },
   "overrides": {
+    "typescript": "^5.9.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.9.2",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -294,7 +294,7 @@ export function Sidebar({ world, ui: _ui }: SidebarProps) {
             windowId="inventory"
             onClose={() => closeWindow('inventory')}
           >
-            <InventoryPanel items={inventory} coins={coins} />
+            <InventoryPanel items={inventory} coins={coins} world={world} />
           </GameWindow>
         )}
 

--- a/packages/client/src/components/panels/InventoryPanel.tsx
+++ b/packages/client/src/components/panels/InventoryPanel.tsx
@@ -8,6 +8,7 @@ import type { InventorySlotItem } from '@hyperscape/shared'
 interface InventoryPanelProps {
   items: InventorySlotItem[]
   coins: number
+  world?: any
   onItemMove?: (fromIndex: number, toIndex: number) => void
   onItemUse?: (item: InventorySlotItem, index: number) => void
   onItemEquip?: (item: InventorySlotItem) => void
@@ -50,6 +51,27 @@ function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
       {...listeners}
       className={`relative bg-black/35 border rounded flex items-center justify-center text-white text-[10px] ${item ? 'cursor-grab active:cursor-grabbing' : 'cursor-default'}`}
       title={item ? `${item.itemId} (${item.quantity})` : 'Empty slot'}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        if (!item) return
+        const items = [
+          { id: 'drop', label: `Drop ${item.itemId}`, enabled: true },
+          { id: 'examine', label: 'Examine', enabled: true },
+        ]
+        const evt = new CustomEvent('contextmenu', {
+          detail: {
+            target: {
+              id: `inventory_slot_${index}`,
+              type: 'inventory',
+              name: item.itemId,
+            },
+            mousePosition: { x: e.clientX, y: e.clientY },
+            items,
+          },
+        })
+        window.dispatchEvent(evt)
+      }}
     >
       {item ? item.itemId.substring(0, 3) : ''}
       {item && item.quantity > 1 ? (
@@ -61,10 +83,13 @@ function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
   )
 }
 
-export function InventoryPanel({ items, coins, onItemMove, onItemUse: _onItemUse, onItemEquip: _onItemEquip }: InventoryPanelProps) {
+export function InventoryPanel({ items, coins, world, onItemMove, onItemUse: _onItemUse, onItemEquip: _onItemEquip }: InventoryPanelProps) {
   const slots: (InventorySlotItem | null)[] = Array(28).fill(null)
-  items.forEach((item, i) => {
-    if (i < 28) slots[i] = item
+  items.forEach((item) => {
+    const s = (item as { slot?: number }).slot
+    if (typeof s === 'number' && s >= 0 && s < 28) {
+      slots[s] = item
+    }
   })
   
   const gridRef = useRef<HTMLDivElement | null>(null)
@@ -73,8 +98,37 @@ export function InventoryPanel({ items, coins, onItemMove, onItemUse: _onItemUse
   const [slotItems, setSlotItems] = useState<(InventorySlotItem | null)[]>(slots)
 
   useEffect(() => {
+    const onCtxSelect = (evt: Event) => {
+      const ce = evt as CustomEvent<{ actionId: string; targetId: string }>
+      const target = ce.detail?.targetId || ''
+      if (!target.startsWith('inventory_slot_')) return
+      const slotIndex = parseInt(target.replace('inventory_slot_', ''), 10)
+      if (Number.isNaN(slotIndex)) return
+      const it = slotItems[slotIndex]
+      if (!it) return
+      if (ce.detail.actionId === 'drop') {
+        try {
+          world?.network?.dropItem?.(it.itemId, slotIndex, it.quantity || 1)
+        } catch {
+          world?.network?.send?.('dropItem', { itemId: it.itemId, slot: slotIndex, quantity: it.quantity || 1 })
+        }
+      }
+      if (ce.detail.actionId === 'examine') {
+        world?.emit?.('@ui:toast', { message: `It's a ${it.itemId}.`, type: 'info' })
+      }
+    }
+    window.addEventListener('contextmenu:select', onCtxSelect as EventListener)
+    return () => window.removeEventListener('contextmenu:select', onCtxSelect as EventListener)
+  }, [slotItems, world])
+
+  useEffect(() => {
     const newSlots: (InventorySlotItem | null)[] = Array(28).fill(null)
-    items.forEach((item, i) => { if (i < 28) newSlots[i] = item })
+    items.forEach((item) => {
+      const s = (item as { slot?: number }).slot
+      if (typeof s === 'number' && s >= 0 && s < 28) {
+        newSlots[s] = item
+      }
+    })
     setSlotItems(newSlots)
   }, [items])
 

--- a/packages/shared/src/entities/ItemEntity.ts
+++ b/packages/shared/src/entities/ItemEntity.ts
@@ -58,6 +58,7 @@ import type { World } from '../World';
 import type { ItemType, MeshUserData, Item } from '../types/core';
 import { EquipmentSlotName, WeaponType } from '../types/core';
 import type { EntityInteractionData, ItemEntityConfig } from '../types/entities';
+import type { EntityData } from '../types';
 import { InteractableEntity, type InteractableConfig } from './InteractableEntity';
 import { EventType } from '../types/events';
 import { modelCache } from '../utils/ModelCache';
@@ -101,10 +102,11 @@ export class ItemEntity extends InteractableEntity {
       return;
     }
     
-    // Try to load 3D model if available
-    if (this.config.model && this.world.loader) {
+    // Try to load 3D model if available (model or modelPath)
+    const modelToLoad = this.config.model || this.config.modelPath || null;
+    if (modelToLoad && this.world.loader) {
       try {
-        const { scene } = await modelCache.loadModel(this.config.model, this.world);
+        const { scene } = await modelCache.loadModel(modelToLoad, this.world);
         
         this.mesh = scene;
         this.mesh.name = `Item_${this.config.itemId}`;
@@ -320,6 +322,7 @@ export class ItemEntity extends InteractableEntity {
     return {
       ...baseData,
       model: this.config.model,
+      modelPath: this.config.modelPath,
       itemId: this.config.itemId,
       itemType: this.config.itemType,
       quantity: this.config.quantity,
@@ -327,5 +330,21 @@ export class ItemEntity extends InteractableEntity {
       rarity: this.config.rarity,
       stackable: this.config.stackable
     };
+  }
+
+  // Override serialize to include model data for network sync
+  serialize(): EntityData {
+    const baseData = super.serialize();
+    return {
+      ...baseData,
+      model: this.config.model,
+      modelPath: this.config.modelPath,
+      itemId: this.config.itemId,
+      itemType: this.config.itemType,
+      quantity: this.config.quantity,
+      value: this.config.value,
+      rarity: this.config.rarity,
+      stackable: this.config.stackable
+    } as EntityData;
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -304,6 +304,7 @@ export type {
   SkillData,
   MovementComponent,
   InventoryItem,
+  InventorySlotItem,
   Item,
   Inventory,
   PlayerEquipment,

--- a/packages/shared/src/packets.ts
+++ b/packages/shared/src/packets.ts
@@ -119,6 +119,8 @@ const names = [
   'attackMob',
   // Item pickup packets
   'pickupItem',
+  // Inventory action packets
+  'dropItem',
   // Inventory sync packets
   'inventoryUpdated',
   // UI feedback packets

--- a/packages/shared/src/systems/ClientNetwork.ts
+++ b/packages/shared/src/systems/ClientNetwork.ts
@@ -926,6 +926,11 @@ export class ClientNetwork extends SystemBase {
     this.send('enterWorld', {})
   }
 
+  // Inventory actions
+  dropItem(itemId: string, slot?: number, quantity?: number) {
+    this.send('dropItem', { itemId, slot, quantity })
+  }
+
   onEntityRemoved = (id: string) => {
     // Remove from interpolation tracking
     this.interpolationStates.delete(id)

--- a/packages/shared/src/systems/ItemSpawnerSystem.ts
+++ b/packages/shared/src/systems/ItemSpawnerSystem.ts
@@ -243,7 +243,6 @@ export class ItemSpawnerSystem extends SystemBase {
     this.#lastKnownIndex[itemData.type] = index;
     const itemId = `gdd_${itemData.id}_${location}_${index}`;
     
-    
     // Ground item to terrain - use Infinity to allow any initial height difference
     // This is safe because we're always grounding to actual terrain height
     const groundedPosition = groundToTerrain(this.world, position, 0.2, Infinity);
@@ -394,12 +393,11 @@ export class ItemSpawnerSystem extends SystemBase {
     return loot;
   }
 
-  private async spawnItemAtLocation(data: { itemId: string; position: { x: number; y: number; z: number }; quantity?: number }, index: number): Promise<void> {
+  private async spawnItemAtLocation(data: { itemId: string; position: { x: number; y: number; z: number }; quantity?: number; model?: string }, index: number): Promise<void> {
     const itemData = getItem(data.itemId);
     if (!itemData) {
       throw new Error(`[ItemSpawnerSystem] Unknown item ID: ${data.itemId}`);
     }
-    
     await this.spawnItemFromData(itemData, data.position, 'spawned', 'Dynamic Spawn', index);
   }
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -65,7 +65,7 @@ export {
 
 export type {
   AnimationTask, BankData, BankEntityData, CombatBonuses, CombatTarget, DialogueNode,
-  DialogueSession, EquipmentComponent, EquipmentSlot, InteractionAction, InventoryItem, LootTable, MeshUserData, MobEntityData, PrayerComponent, RespawnTask, SkillData, Spawner, SpawnPoint, StatsComponent
+  DialogueSession, EquipmentComponent, EquipmentSlot, InteractionAction, InventoryItem, InventorySlotItem, LootTable, MeshUserData, MobEntityData, PrayerComponent, RespawnTask, SkillData, Spawner, SpawnPoint, StatsComponent
 } from './core';
 
 export type PlayerEquipment = PlayerEquipmentItems;


### PR DESCRIPTION
- Add right-click context menu for inventory items (Drop, Examine)
- Wire client drop request to server via dropItem packet
- Make drop server-authoritative to prevent duplication
- Route dropped items through grounded spawn system
- Fix ItemEntity serialization to include modelPath for network sync
- Items now spawn with correct 3D models from manifest
- Works for all item types (logs, arrows, fish, equipment, etc.)"