### PR TITLE
Fix: Combat style displays instantly and switches without cooldown (issue #295)

### DIFF
--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -14,8 +14,19 @@ interface CombatPanelProps {
   equipment: PlayerEquipmentItems | null;
 }
 
+// Client-side cache for combat style state (persists across panel opens/closes)
+// This enables instant display when reopening panel (RuneScape pattern)
+const combatStyleCache = new Map<string, string>();
+
 export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
-  const [style, setStyle] = useState<string>("accurate");
+  // Initialize from cache if available, otherwise default to "accurate"
+  const [style, setStyle] = useState<string>(() => {
+    const playerId = world.entities?.player?.id;
+    if (playerId && combatStyleCache.has(playerId)) {
+      return combatStyleCache.get(playerId)!;
+    }
+    return "accurate";
+  });
   const [cooldown, setCooldown] = useState<number>(0);
   const [targetName, setTargetName] = useState<string | null>(null);
   const [targetHealth, setTargetHealth] = useState<PlayerHealth | null>(null);
@@ -66,6 +77,8 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
         );
         if (info) {
           console.log(`[CombatPanel] Setting initial style to: ${info.style}`);
+          // Update cache for instant display on panel reopen
+          combatStyleCache.set(playerId, info.style);
           setStyle(info.style);
           setCooldown(info.cooldown || 0);
         }
@@ -82,6 +95,8 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
         return;
       }
       console.log("[CombatPanel] Setting style to:", d.currentStyle.id);
+      // Update cache for instant display on panel reopen
+      combatStyleCache.set(playerId, d.currentStyle.id);
       setStyle(d.currentStyle.id);
     };
     const onChanged = (data: unknown) => {
@@ -94,6 +109,8 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
         return;
       }
       console.log("[CombatPanel] Setting style to:", d.currentStyle.id);
+      // Update cache for instant display on panel reopen
+      combatStyleCache.set(playerId, d.currentStyle.id);
       setStyle(d.currentStyle.id);
     };
 

--- a/packages/shared/src/systems/shared/character/PlayerSystem.ts
+++ b/packages/shared/src/systems/shared/character/PlayerSystem.ts
@@ -94,7 +94,7 @@ export class PlayerSystem extends SystemBase {
   // Attack style tracking (merged from AttackStyleSystem)
   private playerAttackStyles = new Map<string, PlayerAttackStyleState>();
   private styleChangeTimers = new Map<string, NodeJS.Timeout>();
-  private readonly STYLE_CHANGE_COOLDOWN = 5000; // 5 seconds between style changes
+  private readonly STYLE_CHANGE_COOLDOWN = 0; // No cooldown - instant style switching like RuneScape
   private skillSaveTimers = new Map<string, NodeJS.Timeout>();
 
   // Attack styles per GDD - Train one skill exclusively


### PR DESCRIPTION
## Summary
Fixes combat style UI to behave like RuneScape - instant display and instant switching.

## Changes
1. **Client-side cache**: Combat style now displays instantly when reopening panel (no 5-second delay)
2. **Removed cooldown**: Combat styles can be switched instantly without waiting (RuneScape pattern)

## Before
- Close/reopen panel → Shows "Accurate" for ~5 seconds → Eventually shows correct style
- Change style → Wait 5 seconds → Can change again

## After
- Close/reopen panel → Shows correct style **instantly** ✅
- Change style → Change again **instantly** ✅

## Technical Details
- Added `combatStyleCache` Map in `CombatPanel.tsx` (persists across unmounts)
- Set `STYLE_CHANGE_COOLDOWN = 0` in `PlayerSystem.ts`

## Testing
- ✅ Select "Aggressive" → Close panel → Reopen → Shows "Aggressive" immediately
- ✅ Switch between styles rapidly → No cooldown warnings

Fixes #295