### PR TITLE
Potential fix for code scanning alert no. 232: Type confusion through parameter tampering

### DIFF
--- a/apps/api/server/routes/embeddings.mjs
+++ b/apps/api/server/routes/embeddings.mjs
@@ -24,9 +24,9 @@ router.get('/search', async (req, res) => {
       threshold = 0.7
     } = req.query
 
-    if (!query) {
+    if (typeof query !== 'string' || !query) {
       return res.status(400).json({
-        error: 'Missing query parameter',
+        error: 'Invalid query parameter',
         code: 'EMBED_3000'
       })
     }


### PR DESCRIPTION
Potential fix for [https://github.com/HyperscapeAI/hyperscape/security/code-scanning/232](https://github.com/HyperscapeAI/hyperscape/security/code-scanning/232)

To fix the issue, robust type checking must be added to the code handling query parameters before assuming they are strings. The most direct place to apply this is at the boundary where `req.query.q` ("query") is first extracted in `apps/api/server/routes/embeddings.mjs`. Before passing `query` further downstream, verify it is a string (via `typeof query === 'string'`). If not, respond with a 400 Bad Request, mirroring the existing validation logic for missing parameters. This prevents injection of arrays (or other types) as query text and ensures valid inputs reach the embedding pipeline.

Alternatively, if downstream code (e.g., EmbeddingService) must defend against misuse regardless of how functions are called, similar type checks can be placed at the start of `generateEmbedding` or `findSimilar`, but for defense-in-depth, the best approach is to validate at the earliest point—in the route handler.

Changes required:
- In `apps/api/server/routes/embeddings.mjs`, within the `/search` route handler, after extracting `query`, check that it is a string; if not, respond with 400 and an error.
- No other regions need modification, as this boundary check suffices.
- No new library imports required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
