### PR TITLE
Fix Issue #269: Add RuneScape-style player health bars that appear only during combat with 8-tick (4.8s) timer

### DIFF
--- a/packages/shared/src/constants/CombatConstants.ts
+++ b/packages/shared/src/constants/CombatConstants.ts
@@ -10,7 +10,7 @@ export const COMBAT_CONSTANTS = {
 
   // Attack timing (RuneScape-style speeds)
   ATTACK_COOLDOWN_MS: 2400, // 2.4 seconds - standard weapon attack speed (4 ticks)
-  COMBAT_TIMEOUT_MS: 10000, // 10 seconds without attacks ends combat
+  COMBAT_TIMEOUT_MS: 4800, // 4.8 seconds (8 ticks) - OSRS in-combat timer after last hit
 
   // OSRS Constants
   TICK_DURATION_MS: 600, // 0.6 seconds per game tick

--- a/packages/shared/src/entities/Entity.ts
+++ b/packages/shared/src/entities/Entity.ts
@@ -1424,16 +1424,6 @@ export class Entity implements IEntity {
       }
     }
 
-    // Debug logging for players only
-    if (this.type === "player") {
-      console.log(`[Entity.getNetworkData] Player ${this.id}`);
-      console.log(`  this.data keys:`, Object.keys(this.data));
-      console.log(`  dataFields:`, dataFields);
-      console.log(`  inCombat:`, dataFields.inCombat);
-      console.log(`  combatTarget:`, dataFields.combatTarget);
-      console.log(`  emote (e):`, dataFields.e);
-    }
-
     return {
       id: this.id,
       type: this.type,

--- a/packages/shared/src/entities/npc/MobEntity.ts
+++ b/packages/shared/src/entities/npc/MobEntity.ts
@@ -1439,13 +1439,14 @@ export class MobEntity extends CombatantEntity {
     // Update base health property for isDead() check
     this.setHealth(0);
 
-    // End combat
-    // CRITICAL FIX FOR ISSUE #275: Don't reset target's emote when mob dies
-    // The target might be mid-attack animation (they just landed the killing blow)
-    const combatSystem = this.world.getSystem("combat") as any;
-    if (combatSystem && typeof combatSystem.forceEndCombat === "function") {
-      combatSystem.forceEndCombat(this.id, { skipTargetEmoteReset: true });
-    }
+    // CRITICAL FIX FOR ISSUE #269: Don't end combat immediately when mob dies
+    // Let combat timeout naturally after 4.8 seconds (8 ticks) to keep health bars visible
+    // This matches RuneScape behavior where combat state persists briefly after death
+    // CombatSystem.handleEntityDied() already removes the dead mob's combat state
+    // The attacker's combat will timeout naturally via the 4.8 second timer
+    //
+    // NOTE: Issue #275 fix (not resetting target's emote) is still preserved because
+    // we're not calling endCombat() at all - the emote will finish naturally
 
     // Play death animation via server emote broadcast
     this.setServerEmote(Emotes.DEATH);

--- a/packages/shared/src/nodes/Nametag.ts
+++ b/packages/shared/src/nodes/Nametag.ts
@@ -22,6 +22,7 @@ export class Nametag extends Node {
     move: (newMatrix: THREE.Matrix4) => void;
     setName: (name: string) => void;
     setHealth: (health: number) => void;
+    setInCombat: (inCombat: boolean) => void;
     destroy: () => void;
   } | null;
 

--- a/packages/shared/src/systems/shared/entities/EntityManager.ts
+++ b/packages/shared/src/systems/shared/entities/EntityManager.ts
@@ -779,11 +779,12 @@ export class EntityManager extends SystemBase {
         // Get network data from entity (includes health and other properties)
         const networkData = entity.getNetworkData();
 
-        // Disabled verbose player logging (too spammy)
+        // Debug logging disabled (too spammy)
         // if (entity.type === 'player') {
         //   console.log(`[EntityManager] 📤 Syncing player ${entityId}`);
         //   console.log(`[EntityManager] 📤 networkData keys:`, Object.keys(networkData));
-        //   console.log(`[EntityManager] 📤 networkData.e:`, (networkData as any).e);
+        //   console.log(`[EntityManager] 📤 networkData.c (inCombat):`, (networkData as { c?: boolean }).c);
+        //   console.log(`[EntityManager] 📤 networkData.e (emote):`, (networkData as { e?: string }).e);
         //   console.log(`[EntityManager] 📤 Full networkData:`, JSON.stringify(networkData, null, 2));
         // }
 

--- a/packages/shared/src/types/rendering/nodes.ts
+++ b/packages/shared/src/types/rendering/nodes.ts
@@ -125,6 +125,10 @@ export interface NametagHandle {
   subtextColor?: string;
   visible: boolean;
   offset: number;
+  move: (newMatrix: THREE.Matrix4) => void;
+  setName: (name: string) => void;
+  setHealth: (health: number) => void;
+  setInCombat: (inCombat: boolean) => void;
   destroy: () => void;
 }
 

--- a/packages/shared/src/types/rendering/ui.ts
+++ b/packages/shared/src/types/rendering/ui.ts
@@ -14,10 +14,12 @@ export interface NametagHandle {
   idx: number;
   name: string;
   health: number;
+  inCombat: boolean;
   matrix: THREE.Matrix4;
   move: (newMatrix: THREE.Matrix4) => void;
   setName: (name: string) => void;
   setHealth: (health: number) => void;
+  setInCombat: (inCombat: boolean) => void;
   destroy: () => void;
 }
 


### PR DESCRIPTION
## Summary
Implements RuneScape-style player overhead health bars that appear only during combat and persist for 8 ticks (4.8 seconds) after the last hit.

Fixes #269
 
## Changes
  - Added player overhead health bars using Nametags system (matches mob health bar size: 50×5px)
  - Health bars appear immediately when combat starts, disappear 4.8s after last hit
  - Implemented `c` (inCombat) network key for efficient combat state synchronization
  - Changed combat timeout from 10s to 4.8s (8 OSRS ticks) with natural timer expiration
  - Removed `forceEndCombat()` from mob death to allow timer to run its course

## Technical Details
  - Modified `CombatSystem.ts`: Natural combat timeout, immediate network sync for `c` field
  - Updated `MobEntity.ts`: Removed immediate combat end on death
  - Enhanced `Nametags.ts`: Added `setInCombat()`, adjusted health bar dimensions to match mobs
  - Updated `PlayerLocal/Remote.ts`: Handle `c` field for health bar visibility

## Testing
  ✅ Health bars appear/disappear correctly during combat
  ✅ 4.8s timer works when running away or killing mobs
  ✅ Visual size matches mob health bars
  ✅ No flickering between attacks
