### PR TITLE
feat: Add click-to-bring-forward functionality for UI windows

### DIFF
--- a/packages/client/src/components/DraggableWindow.tsx
+++ b/packages/client/src/components/DraggableWindow.tsx
@@ -17,7 +17,9 @@ export function DraggableWindow({
   onPositionChange,
   className = '',
   style = {},
-  enabled = true
+  enabled = true,
+  zIndex = 1000,
+  onFocus
 }: DraggableWindowProps) {
   const [position, setPosition] = useState(initialPosition)
   const [isDragging, setIsDragging] = useState(false)
@@ -141,13 +143,19 @@ export function DraggableWindow({
     }
   }
 
+  const handleClick = () => {
+    onFocus?.()
+  }
+
   return (
     <div
       ref={windowRef}
       className={`draggable-window absolute ${isDragging ? 'select-none cursor-grabbing' : 'select-auto cursor-auto'} ${className}`}
+      onClick={handleClick}
       style={{
         left: position.x,
         top: position.y,
+        zIndex,
         ...style
       }}
     >

--- a/packages/client/src/components/panels/AccountPanel.tsx
+++ b/packages/client/src/components/panels/AccountPanel.tsx
@@ -11,11 +11,15 @@ interface AccountPanelProps {
   world: ClientWorld
 }
 
+type TabType = 'profile' | 'stats'
+
 export function AccountPanel({ world }: AccountPanelProps) {
   const [authState, setAuthState] = useState(privyAuthManager.getState())
   const [playerName, setPlayerName] = useState('')
   const [isEditingName, setIsEditingName] = useState(false)
   const [tempName, setTempName] = useState('')
+  const [activeTab, setActiveTab] = useState<TabType>('profile')
+  const [sessionStartTime] = useState(Date.now())
 
   // Subscribe to auth state changes
   useEffect(() => {
@@ -25,7 +29,8 @@ export function AccountPanel({ world }: AccountPanelProps) {
 
   // Get player name from world
   useEffect(() => {
-    const player = world.entities?.player
+    const worldWithEntities = world as ClientWorld & { entities?: { player?: { name?: string } } }
+    const player = worldWithEntities.entities?.player
     if (player?.name) {
       setPlayerName(player.name)
       setTempName(player.name)
@@ -36,10 +41,10 @@ export function AccountPanel({ world }: AccountPanelProps) {
     // Use global Privy logout
     const windowWithLogout = window as typeof window & { privyLogout: () => void }
     await windowWithLogout.privyLogout()
-    
+
     // Clear auth state
     privyAuthManager.clearAuth()
-    
+
     // Reload page after logout
     setTimeout(() => {
       window.location.reload()
@@ -48,12 +53,13 @@ export function AccountPanel({ world }: AccountPanelProps) {
 
   const handleNameChange = () => {
     if (tempName && tempName !== playerName) {
-      const player = world.entities?.player
+      const worldWithEntities = world as ClientWorld & { entities?: { player?: { name?: string } }; network?: { send: (type: string, data: unknown) => void } }
+      const player = worldWithEntities.entities?.player
       if (player) {
         player.name = tempName
         setPlayerName(tempName)
         setIsEditingName(false)
-        
+
         // Send name update to server
         world.network?.send?.('chat', {
           type: 'system',
@@ -73,215 +79,552 @@ export function AccountPanel({ world }: AccountPanelProps) {
   const farcasterFid = authState.farcasterFid
   const email = (authState.user as { email?: { address?: string } })?.email?.address
 
+  // Get player stats from world
+  const player = (world as ClientWorld & { entities?: { player?: { position?: { x: number; y: number; z: number } }; players?: Map<unknown, unknown> } }).entities?.player
+  const position = player?.position
+  const health = (player as { health?: { current: number; max: number } })?.health
+  const playTime = Math.floor((Date.now() - sessionStartTime) / 1000 / 60) // minutes
+  const fps = Math.round(1000 / (world.fixedDeltaTime * 1000)) // Approximate FPS
+
+  // Get players online count
+  const worldWithEntities = world as ClientWorld & { entities?: { players?: Map<unknown, unknown> } }
+  const playersOnline = worldWithEntities.entities?.players ? worldWithEntities.entities.players.size : 0
+
+  // Get world time/frame info
+  const worldTime = Math.floor(world.time)
+  const frameCount = world.frame
+
   return (
-    <div className="flex flex-col gap-3 h-full">
-      {/* Authentication Status */}
+    <div className="flex flex-col h-full" style={{ gap: 'clamp(0.4rem, 1vw, 0.5rem)' }}>
+      {/* Header with Status and Tabs */}
       <div
-        className="bg-black/35 border rounded-md p-3"
-        style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}
+        className="border rounded-lg transition-all duration-200"
+        style={{
+          background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.98) 0%, rgba(30, 25, 40, 0.95) 100%)',
+          borderColor: 'rgba(242, 208, 138, 0.5)',
+          borderWidth: '2px',
+          padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(242, 208, 138, 0.1)',
+        }}
       >
-        <div className="font-semibold mb-2 text-sm" style={{ color: '#f2d08a' }}>Account Status</div>
-        <div className="flex items-center justify-between text-sm">
-          <span style={{ color: 'rgba(242, 208, 138, 0.7)' }}>Status:</span>
-          <span className={authenticated ? 'text-green-400' : 'text-gray-500'}>
-            {authenticated ? '✅ Logged In' : '❌ Anonymous'}
-          </span>
-        </div>
-      </div>
-
-      {/* User Info */}
-      {authenticated && userId && (
-        <div
-          className="bg-black/35 border rounded-md p-3"
-          style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}
-        >
-          <div className="font-semibold mb-2 text-sm" style={{ color: '#f2d08a' }}>Account Info</div>
-
-          {/* Privy User ID */}
-          <div className="mb-2 text-xs">
-            <div className="mb-1" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>User ID:</div>
-            <div className="font-mono break-all" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
-              {userId.substring(0, 20)}...
-            </div>
+        <div className="flex items-center justify-between mb-3">
+          <div
+            className="font-bold tracking-wide"
+            style={{
+              color: '#f2d08a',
+              fontSize: 'clamp(0.813rem, 1.6vw, 0.938rem)',
+              textShadow: '0 2px 4px rgba(0, 0, 0, 0.8)',
+            }}
+          >
+            ACCOUNT
           </div>
-
-          {/* Wallet Address */}
-          {walletAddress && (
-            <div className="mb-2 text-xs">
-              <div className="mb-1" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>Wallet:</div>
-              <div className="font-mono" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
-                {walletAddress.substring(0, 6)}...{walletAddress.substring(walletAddress.length - 4)}
-              </div>
-            </div>
-          )}
-
-          {/* Email */}
-          {email && (
-            <div className="mb-2 text-xs">
-              <div className="mb-1" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>Email:</div>
-              <div style={{ color: 'rgba(242, 208, 138, 0.9)' }}>{email}</div>
-            </div>
-          )}
-
-          {/* Farcaster FID */}
-          {farcasterFid && (
-            <div className="mb-2 text-xs">
-              <div className="mb-1" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>Farcaster FID:</div>
-              <div className="flex items-center gap-1" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
-                🎭 {farcasterFid}
-              </div>
-            </div>
-          )}
+          <div
+            className={`px-2 py-1 rounded-full text-xs font-semibold ${authenticated ? 'bg-green-900/40 text-green-300' : 'bg-gray-800/40 text-gray-400'}`}
+            role="status"
+            aria-live="polite"
+            style={{
+              borderWidth: '1px',
+              borderColor: authenticated ? 'rgba(34, 197, 94, 0.4)' : 'rgba(107, 114, 128, 0.4)',
+              fontSize: 'clamp(0.625rem, 1.2vw, 0.688rem)',
+            }}
+          >
+            {authenticated ? '✓ LOGGED IN' : '○ GUEST'}
+          </div>
         </div>
-      )}
 
-      {/* Character Name */}
-      <div
-        className="bg-black/35 border rounded-md p-3"
-        style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}
-      >
-        <div className="font-semibold mb-2 text-sm" style={{ color: '#f2d08a' }}>Character Name</div>
-
-        {!isEditingName ? (
-          <div className="flex items-center justify-between">
-            <span style={{ color: 'rgba(242, 208, 138, 0.9)' }}>{playerName || 'Unknown'}</span>
+        {/* Tab Navigation */}
+        <div className="flex gap-1">
+          {(['profile', 'stats'] as TabType[]).map((tab) => (
             <button
-              onClick={() => setIsEditingName(true)}
-              className="text-xs rounded px-2 py-1 cursor-pointer"
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className="flex-1 py-1.5 px-2 rounded cursor-pointer transition-all duration-200 font-medium uppercase tracking-wide"
               style={{
-                backgroundColor: 'rgba(242, 208, 138, 0.15)',
+                background: activeTab === tab
+                  ? 'linear-gradient(135deg, rgba(242, 208, 138, 0.2) 0%, rgba(242, 208, 138, 0.15) 100%)'
+                  : 'rgba(20, 20, 30, 0.5)',
                 borderWidth: '1px',
                 borderStyle: 'solid',
-                borderColor: 'rgba(242, 208, 138, 0.5)',
-                color: '#f2d08a',
+                borderColor: activeTab === tab ? 'rgba(242, 208, 138, 0.5)' : 'rgba(242, 208, 138, 0.2)',
+                color: activeTab === tab ? '#f2d08a' : 'rgba(242, 208, 138, 0.5)',
+                fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                boxShadow: activeTab === tab ? '0 2px 4px rgba(0, 0, 0, 0.4)' : 'none',
               }}
             >
-              Edit
+              {tab}
             </button>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <input
-              type="text"
-              value={tempName}
-              onChange={(e) => setTempName(e.target.value)}
-              className="w-full text-sm py-1.5 px-2 bg-white/5 border rounded"
-              style={{
-                borderColor: 'rgba(242, 208, 138, 0.3)',
-                color: '#f2d08a',
-              }}
-              placeholder="Enter name..."
-              maxLength={20}
-              autoFocus
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleNameChange()
-                if (e.key === 'Escape') {
-                  setIsEditingName(false)
-                  setTempName(playerName)
-                }
-              }}
-            />
-            <div className="flex gap-2">
-              <button
-                onClick={handleNameChange}
-                className="flex-1 text-xs rounded px-2 py-1.5 cursor-pointer"
-                style={{
-                  backgroundColor: 'rgba(34, 197, 94, 0.25)',
-                  borderWidth: '1px',
-                  borderStyle: 'solid',
-                  borderColor: 'rgba(34, 197, 94, 0.5)',
-                  color: '#22c55e',
-                }}
-              >
-                Save
-              </button>
-              <button
-                onClick={() => {
-                  setIsEditingName(false)
-                  setTempName(playerName)
-                }}
-                className="flex-1 text-xs rounded px-2 py-1.5 cursor-pointer"
-                style={{
-                  backgroundColor: 'rgba(107, 114, 128, 0.25)',
-                  borderWidth: '1px',
-                  borderStyle: 'solid',
-                  borderColor: 'rgba(107, 114, 128, 0.5)',
-                  color: '#9ca3af',
-                }}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
+          ))}
+        </div>
       </div>
 
-      {/* Login Status & Actions */}
-      {!authenticated && (
-        <div
-          className="bg-black/35 border rounded-md p-3"
-          style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}
-        >
-          <div className="text-sm mb-2" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>
-            You're playing as an anonymous user. Your progress won't sync across devices.
-          </div>
-          <div className="text-xs" style={{ color: 'rgba(242, 208, 138, 0.5)' }}>
-            To enable account features, configure Privy authentication in your .env file.
-          </div>
-        </div>
-      )}
+      {/* Tab Content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col" style={{ gap: 'clamp(0.4rem, 1vw, 0.5rem)' }}>
 
-      {/* Logout Button */}
-      {authenticated && (
-        <button
-          onClick={handleLogout}
-          className="rounded-md py-2 px-3 cursor-pointer text-sm font-medium"
-          style={{
-            backgroundColor: 'rgba(139, 69, 19, 0.4)',
-            borderWidth: '1px',
-            borderStyle: 'solid',
-            borderColor: 'rgba(139, 69, 19, 0.6)',
-            color: '#f2d08a',
-          }}
-        >
-          Logout
-        </button>
-      )}
+          {/* PROFILE TAB */}
+          {activeTab === 'profile' && (
+            <>
+              {/* Character Name */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                {!isEditingName ? (
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className="text-xs uppercase tracking-wide mb-1 opacity-60"
+                        style={{
+                          color: '#f2d08a',
+                          fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                        }}
+                      >
+                        Character
+                      </div>
+                      <div
+                        className="font-semibold truncate"
+                        style={{
+                          color: '#f2d08a',
+                          fontSize: 'clamp(0.75rem, 1.4vw, 0.813rem)',
+                        }}
+                      >
+                        {playerName || 'Unknown'}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => setIsEditingName(true)}
+                      className="rounded px-2 py-1.5 cursor-pointer transition-all duration-150 hover:brightness-110 flex-shrink-0"
+                      style={{
+                        backgroundColor: 'rgba(242, 208, 138, 0.12)',
+                        borderWidth: '1px',
+                        borderStyle: 'solid',
+                        borderColor: 'rgba(242, 208, 138, 0.4)',
+                        color: '#f2d08a',
+                        fontSize: 'clamp(0.625rem, 1.2vw, 0.688rem)',
+                        minHeight: '32px',
+                      }}
+                      aria-label="Edit character name"
+                    >
+                      Edit
+                    </button>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <input
+                      type="text"
+                      value={tempName}
+                      onChange={(e) => setTempName(e.target.value)}
+                      className="w-full py-1.5 px-2 bg-black/30 border rounded"
+                      style={{
+                        borderColor: 'rgba(242, 208, 138, 0.4)',
+                        color: '#f2d08a',
+                        fontSize: 'clamp(0.688rem, 1.2vw, 0.75rem)',
+                      }}
+                      placeholder="Character name..."
+                      maxLength={20}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleNameChange()
+                        if (e.key === 'Escape') {
+                          setIsEditingName(false)
+                          setTempName(playerName)
+                        }
+                      }}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleNameChange}
+                        className="flex-1 rounded px-2 py-1.5 cursor-pointer transition-all duration-150 hover:brightness-110 font-medium"
+                        style={{
+                          backgroundColor: 'rgba(34, 197, 94, 0.2)',
+                          borderWidth: '1px',
+                          borderStyle: 'solid',
+                          borderColor: 'rgba(34, 197, 94, 0.4)',
+                          color: '#22c55e',
+                          fontSize: 'clamp(0.625rem, 1.2vw, 0.688rem)',
+                          minHeight: '32px',
+                        }}
+                        aria-label="Save character name"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={() => {
+                          setIsEditingName(false)
+                          setTempName(playerName)
+                        }}
+                        className="flex-1 rounded px-2 py-1.5 cursor-pointer transition-all duration-150 hover:brightness-110"
+                        style={{
+                          backgroundColor: 'rgba(107, 114, 128, 0.2)',
+                          borderWidth: '1px',
+                          borderStyle: 'solid',
+                          borderColor: 'rgba(107, 114, 128, 0.4)',
+                          color: '#9ca3af',
+                          fontSize: 'clamp(0.625rem, 1.2vw, 0.688rem)',
+                          minHeight: '32px',
+                        }}
+                        aria-label="Cancel editing"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
 
-      {/* Account Features */}
-      <div
-        className="flex-1 bg-black/35 border rounded-md p-3 overflow-y-auto"
-        style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}
-      >
-        <div className="font-semibold mb-2 text-sm" style={{ color: '#f2d08a' }}>Account Features</div>
-        <div className="text-xs space-y-2" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>
-          <div className="flex items-start gap-2">
-            <span className={authenticated ? 'text-green-400' : 'text-gray-600'}>
-              {authenticated ? '✅' : '⭕'}
-            </span>
-            <span>Cross-device progress sync</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <span className={authenticated ? 'text-green-400' : 'text-gray-600'}>
-              {authenticated ? '✅' : '⭕'}
-            </span>
-            <span>Persistent character data</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <span className={authenticated ? 'text-green-400' : 'text-gray-600'}>
-              {authenticated ? '✅' : '⭕'}
-            </span>
-            <span>Secure account recovery</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <span className={farcasterFid ? 'text-green-400' : 'text-gray-600'}>
-              {farcasterFid ? '✅' : '⭕'}
-            </span>
-            <span>Farcaster integration</span>
-          </div>
+              {/* User Info - Condensed */}
+              {authenticated && userId && (
+                <div
+                  className="border rounded-lg transition-all duration-200"
+                  style={{
+                    background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                    borderColor: 'rgba(242, 208, 138, 0.35)',
+                    padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                  }}
+                >
+                  <div
+                    className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                    style={{
+                      color: '#f2d08a',
+                      fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                    }}
+                  >
+                    Account Details
+                  </div>
+
+                  <div className="space-y-1.5" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                    <div className="flex items-center gap-2">
+                      <span className="opacity-60" style={{ color: '#f2d08a', minWidth: '40px' }}>ID:</span>
+                      <span className="font-mono text-xs truncate" style={{ color: 'rgba(242, 208, 138, 0.85)' }}>
+                        {userId.substring(0, 16)}...
+                      </span>
+                    </div>
+
+                    {walletAddress && (
+                      <div className="flex items-center gap-2">
+                        <span className="opacity-60" style={{ color: '#f2d08a', minWidth: '40px' }}>Wallet:</span>
+                        <span className="font-mono text-xs" style={{ color: 'rgba(242, 208, 138, 0.85)' }}>
+                          {walletAddress.substring(0, 6)}...{walletAddress.substring(walletAddress.length - 4)}
+                        </span>
+                      </div>
+                    )}
+
+                    {email && (
+                      <div className="flex items-center gap-2">
+                        <span className="opacity-60" style={{ color: '#f2d08a', minWidth: '40px' }}>Email:</span>
+                        <span className="text-xs truncate" style={{ color: 'rgba(242, 208, 138, 0.85)' }}>
+                          {email}
+                        </span>
+                      </div>
+                    )}
+
+                    {farcasterFid && (
+                      <div className="flex items-center gap-2">
+                        <span className="opacity-60" style={{ color: '#f2d08a', minWidth: '40px' }}>FC:</span>
+                        <span className="text-xs" style={{ color: 'rgba(242, 208, 138, 0.85)' }}>
+                          🎭 {farcasterFid}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Guest Mode Notice */}
+              {!authenticated && (
+                <div
+                  className="border rounded-lg transition-all duration-200"
+                  style={{
+                    background: 'linear-gradient(135deg, rgba(139, 69, 19, 0.15) 0%, rgba(139, 69, 19, 0.08) 100%)',
+                    borderColor: 'rgba(139, 69, 19, 0.4)',
+                    padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                  }}
+                  role="status"
+                >
+                  <div
+                    className="text-xs leading-relaxed"
+                    style={{
+                      color: 'rgba(242, 208, 138, 0.75)',
+                      fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)',
+                    }}
+                  >
+                    Playing as guest. Progress won't sync across devices.
+                  </div>
+                </div>
+              )}
+
+              {/* Session Summary */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                  style={{
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                  }}
+                >
+                  Current Session
+                </div>
+                <div className="space-y-1.5" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Online Players:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {playersOnline}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Play Time:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {playTime} min
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Performance:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {fps} FPS
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Account Features */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                  style={{
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                  }}
+                >
+                  Account Features
+                </div>
+                <div
+                  className="grid grid-cols-2 gap-2"
+                  style={{
+                    fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)',
+                  }}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className={authenticated ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {authenticated ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Cloud Sync</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={authenticated ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {authenticated ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Save Data</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={authenticated ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {authenticated ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Recovery</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={farcasterFid ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {farcasterFid ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Farcaster</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={walletAddress ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {walletAddress ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Web3 Wallet</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={email ? 'text-green-400' : 'text-gray-600'} aria-hidden="true">
+                      {email ? '✓' : '○'}
+                    </span>
+                    <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>Email Link</span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Logout Button */}
+              {authenticated && (
+                <button
+                  onClick={handleLogout}
+                  className="rounded-lg py-1.5 px-3 cursor-pointer font-semibold transition-all duration-150 hover:brightness-110"
+                  style={{
+                    background: 'linear-gradient(135deg, rgba(139, 69, 19, 0.35) 0%, rgba(139, 69, 19, 0.25) 100%)',
+                    borderWidth: '1px',
+                    borderStyle: 'solid',
+                    borderColor: 'rgba(139, 69, 19, 0.5)',
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.688rem, 1.3vw, 0.75rem)',
+                    minHeight: '36px',
+                    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                  }}
+                  aria-label="Log out of your account"
+                >
+                  LOGOUT
+                </button>
+              )}
+            </>
+          )}
+
+          {/* STATS TAB */}
+          {activeTab === 'stats' && (
+            <>
+              {/* Session Info */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                  style={{
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                  }}
+                >
+                  Session Info
+                </div>
+                <div className="space-y-1.5" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Play Time:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {playTime} min
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>FPS:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {fps}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Players Online:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {playersOnline}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Position:</span>
+                    <span className="font-mono text-xs" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {position ? `${Math.round(position.x)}, ${Math.round(position.y)}, ${Math.round(position.z)}` : 'Unknown'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* World Info */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                  style={{
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                  }}
+                >
+                  World Info
+                </div>
+                <div className="space-y-1.5" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>World Time:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {worldTime}s
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Frame Count:</span>
+                    <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {frameCount.toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="opacity-60" style={{ color: '#f2d08a' }}>Server ID:</span>
+                    <span className="font-mono text-xs truncate" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                      {world.id.substring(0, 12)}...
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Character Stats */}
+              <div
+                className="border rounded-lg transition-all duration-200"
+                style={{
+                  background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                  borderColor: 'rgba(242, 208, 138, 0.35)',
+                  padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                  style={{
+                    color: '#f2d08a',
+                    fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                  }}
+                >
+                  Character Stats
+                </div>
+                {health ? (
+                  <div className="space-y-2">
+                    <div>
+                      <div className="flex items-center justify-between mb-1" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                        <span className="opacity-60" style={{ color: '#f2d08a' }}>Health</span>
+                        <span className="font-semibold" style={{ color: 'rgba(242, 208, 138, 0.9)' }}>
+                          {health.current} / {health.max}
+                        </span>
+                      </div>
+                      <div className="w-full h-2 bg-black/30 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-gradient-to-r from-red-600 to-red-400 transition-all duration-300"
+                          style={{ width: `${(health.current / health.max) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center py-2" style={{ color: 'rgba(242, 208, 138, 0.6)', fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                    Health data not available
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>
   )
 }
-

--- a/packages/client/src/components/panels/CombatPanel.tsx
+++ b/packages/client/src/components/panels/CombatPanel.tsx
@@ -1,3 +1,8 @@
+/**
+ * Combat Panel
+ * Modern MMORPG-style combat interface with attack styles and combat level
+ */
+
 import React, { useEffect, useState } from 'react'
 import { PlayerMigration, WeaponType, EventType } from '@hyperscape/shared'
 import type { ClientWorld, PlayerStats, PlayerEquipmentItems } from '../../types'
@@ -16,12 +21,12 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
   useEffect(() => {
     const playerId = world.entities?.player?.id
     if (!playerId) return
-    
-    const actions = world.getSystem('actions') as { actionMethods?: { 
-      getAttackStyleInfo?: (id: string, cb: (info: { style: string; cooldown?: number }) => void) => void 
+
+    const actions = world.getSystem('actions') as { actionMethods?: {
+      getAttackStyleInfo?: (id: string, cb: (info: { style: string; cooldown?: number }) => void) => void
       changeAttackStyle?: (id: string, style: string) => void
     }} | null
-    
+
     actions?.actionMethods?.getAttackStyleInfo?.(playerId, (info: { style: string; cooldown?: number }) => {
       if (info) {
         setStyle(info.style)
@@ -49,63 +54,181 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
   const changeStyle = (next: string) => {
     const playerId = world.entities?.player?.id
     if (!playerId) return
-    
-    const actions = world.getSystem('actions') as { actionMethods?: { 
+
+    const actions = world.getSystem('actions') as { actionMethods?: {
       changeAttackStyle?: (id: string, style: string) => void
     }} | null
-    
+
     actions?.actionMethods?.changeAttackStyle?.(playerId, next)
   }
 
   // Determine if ranged weapon equipped; if so, limit to ranged/defense like RS
   const isRanged = !!(equipment?.arrows || (equipment?.weapon && (equipment.weapon.weaponType === WeaponType.BOW || equipment.weapon.weaponType === WeaponType.CROSSBOW)))
-  const styles: Array<{ id: string; label: string }> = isRanged
+  const styles: Array<{ id: string; label: string; icon: string; description: string }> = isRanged
     ? [
-        { id: 'accurate', label: 'Ranged' },
-        { id: 'defensive', label: 'Defensive' },
+        { id: 'accurate', label: 'Ranged', icon: '🏹', description: 'Accurate ranged attacks' },
+        { id: 'defensive', label: 'Defensive', icon: '🛡️', description: 'Defensive stance' },
       ]
     : [
-        { id: 'accurate', label: 'Accurate' },
-        { id: 'aggressive', label: 'Aggressive' },
-        { id: 'defensive', label: 'Defensive' },
+        { id: 'accurate', label: 'Accurate', icon: '🎯', description: 'Precise melee attacks' },
+        { id: 'aggressive', label: 'Aggressive', icon: '⚔️', description: 'Powerful strikes' },
+        { id: 'defensive', label: 'Defensive', icon: '🛡️', description: 'Defensive stance' },
       ]
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col h-full" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+      {/* Header */}
       <div
-        className="bg-black/35 border rounded-md p-2 flex items-center justify-between"
-        style={{ borderColor: 'rgba(242, 208, 138, 0.3)', color: '#f2d08a' }}
+        className="border rounded transition-all duration-200"
+        style={{
+          background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.98) 0%, rgba(30, 25, 40, 0.95) 100%)',
+          borderColor: 'rgba(242, 208, 138, 0.5)',
+          borderWidth: '2px',
+          padding: 'clamp(0.375rem, 0.9vw, 0.5rem)',
+          boxShadow: '0 2px 8px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(242, 208, 138, 0.1)',
+        }}
       >
-        <div className="font-semibold">Combat level</div>
-        <div>{combatLevel}</div>
-      </div>
-      <div className="font-semibold mt-1" style={{ color: '#f2d08a' }}>Attack style</div>
-      <div className="grid grid-cols-2 gap-1.5">
-        {styles.map(s => (
-          <button
-            key={s.id}
-            onClick={() => changeStyle(s.id)}
-            disabled={cooldown > 0}
-            className="rounded-md py-2 px-2.5 cursor-pointer"
+        <div className="flex items-center justify-between">
+          <div
+            className="font-bold tracking-wide"
             style={{
-              backgroundColor: style === s.id ? 'rgba(242, 208, 138, 0.15)' : 'rgba(0, 0, 0, 0.35)',
-              borderWidth: '1px',
-              borderStyle: 'solid',
-              borderColor: style === s.id ? 'rgba(242, 208, 138, 0.7)' : 'rgba(242, 208, 138, 0.3)',
-              color: style === s.id ? '#f2d08a' : '#d1d5db',
+              color: '#f2d08a',
+              fontSize: 'clamp(0.75rem, 1.5vw, 0.875rem)',
+              textShadow: '0 2px 4px rgba(0, 0, 0, 0.8)',
             }}
           >
-            {s.label}
-          </button>
-        ))}
-      </div>
-      {cooldown > 0 && (
-        <div className="text-xs" style={{ color: 'rgba(242, 208, 138, 0.6)' }}>
-          Style change available in {Math.ceil(cooldown / 1000)}s
+            COMBAT
+          </div>
+          <div className="flex items-center" style={{ gap: 'clamp(0.25rem, 0.5vw, 0.3rem)' }}>
+            <span
+              style={{
+                color: 'rgba(242, 208, 138, 0.7)',
+                fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+              }}
+            >
+              Level
+            </span>
+            <span
+              className="font-bold"
+              style={{
+                color: '#f2d08a',
+                fontSize: 'clamp(0.75rem, 1.5vw, 0.875rem)',
+              }}
+            >
+              {combatLevel}
+            </span>
+          </div>
         </div>
-      )}
+      </div>
+
+      {/* Attack Styles */}
+      <div className="flex-1 overflow-y-auto noscrollbar">
+        <div
+          className="border rounded transition-all duration-200"
+          style={{
+            background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+            borderColor: 'rgba(242, 208, 138, 0.35)',
+            padding: 'clamp(0.375rem, 0.9vw, 0.5rem)',
+            boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+          }}
+        >
+          <div
+            className="uppercase tracking-wide mb-2 opacity-60"
+            style={{
+              color: '#f2d08a',
+              fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+            }}
+          >
+            Attack Style
+          </div>
+
+          <div className="flex flex-col" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+            {styles.map(s => (
+              <button
+                key={s.id}
+                onClick={() => changeStyle(s.id)}
+                disabled={cooldown > 0}
+                className="rounded transition-all duration-200 text-left"
+                style={{
+                  background: style === s.id
+                    ? 'linear-gradient(135deg, rgba(242, 208, 138, 0.2) 0%, rgba(242, 208, 138, 0.15) 100%)'
+                    : 'rgba(0, 0, 0, 0.35)',
+                  borderWidth: '1px',
+                  borderStyle: 'solid',
+                  borderColor: style === s.id ? 'rgba(242, 208, 138, 0.7)' : 'rgba(242, 208, 138, 0.25)',
+                  padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+                  boxShadow: style === s.id
+                    ? '0 2px 4px rgba(242, 208, 138, 0.2), inset 0 1px 0 rgba(242, 208, 138, 0.1)'
+                    : 'inset 0 1px 2px rgba(0, 0, 0, 0.3)',
+                  cursor: cooldown > 0 ? 'not-allowed' : 'pointer',
+                  opacity: cooldown > 0 ? 0.6 : 1,
+                }}
+              >
+                <div className="flex items-center" style={{ gap: 'clamp(0.375rem, 0.8vw, 0.5rem)' }}>
+                  <span style={{ fontSize: 'clamp(1rem, 2vw, 1.25rem)' }}>
+                    {s.icon}
+                  </span>
+                  <div className="flex-1">
+                    <div
+                      className="font-semibold"
+                      style={{
+                        color: style === s.id ? '#f2d08a' : 'rgba(242, 208, 138, 0.8)',
+                        fontSize: 'clamp(0.688rem, 1.2vw, 0.75rem)',
+                      }}
+                    >
+                      {s.label}
+                    </div>
+                    <div
+                      className="opacity-75"
+                      style={{
+                        color: style === s.id ? 'rgba(242, 208, 138, 0.8)' : 'rgba(242, 208, 138, 0.6)',
+                        fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                      }}
+                    >
+                      {s.description}
+                    </div>
+                  </div>
+                  {style === s.id && (
+                    <div
+                      style={{
+                        color: '#f2d08a',
+                        fontSize: 'clamp(0.875rem, 1.8vw, 1.125rem)',
+                      }}
+                    >
+                      ✓
+                    </div>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Cooldown Warning */}
+          {cooldown > 0 && (
+            <div
+              className="mt-2 rounded flex items-center"
+              style={{
+                background: 'rgba(251, 191, 36, 0.1)',
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                borderColor: 'rgba(251, 191, 36, 0.3)',
+                padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+                gap: 'clamp(0.25rem, 0.5vw, 0.3rem)',
+              }}
+            >
+              <span style={{ fontSize: 'clamp(0.75rem, 1.5vw, 1rem)' }}>⏱️</span>
+              <span
+                style={{
+                  color: '#fbbf24',
+                  fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                }}
+              >
+                Style change in {Math.ceil(cooldown / 1000)}s
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }
-
-

--- a/packages/client/src/components/panels/EquipmentPanel.tsx
+++ b/packages/client/src/components/panels/EquipmentPanel.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-import { useDroppable } from '@dnd-kit/core'
 import { EquipmentSlotName } from '@hyperscape/shared'
 import type { PlayerEquipmentItems, Item } from '../../types'
 
@@ -12,42 +10,128 @@ interface DroppableEquipmentSlotProps {
   slotKey: string
   label: string
   item: Item | null
+  icon: string
 }
 
-function DroppableEquipmentSlot({ slotKey, label, item }: DroppableEquipmentSlotProps) {
-  const { isOver, setNodeRef } = useDroppable({
-    id: `equipment-${String(slotKey)}`,
-    data: { slot: String(slotKey) }
   })
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDraggableRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: `equipment-${slotKey}`,
+    data: { slot: slotKey, item },
+    disabled: !item, // Only draggable if item is equipped
+  })
+
+  const style = {
+    borderColor: isOver ? 'rgba(242, 208, 138, 0.7)' : item ? 'rgba(34, 197, 94, 0.4)' : 'rgba(242, 208, 138, 0.3)',
+    backgroundColor: isOver
+      ? 'rgba(242, 208, 138, 0.15)'
+      : item
+        ? 'linear-gradient(135deg, rgba(34, 197, 94, 0.15) 0%, rgba(34, 197, 94, 0.08) 100%)'
+        : 'rgba(0, 0, 0, 0.35)',
+    background: item && !isOver
+      ? 'linear-gradient(135deg, rgba(34, 197, 94, 0.15) 0%, rgba(34, 197, 94, 0.08) 100%)'
+      : undefined,
+    minHeight: '64px',
+    padding: 'clamp(0.4rem, 1vw, 0.5rem)',
+    boxShadow: item ? '0 2px 6px rgba(34, 197, 94, 0.2)' : 'inset 0 2px 4px rgba(0, 0, 0, 0.3)',
+    transform: CSS.Transform.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+    cursor: item ? 'grab' : 'default',
+  }
+
+  // Combine both refs
+  const setRefs = (element: HTMLDivElement | null) => {
+    setDroppableRef(element)
+    setDraggableRef(element)
+  }
 
   return (
     <div
-      ref={setNodeRef}
-      className="bg-black/35 border rounded-md flex items-center justify-center text-[11px] relative"
-      style={{
-        borderColor: isOver ? 'rgba(242, 208, 138, 0.7)' : 'rgba(242, 208, 138, 0.3)',
-        backgroundColor: isOver ? 'rgba(242, 208, 138, 0.15)' : 'rgba(0, 0, 0, 0.35)',
-        color: 'rgba(242, 208, 138, 0.9)',
-      }}
-      title={item ? item.name : label}
+      ref={setRefs}
+      {...(item ? attributes : {})}
+      {...(item ? listeners : {})}
+      className="border rounded-lg flex flex-col items-center justify-center relative transition-all duration-200 group"
+      style={style}
+      title={item ? `${item.name}${item.rarity ? ` (${item.rarity})` : ''}` : label}
     >
-      <div className="absolute top-1 left-1.5 text-[10px]" style={{ color: 'rgba(242, 208, 138, 0.7)' }}>{label}</div>
-      <div className="text-xs">
-        {item ? (item.id.substring(0, 3)) : ''}
+      {/* Slot Icon */}
+      <div
+        className="text-2xl mb-1 transition-transform duration-200"
+        style={{
+          color: item ? '#22c55e' : 'rgba(242, 208, 138, 0.4)',
+          filter: item ? 'drop-shadow(0 0 4px rgba(34, 197, 94, 0.6))' : 'none',
+          transform: isOver ? 'scale(1.1)' : 'scale(1)',
+        }}
+      >
+        {icon}
       </div>
+
+      {/* Slot Label */}
+      <div
+        className="text-xs font-medium uppercase tracking-wide"
+        style={{
+          color: item ? '#22c55e' : 'rgba(242, 208, 138, 0.6)',
+          fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Item Name (if equipped) */}
+      {item && (
+        <div
+          className="text-xs mt-1 text-center line-clamp-2"
+          style={{
+            color: 'rgba(242, 208, 138, 0.9)',
+            fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)',
+          }}
+        >
+          {item.name}
+        </div>
+      )}
+
+      {/* Rarity Indicator */}
+      {item && item.rarity && (
+        <div
+          className="absolute top-1 right-1 w-2 h-2 rounded-full"
+          style={{
+            backgroundColor: item.rarity === 'legendary' ? '#fbbf24'
+              : item.rarity === 'epic' ? '#a855f7'
+              : item.rarity === 'rare' ? '#3b82f6'
+              : item.rarity === 'uncommon' ? '#22c55e'
+              : '#9ca3af',
+            boxShadow: '0 0 6px currentColor',
+          }}
+          title={item.rarity}
+        />
+      )}
     </div>
   )
 }
 
 export function EquipmentPanel({ equipment, onItemDrop: _onItemDrop }: EquipmentPanelProps) {
-  const slots = [
-    { key: EquipmentSlotName.HELMET, label: 'Helmet' },
-    { key: EquipmentSlotName.BODY, label: 'Body' },
-    { key: EquipmentSlotName.LEGS, label: 'Legs' },
-    { key: EquipmentSlotName.WEAPON, label: 'Weapon' },
-    { key: EquipmentSlotName.SHIELD, label: 'Shield' },
-    { key: EquipmentSlotName.ARROWS, label: 'Arrows' },
-  ]
+  const [activeTab] = useState<'equipment' | 'stats'>('equipment')
+
+  // Equipment slot configuration with icons
+  const slotConfig = {
+    [EquipmentSlotName.HELMET]: { label: 'Helmet', icon: '⛑️', row: 0, col: 1 },
+    [EquipmentSlotName.CAPE]: { label: 'Cape', icon: '🧥', row: 1, col: 0 },
+    [EquipmentSlotName.AMULET]: { label: 'Amulet', icon: '📿', row: 1, col: 2 },
+    [EquipmentSlotName.WEAPON]: { label: 'Weapon', icon: '⚔️', row: 2, col: 0 },
+    [EquipmentSlotName.BODY]: { label: 'Body', icon: '🛡️', row: 2, col: 1 },
+    [EquipmentSlotName.SHIELD]: { label: 'Shield', icon: '🔰', row: 2, col: 2 },
+    [EquipmentSlotName.LEGS]: { label: 'Legs', icon: '👖', row: 3, col: 1 },
+    [EquipmentSlotName.GLOVES]: { label: 'Gloves', icon: '🧤', row: 4, col: 0 },
+    [EquipmentSlotName.BOOTS]: { label: 'Boots', icon: '👢', row: 4, col: 2 },
+    [EquipmentSlotName.RING]: { label: 'Ring', icon: '💍', row: 5, col: 1 },
+    [EquipmentSlotName.ARROWS]: { label: 'Arrows', icon: '🏹', row: 5, col: 2 },
+  }
 
   // Equipment slots are keyed by EquipmentSlotName enum values
   const itemMap: Record<string, Item | null> = equipment ? {
@@ -59,22 +143,142 @@ export function EquipmentPanel({ equipment, onItemDrop: _onItemDrop }: Equipment
     arrows: equipment.arrows || null,
   } : {}
 
+  // Calculate total stats from equipped items
+  const calculateStats = () => {
+    const stats = {
+      attackBonus: 0,
+      strengthBonus: 0,
+      defenseBonus: 0,
+      rangedBonus: 0,
+      magicBonus: 0,
+      prayer: 0,
+    }
+
+    Object.values(itemMap).forEach((item) => {
+      if (item && item.bonuses) {
+        stats.attackBonus += item.bonuses.attackBonus || 0
+        stats.strengthBonus += item.bonuses.strengthBonus || 0
+        stats.defenseBonus += item.bonuses.defenseBonus || 0
+        stats.rangedBonus += item.bonuses.rangedBonus || 0
+        stats.magicBonus += item.bonuses.magicBonus || 0
+        stats.prayer += item.bonuses.prayer || 0
+      }
+    })
+
+    return stats
+  }
+
+  const stats = calculateStats()
+  const equippedCount = Object.values(itemMap).filter(item => item !== null).length
+  const totalSlots = Object.keys(slotConfig).length
+
   return (
-    <div>
-      <div className="bg-black/35 border rounded-md p-2" style={{ borderColor: 'rgba(242, 208, 138, 0.3)' }}>
-        <div className="grid grid-cols-3 grid-rows-4 gap-1.5">
-          {slots.map((s) => (
-            <div key={String(s.key)} className="w-full aspect-square">
-              <DroppableEquipmentSlot
-                slotKey={String(s.key)}
-                label={s.label}
-                item={(itemMap && Object.prototype.hasOwnProperty.call(itemMap, String(s.key)) ? itemMap[String(s.key)] : null) as Item | null}
-              />
             </div>
-          ))}
+          )}
+
+          {/* Combat Stats Card */}
+          <div
+            className="border rounded-lg transition-all duration-200"
+            style={{
+              background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+              borderColor: 'rgba(242, 208, 138, 0.35)',
+              padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+            }}
+          >
+            <div
+              className="text-xs uppercase tracking-wide mb-2 opacity-60"
+              style={{
+                color: '#f2d08a',
+                fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+              }}
+            >
+              Combat Bonuses
+            </div>
+            <div className="grid grid-cols-2 gap-2" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>⚔️ Attack:</span>
+                <span className="font-semibold" style={{ color: stats.attackBonus > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.attackBonus > 0 ? '+' : ''}{stats.attackBonus}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>💪 Strength:</span>
+                <span className="font-semibold" style={{ color: stats.strengthBonus > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.strengthBonus > 0 ? '+' : ''}{stats.strengthBonus}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>🛡️ Defense:</span>
+                <span className="font-semibold" style={{ color: stats.defenseBonus > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.defenseBonus > 0 ? '+' : ''}{stats.defenseBonus}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>🏹 Ranged:</span>
+                <span className="font-semibold" style={{ color: stats.rangedBonus > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.rangedBonus > 0 ? '+' : ''}{stats.rangedBonus}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>✨ Magic:</span>
+                <span className="font-semibold" style={{ color: stats.magicBonus > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.magicBonus > 0 ? '+' : ''}{stats.magicBonus}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span style={{ color: 'rgba(242, 208, 138, 0.75)' }}>🙏 Prayer:</span>
+                <span className="font-semibold" style={{ color: stats.prayer > 0 ? '#22c55e' : 'rgba(242, 208, 138, 0.9)' }}>
+                  {stats.prayer > 0 ? '+' : ''}{stats.prayer}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Equipment Quick Info */}
+          {equippedCount > 0 && (
+            <div
+              className="border rounded-lg transition-all duration-200"
+              style={{
+                background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+                borderColor: 'rgba(242, 208, 138, 0.35)',
+                padding: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+                boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+              }}
+            >
+              <div
+                className="text-xs uppercase tracking-wide mb-2 opacity-60"
+                style={{
+                  color: '#f2d08a',
+                  fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+                }}
+              >
+                Equipment Summary
+              </div>
+              <div className="space-y-1" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)' }}>
+                {Object.entries(itemMap)
+                  .filter(([_, item]) => item !== null)
+                  .map(([slot, item]) => (
+                    <div key={slot} className="flex items-center justify-between">
+                      <span style={{ color: 'rgba(242, 208, 138, 0.7)' }}>
+                        {slotConfig[slot as EquipmentSlotName]?.icon} {slotConfig[slot as EquipmentSlotName]?.label}:
+                      </span>
+                      <span
+                        className="font-medium truncate ml-2"
+                        style={{
+                          color: 'rgba(242, 208, 138, 0.9)',
+                          maxWidth: '60%'
+                        }}
+                      >
+                        {item!.name}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>
   )
 }
-

--- a/packages/client/src/components/panels/InventoryPanel.tsx
+++ b/packages/client/src/components/panels/InventoryPanel.tsx
@@ -1,5 +1,10 @@
+/**
+ * Inventory Panel
+ * Modern MMORPG-style inventory interface with drag-and-drop functionality
+ */
+
 import React, { useEffect, useRef, useState } from 'react'
-import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, closestCenter } from '@dnd-kit/core'
+import { DragEndEvent, DragOverlay, DragStartEvent } from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -20,10 +25,9 @@ interface InventoryPanelProps {
 interface DraggableItemProps {
   item: InventorySlotViewItem | null
   index: number
-  size: number
 }
 
-function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
+function DraggableInventorySlot({ item, index }: DraggableItemProps) {
   const {
     attributes,
     listeners,
@@ -34,12 +38,9 @@ function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
   } = useSortable({ id: `inventory-${index}`, data: { item, index } })
 
   const style = {
-    width: size,
-    height: size,
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    borderColor: 'rgba(242, 208, 138, 0.3)',
   }
 
   return (
@@ -48,8 +49,7 @@ function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
       style={style}
       {...attributes}
       {...listeners}
-      className={`relative bg-black/35 border rounded flex items-center justify-center text-white text-[10px] ${item ? 'cursor-grab active:cursor-grabbing' : 'cursor-default'}`}
-      title={item ? `${item.itemId} (${item.quantity})` : 'Empty slot'}
+      className="relative border rounded flex items-center justify-center transition-all duration-200 group aspect-square"
       onContextMenu={(e) => {
         e.preventDefault()
         e.stopPropagation()
@@ -71,13 +71,82 @@ function DraggableInventorySlot({ item, index, size }: DraggableItemProps) {
         })
         window.dispatchEvent(evt)
       }}
+      title={item ? `${item.item?.name || item.itemId}${item.item?.rarity ? ` (${item.item.rarity})` : ''}` : 'Empty slot'}
+      style={{
+        ...style,
+        borderColor: item ? rarityColor : 'rgba(242, 208, 138, 0.2)',
+        background: item
+          ? 'linear-gradient(135deg, rgba(242, 208, 138, 0.08) 0%, rgba(242, 208, 138, 0.04) 100%)'
+          : 'rgba(0, 0, 0, 0.35)',
+        boxShadow: item
+          ? `0 1px 3px ${rarityColor}40, inset 0 1px 0 rgba(242, 208, 138, 0.05)`
+          : 'inset 0 1px 2px rgba(0, 0, 0, 0.3)',
+        cursor: item ? 'grab' : 'default',
+      }}
     >
-      {item ? item.itemId.substring(0, 3) : ''}
-      {item && item.quantity > 1 ? (
-        <div className="absolute bottom-0.5 right-0.5 bg-black/70 font-bold rounded-sm py-0.5 px-1 text-[9px]" style={{ color: '#f2d08a' }}>
+      {/* Rarity Glow */}
+      {item?.item?.rarity && (
+        <div
+          className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full"
+          style={{
+            backgroundColor: rarityColor,
+            boxShadow: `0 0 4px ${rarityColor}`,
+          }}
+        />
+      )}
+
+      {/* Item Icon - Centered */}
+      {item ? (
+        <div
+          className="transition-transform duration-200 group-hover:scale-110"
+          style={{
+            color: rarityColor === 'rgba(242, 208, 138, 0.3)' ? '#f2d08a' : rarityColor,
+            filter: item.item?.rarity ? `drop-shadow(0 0 2px ${rarityColor})` : 'none',
+            fontSize: 'clamp(0.875rem, 2vw, 1.125rem)',
+          }}
+        >
+          {item.itemId.includes('sword') ? '⚔️' :
+           item.itemId.includes('shield') ? '🛡️' :
+           item.itemId.includes('helmet') || item.itemId.includes('helm') ? '⛑️' :
+           item.itemId.includes('boots') || item.itemId.includes('boot') ? '👢' :
+           item.itemId.includes('glove') ? '🧤' :
+           item.itemId.includes('cape') ? '🧥' :
+           item.itemId.includes('amulet') ? '📿' :
+           item.itemId.includes('ring') ? '💍' :
+           item.itemId.includes('arrow') ? '🏹' :
+           item.itemId.includes('fish') ? '🐟' :
+           item.itemId.includes('log') || item.itemId.includes('wood') ? '🪵' :
+           item.itemId.includes('ore') ? '⛏️' :
+           item.itemId.includes('coin') ? '💰' :
+           item.itemId.includes('potion') ? '🧪' :
+           item.itemId.substring(0, 2).toUpperCase()}
+        </div>
+      ) : (
+        <div
+          className="opacity-20"
+          style={{
+            color: '#f2d08a',
+            fontSize: 'clamp(0.625rem, 1.5vw, 0.75rem)',
+          }}
+        >
+          •
+        </div>
+      )}
+
+      {/* Quantity Badge */}
+      {item && item.quantity > 1 && (
+        <div
+          className="absolute bottom-0.5 right-0.5 font-bold rounded px-1 py-0.5 leading-none"
+          style={{
+            background: 'linear-gradient(135deg, rgba(242, 208, 138, 0.95) 0%, rgba(242, 208, 138, 0.85) 100%)',
+            color: 'rgba(20, 20, 30, 0.95)',
+            fontSize: 'clamp(0.5rem, 1.2vw, 0.625rem)',
+            boxShadow: '0 1px 2px rgba(0, 0, 0, 0.6)',
+          }}
+        >
           {item.quantity}
         </div>
-      ) : null}
+      )}
     </div>
   )
 }
@@ -90,13 +159,6 @@ export function InventoryPanel({ items, coins, world, onItemMove, onItemUse: _on
       slots[s] = item
     }
   })
-  
-  const wrapperRef = useRef<HTMLDivElement | null>(null)
-  const gridRef = useRef<HTMLDivElement | null>(null)
-  const coinsRef = useRef<HTMLDivElement | null>(null)
-  const [size, setSize] = useState<number>(40)
-  const [activeId, setActiveId] = useState<string | null>(null)
-  const [slotItems, setSlotItems] = useState<(InventorySlotViewItem | null)[]>(slots)
 
   useEffect(() => {
     const onCtxSelect = (evt: Event) => {
@@ -115,7 +177,6 @@ export function InventoryPanel({ items, coins, world, onItemMove, onItemUse: _on
         }
       }
       if (ce.detail.actionId === 'examine') {
-        world?.emit(EventType.UI_TOAST, { message: `It's a ${it.itemId}.`, type: 'info' })
       }
     }
     window.addEventListener('contextmenu:select', onCtxSelect as EventListener)
@@ -132,41 +193,6 @@ export function InventoryPanel({ items, coins, world, onItemMove, onItemUse: _on
     })
     setSlotItems(newSlots)
   }, [items])
-
-  useEffect(() => {
-    const compute = () => {
-      const grid = gridRef.current
-      const wrap = wrapperRef.current
-      if (!grid || !wrap) return
-      const parent = grid.parentElement as HTMLElement | null
-      const columns = 4
-      const rows = 7
-      const gap = 8
-      // Available width from wrapper (preferred) or parent
-      const widthAvailable = (wrap.clientWidth || parent?.clientWidth || grid.clientWidth)
-      const byWidth = Math.floor((widthAvailable - gap * (columns - 1)) / columns)
-      // Available height strictly from wrapper's current content box
-      const coinsMargins = coinsRef.current ? (parseFloat(getComputedStyle(coinsRef.current).marginTop || '0') + parseFloat(getComputedStyle(coinsRef.current).marginBottom || '0')) : 10
-      const coinsBarHeight = (coinsRef.current?.offsetHeight || 44) + coinsMargins
-      const wrapHeight = wrap.clientHeight || 0
-      const heightAvailable = Math.max(0, wrapHeight - coinsBarHeight - 2)
-      const byHeight = Math.floor((heightAvailable - gap * (rows - 1)) / rows)
-      const maxSlot = 68
-      const minSlot = 44
-      const next = Math.max(minSlot, Math.min(byWidth, byHeight, maxSlot))
-      setSize(next)
-    }
-    compute()
-    // one more pass after layout settles
-    const t = window.setTimeout(compute, 200)
-    window.addEventListener('resize', compute)
-    return () => { window.clearTimeout(t); window.removeEventListener('resize', compute) }
-  }, [])
-
-  const rows = 7
-  const columns = 4
-  const gap = 8
-  const gridWidth = size * columns + gap * (columns - 1)
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string)
@@ -193,67 +219,205 @@ export function InventoryPanel({ items, coins, world, onItemMove, onItemUse: _on
 
   const activeItem = activeId ? slotItems[parseInt(activeId.split('-')[1])] : null
 
+  // Calculate total weight
+  const totalWeight = items.reduce((sum, item) => {
+    const weight = item.item?.weight || 0
+    const quantity = item.quantity || 1
+    return sum + (weight * quantity)
+  }, 0)
+
+  const itemCount = items.filter(item => item !== null).length
+  const maxSlots = 28
+
+  // Get current page items
+  const startIndex = currentPage * SLOTS_PER_PAGE
+  const endIndex = Math.min(startIndex + SLOTS_PER_PAGE, 28)
+  const currentPageItems = slotItems.slice(startIndex, endIndex)
+
   return (
-    <DndContext 
-      collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-    >
-      <div ref={wrapperRef} className="w-full flex-1 min-h-0 flex flex-col box-border overflow-hidden">
-        <div className="mx-auto" style={{ width: gridWidth }}>
+          </div>
+        </div>
+      </div>
+
+      {/* Inventory Grid */}
+      <div className="flex-1 overflow-y-auto noscrollbar">
+        <div
+          className="border rounded transition-all duration-200"
+          style={{
+            background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+            borderColor: 'rgba(242, 208, 138, 0.35)',
+            padding: 'clamp(0.375rem, 0.9vw, 0.5rem)',
+            boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+          }}
+        >
           <SortableContext items={slotItems.map((_, i) => `inventory-${i}`)} strategy={rectSortingStrategy}>
-            <div 
-              ref={gridRef} 
-              className="mx-auto grid grid-flow-row"
-              style={{ 
-                gridTemplateColumns: `repeat(${columns}, ${size}px)`, 
-                gridTemplateRows: `repeat(${rows}, ${size}px)`,
-                gap: gap, 
-                width: gridWidth 
+            <div
+              className="grid grid-cols-4"
+              style={{
+                gridAutoRows: '1fr',
+                gap: 'clamp(0.3rem, 0.7vw, 0.4rem)',
               }}
             >
-              {slotItems.map((item, i) => (
-                <DraggableInventorySlot
-                  key={i}
-                  item={item}
-                  index={i}
-                  size={size}
-                />
-              ))}
+              {currentPageItems.map((item, i) => {
+                const actualIndex = startIndex + i
+                return (
+                  <DraggableInventorySlot
+                    key={actualIndex}
+                    item={item}
+                    index={actualIndex}
+                  />
+                )
+              })}
             </div>
           </SortableContext>
 
           <DragOverlay>
-          {activeItem ? (
-            <div
-              className="bg-black/35 border rounded flex items-center justify-center text-white text-[10px]"
-              style={{
-                width: size,
-                height: size,
-                borderColor: 'rgba(242, 208, 138, 0.3)',
-              }}
-            >
-              {activeItem.itemId.substring(0, 3)}
-            </div>
-          ) : null}
+            {activeItem ? (
+              <div
+                className="border rounded flex items-center justify-center aspect-square"
+                style={{
+                  width: 'clamp(40px, 8vw, 60px)',
+                  borderColor: activeItem.item?.rarity
+                    ? activeItem.item.rarity === 'legendary' ? '#fbbf24'
+                    : activeItem.item.rarity === 'epic' ? '#a855f7'
+                    : activeItem.item.rarity === 'rare' ? '#3b82f6'
+                    : activeItem.item.rarity === 'uncommon' ? '#22c55e'
+                    : 'rgba(242, 208, 138, 0.3)'
+                    : 'rgba(242, 208, 138, 0.3)',
+                  background: 'linear-gradient(135deg, rgba(242, 208, 138, 0.15) 0%, rgba(242, 208, 138, 0.08) 100%)',
+                  fontSize: 'clamp(1rem, 2.5vw, 1.5rem)',
+                  color: '#f2d08a',
+                }}
+              >
+                {activeItem.itemId.substring(0, 2).toUpperCase()}
+              </div>
+            ) : null}
           </DragOverlay>
-
-          <div
-            ref={coinsRef}
-            className="mt-2.5 flex justify-between items-center bg-black/35 border rounded-md py-2 px-2.5 text-[13px] mx-auto"
-            style={{
-              borderColor: 'rgba(242, 208, 138, 0.3)',
-              color: '#f2d08a',
-              width: gridWidth
-            }}
-          >
-            <span>Coins</span>
-            <span className="font-bold">{coins.toLocaleString()} gp</span>
-          </div>
         </div>
       </div>
-    </DndContext>
+
+      {/* Footer Stats */}
+      <div className="flex flex-col" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+        {/* Page Navigation */}
+        <div
+          className="border rounded transition-all duration-200 flex items-center justify-center"
+          style={{
+            background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+            borderColor: 'rgba(242, 208, 138, 0.35)',
+            padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5)',
+          }}
+        >
+          <div className="flex items-center" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+            <button
+              onClick={() => setCurrentPage(Math.max(0, currentPage - 1))}
+              disabled={currentPage === 0}
+              className="transition-all duration-200"
+              style={{
+                color: currentPage === 0 ? 'rgba(242, 208, 138, 0.3)' : '#f2d08a',
+                fontSize: 'clamp(1rem, 2vw, 1.25rem)',
+                cursor: currentPage === 0 ? 'default' : 'pointer',
+                opacity: currentPage === 0 ? 0.5 : 1,
+                fontWeight: 'bold',
+              }}
+            >
+              ◀
+            </button>
+            <div
+              className="font-medium"
+              style={{
+                color: '#f2d08a',
+                fontSize: 'clamp(0.75rem, 1.5vw, 0.875rem)',
+                minWidth: 'clamp(2.5rem, 5vw, 3.5rem)',
+                textAlign: 'center',
+              }}
+            >
+              Page {currentPage + 1}/{totalPages}
+            </div>
+            <button
+              onClick={() => setCurrentPage(Math.min(totalPages - 1, currentPage + 1))}
+              disabled={currentPage === totalPages - 1}
+              className="transition-all duration-200"
+              style={{
+                color: currentPage === totalPages - 1 ? 'rgba(242, 208, 138, 0.3)' : '#f2d08a',
+                fontSize: 'clamp(1rem, 2vw, 1.25rem)',
+                cursor: currentPage === totalPages - 1 ? 'default' : 'pointer',
+                opacity: currentPage === totalPages - 1 ? 0.5 : 1,
+                fontWeight: 'bold',
+              }}
+            >
+              ▶
+            </button>
+          </div>
+        </div>
+
+        {/* Coins */}
+        <div
+          className="border rounded transition-all duration-200 flex items-center justify-between"
+          style={{
+            background: 'linear-gradient(135deg, rgba(251, 191, 36, 0.15) 0%, rgba(251, 191, 36, 0.08) 100%)',
+            borderColor: 'rgba(251, 191, 36, 0.4)',
+            padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+            boxShadow: '0 1px 3px rgba(251, 191, 36, 0.2)',
+          }}
+        >
+          <div className="flex items-center" style={{ gap: 'clamp(0.25rem, 0.6vw, 0.375rem)' }}>
+            <span style={{ fontSize: 'clamp(0.875rem, 1.8vw, 1.125rem)' }}>💰</span>
+            <span
+              className="font-medium"
+              style={{
+                color: '#fbbf24',
+                fontSize: 'clamp(0.625rem, 1.1vw, 0.688rem)',
+              }}
+            >
+              Coins
+            </span>
+          </div>
+          <span
+            className="font-bold"
+            style={{
+              color: '#fbbf24',
+              fontSize: 'clamp(0.688rem, 1.2vw, 0.75rem)',
+              textShadow: '0 1px 2px rgba(0, 0, 0, 0.6)',
+            }}
+          >
+            {coins.toLocaleString()}
+          </span>
+        </div>
+
+        {/* Weight */}
+        <div
+          className="border rounded transition-all duration-200 flex items-center justify-between"
+          style={{
+            background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+            borderColor: 'rgba(242, 208, 138, 0.35)',
+            padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5)',
+          }}
+        >
+          <div className="flex items-center" style={{ gap: 'clamp(0.25rem, 0.5vw, 0.3rem)' }}>
+            <span style={{ fontSize: 'clamp(0.75rem, 1.5vw, 1rem)' }}>⚖️</span>
+            <span
+              className="font-medium opacity-75"
+              style={{
+                color: '#f2d08a',
+                fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+              }}
+            >
+              Weight
+            </span>
+          </div>
+          <span
+            className="font-semibold"
+            style={{
+              color: 'rgba(242, 208, 138, 0.9)',
+              fontSize: 'clamp(0.563rem, 1vw, 0.625rem)',
+            }}
+          >
+            {totalWeight.toFixed(1)} kg
+          </span>
+        </div>
+      </div>
+    </div>
   )
 }
-
-

--- a/packages/client/src/components/panels/SkillsPanel.tsx
+++ b/packages/client/src/components/panels/SkillsPanel.tsx
@@ -1,14 +1,20 @@
-import React, { useState } from 'react'
-import type { ClientWorld, PlayerStats } from '../../types'
 
 interface SkillsPanelProps {
   world: ClientWorld
   stats: PlayerStats | null
 }
 
-export function SkillsPanel({ world: _world, stats }: SkillsPanelProps) {
+interface SkillItem {
+  key: string
+  label: string
+  icon: string
+  level: number
+  xp: number
+}
+
+export function SkillsPanel({ world, stats }: SkillsPanelProps) {
   const s = stats?.skills || ({} as NonNullable<PlayerStats['skills']>)
-  const items = [
+  const items: SkillItem[] = [
     { key: 'attack', label: 'Attack', icon: '⚔️', level: s?.attack?.level || 1, xp: s?.attack?.xp || 0 },
     { key: 'constitution', label: 'Constitution', icon: '❤️', level: Math.max(10, s?.constitution?.level || 10), xp: s?.constitution?.xp || 0 },
     { key: 'strength', label: 'Strength', icon: '💪', level: s?.strength?.level || 1, xp: s?.strength?.xp || 0 },
@@ -21,67 +27,249 @@ export function SkillsPanel({ world: _world, stats }: SkillsPanelProps) {
   ]
   const totalLevel = items.reduce((sum, it) => sum + (it.level || 1), 0)
   const totalXP = items.reduce((sum, it) => sum + (it.xp || 0), 0)
-  const [hover, setHover] = useState<{ label: string; xp: number } | null>(null)
-  const [mouse, setMouse] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [selectedSkill, setSelectedSkill] = useState<SkillItem | null>(null)
+
+  // XP calculation helper (using same formula as SkillsSystem)
+  const calculateXPForLevel = (level: number): number => {
+    if (level < 1) return 0
+    if (level > 99) level = 99
+
+    let totalXP = 0
+    for (let l = 2; l <= level; l++) {
+      const xp = Math.floor((l - 1) + 300 * Math.pow(2, (l - 1) / 7)) / 4
+      totalXP += Math.floor(xp)
+    }
+    return Math.floor(totalXP)
+  }
+
+  const getSkillProgress = (skill: SkillItem) => {
+    if (skill.level >= 99) return { progress: 100, xpToNext: 0, currentLevelXP: skill.xp, nextLevelXP: skill.xp }
+
+    const currentLevelXP = calculateXPForLevel(skill.level)
+    const nextLevelXP = calculateXPForLevel(skill.level + 1)
+    const progressXP = skill.xp - currentLevelXP
+    const requiredXP = nextLevelXP - currentLevelXP
+    const progress = (progressXP / requiredXP) * 100
+    const xpToNext = nextLevelXP - skill.xp
+
+    return { progress, xpToNext, currentLevelXP, nextLevelXP }
+  }
 
   return (
-    <div className="relative h-full" onMouseMove={(e) => setMouse({ x: e.clientX, y: e.clientY })}>
-      <div className="grid grid-cols-3 gap-1.5">
-        {items.map((it) => (
-          <div key={it.key}
-            className="bg-black/35 border rounded-md py-1.5 px-2 flex items-center justify-center flex-col text-[13px] cursor-default"
-            style={{
-              borderColor: 'rgba(242, 208, 138, 0.3)',
-              color: 'rgba(242, 208, 138, 0.9)',
-            }}
-            onMouseEnter={() => setHover({ label: it.label, xp: it.xp })}
-            onMouseLeave={() => setHover(null)}
-          >
-            <span className="text-lg">{it.icon}</span>
-            <span>{it.level}/{it.level}</span>
-          </div>
-        ))}
-      </div>
-      <div
-        className="absolute left-2 right-2 bottom-2 text-right text-xs cursor-default"
-        style={{ color: 'rgba(242, 208, 138, 0.7)' }}
-        onMouseEnter={() => setHover({ label: 'Total', xp: totalXP })}
-        onMouseLeave={() => setHover(null)}
-      >
-        Total level: {totalLevel}
-      </div>
-      {hover && (
-        (() => {
-          const pad = 12
-          const tooltipWidth = 160
-          const tooltipHeight = 56
-          let left = mouse.x + pad
-          if (left + tooltipWidth > window.innerWidth - 8) left = mouse.x - tooltipWidth - pad
-          if (left < 8) left = 8
-          let top = mouse.y + pad
-          if (top + tooltipHeight > window.innerHeight - 8) top = mouse.y - tooltipHeight - pad
-          if (top < 8) top = 8
-          return (
+    <>
+      <div className="flex flex-col h-full" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+        {/* Header */}
+        <div
+          className="border rounded transition-all duration-200"
+          style={{
+            background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.98) 0%, rgba(30, 25, 40, 0.95) 100%)',
+            borderColor: 'rgba(242, 208, 138, 0.5)',
+            borderWidth: '2px',
+            padding: 'clamp(0.375rem, 0.9vw, 0.5rem)',
+            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(242, 208, 138, 0.1)',
+          }}
+        >
+          <div className="flex items-center justify-between">
             <div
-              className="fixed border rounded-md p-1.5 text-xs pointer-events-none z-[200]"
+              className="font-bold tracking-wide"
               style={{
-                left,
-                top,
-                width: tooltipWidth,
-                backgroundColor: 'rgba(20,20,28,0.98)',
-                borderColor: 'rgba(242, 208, 138, 0.4)',
-                color: 'rgba(242, 208, 138, 0.9)',
+                color: '#f2d08a',
+                fontSize: 'clamp(0.75rem, 1.5vw, 0.875rem)',
+                textShadow: '0 2px 4px rgba(0, 0, 0, 0.8)',
               }}
             >
-              <div className="font-semibold mb-0.5" style={{ color: '#f2d08a' }}>
-                {hover.label === 'Total' ? 'Total Experience' : hover.label}
-              </div>
-              <div>{hover.label === 'Total' ? 'Total XP' : 'XP'}: {Math.floor(hover.xp).toLocaleString()}</div>
+              SKILLS
             </div>
-          )
-        })()
-      )}
-    </div>
+            <div className="flex items-center" style={{ gap: 'clamp(0.25rem, 0.5vw, 0.3rem)' }}>
+              <span style={{ color: 'rgba(242, 208, 138, 0.7)', fontSize: 'clamp(0.563rem, 1vw, 0.625rem)' }}>
+                Total
+              </span>
+              <span className="font-bold" style={{ color: '#f2d08a', fontSize: 'clamp(0.75rem, 1.5vw, 0.875rem)' }}>
+                {totalLevel}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Condensed Skills Grid */}
+        <div className="flex-1 overflow-y-auto noscrollbar">
+          <div
+            className="border rounded transition-all duration-200"
+            style={{
+              background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.95) 0%, rgba(25, 20, 35, 0.92) 100%)',
+              borderColor: 'rgba(242, 208, 138, 0.35)',
+              padding: 'clamp(0.375rem, 0.9vw, 0.5rem)',
+              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.5)',
+            }}
+          >
+            <div className="grid grid-cols-3" style={{ gap: 'clamp(0.3rem, 0.7vw, 0.4rem)' }}>
+              {items.map((it) => (
+                <button
+                  key={it.key}
+                  onClick={() => setSelectedSkill(it)}
+                  className="rounded transition-all duration-200 cursor-pointer group"
+                  style={{
+                    background: 'rgba(0, 0, 0, 0.35)',
+                    borderWidth: '1px',
+                    borderStyle: 'solid',
+                    borderColor: 'rgba(242, 208, 138, 0.25)',
+                    padding: 'clamp(0.3rem, 0.7vw, 0.375rem)',
+                    boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.3)',
+                  }}
+                >
+                  <div className="flex items-center justify-center" style={{ gap: 'clamp(0.25rem, 0.6vw, 0.375rem)' }}>
+                    <span
+                      className="transition-transform duration-200 group-hover:scale-110"
+                      style={{
+                        fontSize: 'clamp(0.875rem, 1.8vw, 1rem)',
+                        filter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5))',
+                      }}
+                    >
+                      {it.icon}
+                    </span>
+                    <div className="font-bold" style={{ color: 'rgba(242, 208, 138, 0.9)', fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)' }}>
+                      {it.level}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Detailed Skill Popup */}
+      {selectedSkill && (() => {
+        const progress = getSkillProgress(selectedSkill)
+        return (
+          <div
+            className="fixed inset-0 flex items-center justify-center z-[300]"
+            style={{ background: 'rgba(0, 0, 0, 0.7)' }}
+            onClick={() => setSelectedSkill(null)}
+          >
+            <div
+              className="border rounded"
+              style={{
+                background: 'linear-gradient(135deg, rgba(20, 20, 30, 0.98) 0%, rgba(30, 25, 40, 0.95) 100%)',
+                borderColor: 'rgba(242, 208, 138, 0.5)',
+                borderWidth: '2px',
+                padding: 'clamp(0.75rem, 1.5vw, 1rem)',
+                boxShadow: '0 8px 24px rgba(0, 0, 0, 0.9)',
+                width: 'clamp(250px, 40vw, 350px)',
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center" style={{ gap: 'clamp(0.375rem, 0.8vw, 0.5rem)' }}>
+                  <span style={{ fontSize: 'clamp(1.25rem, 2.5vw, 1.5rem)' }}>{selectedSkill.icon}</span>
+                  <div>
+                    <div className="font-bold" style={{ color: '#f2d08a', fontSize: 'clamp(0.875rem, 1.5vw, 1rem)' }}>
+                      {selectedSkill.label}
+                    </div>
+                    <div style={{ color: 'rgba(242, 208, 138, 0.7)', fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)' }}>
+                      Level {selectedSkill.level}
+                    </div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => setSelectedSkill(null)}
+                  style={{ color: 'rgba(242, 208, 138, 0.7)', fontSize: 'clamp(0.875rem, 1.5vw, 1rem)' }}
+                >
+                  ✕
+                </button>
+              </div>
+
+              {/* XP Progress Bar */}
+              <div className="mb-3">
+                <div className="flex justify-between mb-1" style={{ fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)' }}>
+                  <span style={{ color: 'rgba(242, 208, 138, 0.8)' }}>XP Progress</span>
+                  <span style={{ color: '#f2d08a', fontWeight: 'bold' }}>
+                    {Math.floor(progress.progress)}%
+                  </span>
+                </div>
+                <div
+                  className="rounded"
+                  style={{
+                    background: 'rgba(0, 0, 0, 0.5)',
+                    height: 'clamp(12px, 2vw, 16px)',
+                    border: '1px solid rgba(242, 208, 138, 0.3)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    className="h-full transition-all duration-300"
+                    style={{
+                      background: 'linear-gradient(90deg, rgba(242, 208, 138, 0.6) 0%, rgba(242, 208, 138, 0.8) 100%)',
+                      width: `${Math.min(100, Math.max(0, progress.progress))}%`,
+                      boxShadow: '0 0 8px rgba(242, 208, 138, 0.5)',
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* XP Details */}
+              <div className="space-y-2">
+                <div
+                  className="flex justify-between"
+                  style={{
+                    fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)',
+                    color: 'rgba(242, 208, 138, 0.8)',
+                  }}
+                >
+                  <span>Current XP</span>
+                  <span style={{ color: '#f2d08a', fontWeight: 'bold' }}>
+                    {Math.floor(selectedSkill.xp).toLocaleString()}
+                  </span>
+                </div>
+                {selectedSkill.level < 99 && (
+                  <>
+                    <div
+                      className="flex justify-between"
+                      style={{
+                        fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)',
+                        color: 'rgba(242, 208, 138, 0.8)',
+                      }}
+                    >
+                      <span>XP to Level {selectedSkill.level + 1}</span>
+                      <span style={{ color: '#f2d08a', fontWeight: 'bold' }}>
+                        {Math.floor(progress.xpToNext).toLocaleString()}
+                      </span>
+                    </div>
+                    <div
+                      className="flex justify-between"
+                      style={{
+                        fontSize: 'clamp(0.625rem, 1.1vw, 0.75rem)',
+                        color: 'rgba(242, 208, 138, 0.8)',
+                      }}
+                    >
+                      <span>Next Level at</span>
+                      <span style={{ color: '#f2d08a', fontWeight: 'bold' }}>
+                        {Math.floor(progress.nextLevelXP).toLocaleString()} XP
+                      </span>
+                    </div>
+                  </>
+                )}
+                {selectedSkill.level === 99 && (
+                  <div
+                    className="text-center font-bold"
+                    style={{
+                      color: '#f2d08a',
+                      fontSize: 'clamp(0.688rem, 1.2vw, 0.75rem)',
+                      padding: 'clamp(0.375rem, 0.8vw, 0.5rem)',
+                      background: 'rgba(242, 208, 138, 0.1)',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    ⭐ MASTERED ⭐
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )
+      })()}
+    </>
   )
 }
 

--- a/packages/client/src/components/shared/GameWindow.tsx
+++ b/packages/client/src/components/shared/GameWindow.tsx
@@ -8,11 +8,13 @@ interface GameWindowProps {
   defaultX?: number
   defaultY?: number
   windowId?: string
+  zIndex?: number
+  onFocus?: () => void
   children: React.ReactNode
   fitContent?: boolean
 }
 
-export function GameWindow({ title, onClose, defaultX, defaultY, windowId = 'default', children, fitContent = false }: GameWindowProps) {
+export function GameWindow({ title, onClose, defaultX, defaultY, windowId = 'default', zIndex = 1000, onFocus, children, fitContent = false }: GameWindowProps) {
   const dragHandleRef = useRef<HTMLDivElement>(null)
   const [isMobile, setIsMobile] = useState(windowManager.isMobile())
   const [isTablet, setIsTablet] = useState(windowManager.isTablet())
@@ -51,19 +53,21 @@ export function GameWindow({ title, onClose, defaultX, defaultY, windowId = 'def
         {/* Mobile backdrop */}
         {showBackdrop && (
           <div
-            className="fixed inset-0 bg-black/50 pointer-events-auto z-[999] transition-opacity duration-300"
+            className="fixed inset-0 bg-black/50 pointer-events-auto transition-opacity duration-300"
             onClick={onClose}
-            style={{ opacity: showBackdrop ? 1 : 0 }}
+            style={{ opacity: showBackdrop ? 1 : 0, zIndex: zIndex - 1 }}
           />
         )}
 
         {/* Mobile bottom sheet */}
         <div
-          className="fixed bottom-0 left-0 right-0 bg-[rgba(11,10,21,0.98)] border-t rounded-t-2xl shadow-[0_-10px_30px_rgba(0,0,0,0.5)] pointer-events-auto z-[1000] animate-slideUp"
+          className="fixed bottom-0 left-0 right-0 bg-[rgba(11,10,21,0.98)] border-t rounded-t-2xl shadow-[0_-10px_30px_rgba(0,0,0,0.5)] pointer-events-auto animate-slideUp"
+          onClick={onFocus}
           style={{
             borderColor: 'rgba(242, 208, 138, 0.4)',
             maxHeight: '85vh',
             bottom: 'calc(var(--mobile-chat-offset, 0px) + env(safe-area-inset-bottom))',
+            zIndex
           }}
         >
           <style>{`
@@ -118,6 +122,8 @@ export function GameWindow({ title, onClose, defaultX, defaultY, windowId = 'def
   return (
     <DraggableWindow
       initialPosition={{ x: finalX, y: finalY }}
+      zIndex={zIndex}
+      onFocus={onFocus}
       dragHandle={
         <div
           ref={dragHandleRef}
@@ -139,7 +145,7 @@ export function GameWindow({ title, onClose, defaultX, defaultY, windowId = 'def
           </button>
         </div>
       }
-      className="bg-[rgba(11,10,21,0.96)] border rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.5)] pointer-events-auto z-[1000]"
+      className="bg-[rgba(11,10,21,0.96)] border rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.5)] pointer-events-auto"
       style={{
         borderColor: 'rgba(242, 208, 138, 0.4)',
         minWidth: fitContent ? undefined : minWidth,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -328,6 +328,7 @@ export type {
   UISceneItem,
   UIYogaNode,
 } from './types/nodes';
+export type { DraggableWindowProps } from './types/ui';
 export type { NodeData, Position3D } from './types/index';
 // Re-export extras used by PlayerRemote and others
 export { LerpVector3 } from './extras/LerpVector3';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -82,6 +82,48 @@ export * from './events';
 export * from './identifiers';
 export * from './networking';
 export * from './nodes';
+// Export UI types, excluding NametagHandle which is already exported from ./nodes
+export type {
+  ActionTestData,
+  BankWindowProps,
+  ContextMenuAction,
+  ContextMenuProps,
+  ContextMenuState,
+  CurvePaneProps,
+  CurvePreviewProps,
+  DraggableWindowProps,
+  EntityPip,
+  EntityWindowProps,
+  FieldBtnProps,
+  FieldCurveProps,
+  FieldFileProps,
+  FieldNumberProps,
+  FieldRangeProps,
+  FieldSwitchProps,
+  FieldTextareaProps,
+  FieldTextProps,
+  FieldToggleProps,
+  FieldVec3Props,
+  HierarchyNode,
+  HintContextType,
+  HintProviderProps,
+  InputBaseProps,
+  InputDropdownProps,
+  InputFileProps,
+  InputNumberProps,
+  InputRangeProps,
+  InputSwitchProps,
+  InputTextareaProps,
+  InputTextProps,
+  MenuContextType,
+  MinimapProps,
+  PaneInfo,
+  ParseResult,
+  PlayerWithEquipmentSupport,
+  StoreWindowProps,
+  SwitchOption,
+  WindowProps
+} from './ui';
 
 // Import AvatarFactory from nodes for use in LoadedAvatar type below
 import type { AvatarFactory as AvatarFactoryType } from './nodes';

--- a/packages/shared/src/types/ui.ts
+++ b/packages/shared/src/types/ui.ts
@@ -72,6 +72,8 @@ export interface DraggableWindowProps {
   className?: string
   style?: CSSProperties
   enabled?: boolean
+  zIndex?: number
+  onFocus?: () => void
 }
 
 // Curve component interfaces


### PR DESCRIPTION
## Summary
Implements z-index management system that allows clicking on any UI window to bring it to the front when multiple windows are open.

## Changes
- ✨ Add z-index state management in Sidebar component
- 📊 Track window stacking order with incrementing z-index values  
- 🔄 Pass zIndex and onFocus props to all GameWindow instances
- 📱 Update GameWindow to apply z-index to both mobile and desktop views
- 🖱️ Add click handler to DraggableWindow to trigger focus callback
- 📦 Export DraggableWindowProps from shared package

## Behavior
Windows now automatically come to front when:
- Newly opened from menu buttons
- Clicked anywhere on the window surface

Works for both mobile bottom sheets and desktop draggable windows.

## Technical Details
- Each window starts with base z-index of 1000
- Clicking a window increments a counter and assigns the new highest z-index
- Z-index is applied to both desktop draggable windows and mobile bottom sheets
- Mobile backdrops use `zIndex - 1` to stay behind their window