### PR TITLE
Add passive health regeneration with real-time HUD updates (#315)

### DIFF
--- a/packages/server/src/systems/ServerNetwork/event-bridge.ts
+++ b/packages/server/src/systems/ServerNetwork/event-bridge.ts
@@ -347,29 +347,29 @@ export class EventBridge {
   private setupPlayerEvents(): void {
     try {
       // Forward player updates to specific player (health, stats, etc.)
+      // Note: emitPlayerUpdate() sends { playerId, component, data: playerData }
+      // where data.health is { current, max } object
       this.world.on(EventType.PLAYER_UPDATED, (payload: unknown) => {
         const data = payload as {
           playerId: string;
-          playerData?: {
+          component?: string;
+          data?: {
             id: string;
             name: string;
             level: number;
-            health: number;
-            maxHealth: number;
+            health: { current: number; max: number };
             alive: boolean;
           };
         };
 
-        if (data.playerId && data.playerData) {
-          console.log(
-            `[EventBridge] Forwarding PLAYER_UPDATED to ${data.playerId}: health ${data.playerData.health}/${data.playerData.maxHealth}`,
-          );
+        if (data.playerId && data.data) {
+          const playerData = data.data;
 
-          // Send to specific player
+          // Send to specific player with flat health values for client
           this.broadcast.sendToPlayer(data.playerId, "playerUpdated", {
-            health: data.playerData.health,
-            maxHealth: data.playerData.maxHealth,
-            alive: data.playerData.alive,
+            health: playerData.health.current,
+            maxHealth: playerData.health.max,
+            alive: playerData.alive,
           });
         }
       });

--- a/packages/shared/src/constants/GameConstants.ts
+++ b/packages/shared/src/constants/GameConstants.ts
@@ -24,7 +24,9 @@ export const PLAYER_CONSTANTS = {
   DEFAULT_MAX_STAMINA: 100,
   BASE_MOVEMENT_SPEED: 1.0,
   RUNNING_SPEED_MULTIPLIER: 1.5,
-  HEALTH_REGEN_RATE: 1.0,
+  HEALTH_REGEN_RATE: 1, // 1 HP per regen tick (RuneScape-style)
+  HEALTH_REGEN_COOLDOWN: 10000, // 10 seconds after combat/damage before regen starts
+  HEALTH_REGEN_INTERVAL: 60000, // Regen 1 HP every 60 seconds (RuneScape-style)
   STAMINA_REGEN_RATE: 2.0,
   STAMINA_DRAIN_RATE: 5.0,
 } as const;

--- a/packages/shared/src/entities/managers/DeathStateManager.ts
+++ b/packages/shared/src/entities/managers/DeathStateManager.ts
@@ -228,9 +228,6 @@ export class DeathStateManager {
       this.isDead = true;
     }
     this.deathPosition = position.clone();
-    console.log(
-      `[DeathStateManager] [CLIENT] Locked to server death position: (${this.deathPosition.x.toFixed(2)}, ${this.deathPosition.y.toFixed(2)}, ${this.deathPosition.z.toFixed(2)})`,
-    );
   }
 
   /**

--- a/packages/shared/src/runtime/createClientWorld.ts
+++ b/packages/shared/src/runtime/createClientWorld.ts
@@ -227,11 +227,7 @@ export function createClientWorld() {
 
     const damageSplatSystem = world.getSystem("damage-splat");
     if (damageSplatSystem && !damageSplatSystem.isInitialized()) {
-      console.log(
-        "[createClientWorld] 🔄 Manually initializing DamageSplatSystem...",
-      );
       await damageSplatSystem.init(worldOptions);
-      console.log("[createClientWorld] ✅ DamageSplatSystem initialized!");
     }
 
     // Re-expose utilities after RPG systems load (in case they were cleared)

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -867,9 +867,6 @@ export class ClientNetwork extends SystemBase {
       // Clear interpolation buffer for ANY dead mob (defense in depth)
       if (isDead && this.interpolationStates.has(id)) {
         this.interpolationStates.delete(id);
-        console.log(
-          `[ClientNetwork] ✅ Cleared interpolation buffer for dead mob ${id}`,
-        );
       }
 
       // Skip adding new interpolation snapshots for dead mobs
@@ -1558,21 +1555,8 @@ export class ClientNetwork extends SystemBase {
     targetType: "player" | "mob";
     position: { x: number; y: number; z: number };
   }) => {
-    console.log(
-      `[ClientNetwork] Received combatDamageDealt: ${data.damage} damage to ${data.targetId}`,
-    );
-
-    // Check if DamageSplatSystem exists
-    const damageSplatSystem = this.world.getSystem("damage-splat");
-    console.log(
-      `[ClientNetwork] DamageSplatSystem found:`,
-      damageSplatSystem ? "YES ✅" : "NO ❌",
-    );
-
     // Forward to local event system so DamageSplatSystem can show visual feedback
-    console.log(`[ClientNetwork] Emitting COMBAT_DAMAGE_DEALT event...`);
     this.world.emit(EventType.COMBAT_DAMAGE_DEALT, data);
-    console.log(`[ClientNetwork] Event emitted successfully`);
   };
 
   onPlayerUpdated = (data: {
@@ -1585,10 +1569,6 @@ export class ClientNetwork extends SystemBase {
       console.warn("[ClientNetwork] onPlayerUpdated: No local player found");
       return;
     }
-
-    console.log(
-      `[ClientNetwork] 💚 Received playerUpdated: health ${data.health}/${data.maxHealth}`,
-    );
 
     // Use modify() to update entity - this triggers PlayerLocal.modify()
     // which updates _playerHealth (the field the UI reads)
@@ -1608,10 +1588,6 @@ export class ClientNetwork extends SystemBase {
       health: data.health,
       maxHealth: data.maxHealth,
     });
-
-    console.log(
-      `[ClientNetwork] ✅ Local player health updated: ${data.health}/${data.maxHealth}`,
-    );
   };
 
   onCorpseLoot = (data: {

--- a/packages/shared/src/systems/client/DamageSplatSystem.ts
+++ b/packages/shared/src/systems/client/DamageSplatSystem.ts
@@ -40,43 +40,19 @@ export class DamageSplatSystem extends System {
 
   constructor(world: World) {
     super(world);
-    console.log("[DamageSplatSystem] 🏗️ Constructor called");
   }
 
   async init(): Promise<void> {
     // Only run on client
     if (!this.world.isClient) {
-      console.log(
-        "[DamageSplatSystem] Skipping initialization (not on client)",
-      );
       return;
     }
 
-    console.log("[DamageSplatSystem] Initializing on client...");
-    console.log(
-      `[DamageSplatSystem] EventType.COMBAT_DAMAGE_DEALT = "${EventType.COMBAT_DAMAGE_DEALT}"`,
-    );
-
     // Listen for combat damage events
-    console.log("[DamageSplatSystem] Registering event listener...");
     this.world.on(
       EventType.COMBAT_DAMAGE_DEALT,
       this.onDamageDealt.bind(this),
       this,
-    );
-    console.log("[DamageSplatSystem] Event listener registered");
-
-    // Verify listener was added
-    const listeners = (this.world as any)._events?.[
-      EventType.COMBAT_DAMAGE_DEALT
-    ];
-    console.log(
-      `[DamageSplatSystem] Event listeners for COMBAT_DAMAGE_DEALT:`,
-      listeners ? listeners.length : "none",
-    );
-
-    console.log(
-      "[DamageSplatSystem] ✅ Initialized and listening for COMBAT_DAMAGE_DEALT events",
     );
   }
 
@@ -89,21 +65,10 @@ export class DamageSplatSystem extends System {
 
     const { damage, targetId, position } = payload;
 
-    console.log(
-      `[DamageSplatSystem] 💥 onDamageDealt: ${damage} damage to ${targetId}, position:`,
-      position,
-    );
-
     // Get target entity for position
     const target = this.world.entities.get(targetId);
     if (!target) {
-      console.warn(
-        `[DamageSplatSystem] Target entity ${targetId} not found, using provided position`,
-      );
       if (!position) {
-        console.error(
-          "[DamageSplatSystem] No position provided and target not found, cannot show splat",
-        );
         return;
       }
       this.createDamageSplat(damage, position);
@@ -113,13 +78,8 @@ export class DamageSplatSystem extends System {
     // Use provided position or entity position
     const targetPos = position || target.position;
     if (!targetPos) {
-      console.error(
-        `[DamageSplatSystem] No position available for target ${targetId}`,
-      );
       return;
     }
-
-    console.log(`[DamageSplatSystem] Creating splat at position:`, targetPos);
 
     // Create damage splat
     this.createDamageSplat(damage, targetPos);
@@ -129,15 +89,8 @@ export class DamageSplatSystem extends System {
     damage: number,
     position: { x: number; y: number; z: number },
   ): void {
-    console.log(
-      `[DamageSplatSystem] 🎨 Creating splat: damage=${damage}, pos=(${position.x.toFixed(1)}, ${position.y.toFixed(1)}, ${position.z.toFixed(1)})`,
-    );
-
     // Check if scene is available
     if (!this.world.stage?.scene) {
-      console.error(
-        "[DamageSplatSystem] Cannot create splat: world.stage.scene not available",
-      );
       return;
     }
 
@@ -145,7 +98,6 @@ export class DamageSplatSystem extends System {
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d");
     if (!context) {
-      console.error("[DamageSplatSystem] Failed to get 2D context for canvas");
       return;
     }
 
@@ -200,10 +152,6 @@ export class DamageSplatSystem extends System {
 
     // Add to scene
     this.world.stage.scene.add(sprite);
-
-    console.log(
-      `[DamageSplatSystem] ✅ Splat added to scene at (${sprite.position.x.toFixed(1)}, ${sprite.position.y.toFixed(1)}, ${sprite.position.z.toFixed(1)}), active splats: ${this.activeSplats.length + 1}`,
-    );
 
     // Track splat for animation
     this.activeSplats.push({

--- a/packages/shared/src/systems/shared/character/HealthRegenSystem.ts
+++ b/packages/shared/src/systems/shared/character/HealthRegenSystem.ts
@@ -1,0 +1,275 @@
+/**
+ * HealthRegenSystem - Passive Health Regeneration (RuneScape-style)
+ *
+ * Server-authoritative system that handles passive health regeneration for all players.
+ * Implements RuneScape-like mechanics:
+ * - No regeneration while in combat
+ * - 10-second cooldown after taking damage before regen starts
+ * - Regenerates 1 HP per second when conditions are met
+ *
+ * Works for both human players and AI agent players automatically.
+ *
+ * @see {@link CombatSystem} for combat state tracking
+ * @see {@link GAME_CONSTANTS.PLAYER} for regen rate configuration
+ */
+
+import { SystemBase } from "..";
+import type { World } from "../../../core/World";
+import { GAME_CONSTANTS } from "../../../constants/GameConstants";
+import type { CombatSystem } from "../combat/CombatSystem";
+import type { PlayerSystem } from "./PlayerSystem";
+import type { Player } from "../../../types/core/core";
+
+// Default constants if not defined in GameConstants
+const DEFAULT_REGEN_RATE = 1; // 1 HP per regen tick
+const DEFAULT_REGEN_COOLDOWN = 10000; // 10 seconds after combat/damage
+const DEFAULT_REGEN_INTERVAL = 60000; // 60 seconds between regen ticks (RuneScape-style)
+
+/**
+ * HealthRegenSystem - Manages passive health regeneration for all players
+ *
+ * This system runs on the server only and handles:
+ * - Checking if players are eligible for regeneration
+ * - Applying health regeneration at configured rate
+ * - Respecting combat cooldown periods
+ */
+export class HealthRegenSystem extends SystemBase {
+  declare world: World;
+
+  /** Time accumulator for throttled updates */
+  private timeSinceLastRegen: number = 0;
+
+  /** Reference to combat system for checking combat state */
+  private combatSystem: CombatSystem | null = null;
+
+  /** Reference to player system for getting players */
+  private playerSystem: PlayerSystem | null = null;
+
+  /** Regen configuration */
+  private regenRate: number;
+  private regenCooldown: number;
+  private regenInterval: number;
+
+  constructor(world: World) {
+    super(world, {
+      name: "health-regen",
+      dependencies: {
+        optional: ["combat", "player"],
+      },
+      autoCleanup: true,
+    });
+
+    // Load configuration from constants
+    this.regenRate =
+      GAME_CONSTANTS.PLAYER.HEALTH_REGEN_RATE ?? DEFAULT_REGEN_RATE;
+    this.regenCooldown =
+      (GAME_CONSTANTS.PLAYER as { HEALTH_REGEN_COOLDOWN?: number })
+        .HEALTH_REGEN_COOLDOWN ?? DEFAULT_REGEN_COOLDOWN;
+    this.regenInterval =
+      (GAME_CONSTANTS.PLAYER as { HEALTH_REGEN_INTERVAL?: number })
+        .HEALTH_REGEN_INTERVAL ?? DEFAULT_REGEN_INTERVAL;
+  }
+
+  /**
+   * Initialize the system
+   * Called after all systems are registered
+   */
+  override async start(): Promise<void> {
+    // Get reference to combat system
+    this.combatSystem = this.world.getSystem("combat") as CombatSystem | null;
+    this.playerSystem = this.world.getSystem("player") as PlayerSystem | null;
+
+    if (!this.combatSystem) {
+      console.warn(
+        "[HealthRegenSystem] CombatSystem not found - combat state checks will be skipped",
+      );
+    }
+
+    if (!this.playerSystem) {
+      console.warn(
+        "[HealthRegenSystem] PlayerSystem not found - regen will be disabled",
+      );
+    }
+
+    console.log(
+      `[HealthRegenSystem] Started - Rate: ${this.regenRate} HP/sec, ` +
+        `Cooldown: ${this.regenCooldown}ms, Interval: ${this.regenInterval}ms`,
+    );
+  }
+
+  /**
+   * Update loop - called every frame
+   * Throttled to only process regen at configured interval
+   */
+  override update(delta: number): void {
+    // Only run on server
+    if (!this.world.isServer) return;
+
+    // Need player system to function
+    if (!this.playerSystem) return;
+
+    // Accumulate time
+    this.timeSinceLastRegen += delta * 1000; // Convert to ms
+
+    // Throttle updates to configured interval (default: every 60 seconds)
+    if (this.timeSinceLastRegen < this.regenInterval) {
+      return;
+    }
+
+    // Reset timer
+    this.timeSinceLastRegen = 0;
+
+    // Process all players - heal fixed amount per tick
+    this.processPlayerRegen();
+  }
+
+  /**
+   * Process health regeneration for all players
+   */
+  private processPlayerRegen(): void {
+    if (!this.playerSystem) return;
+
+    const now = Date.now();
+    const players = this.playerSystem.getAllPlayers();
+
+    for (const player of players) {
+      // Check if player should regenerate
+      const regenStatus = this.getRegenStatus(player, now);
+
+      if (!regenStatus.shouldRegen) {
+        continue;
+      }
+
+      // Apply regeneration
+      this.applyRegen(player);
+    }
+  }
+
+  /**
+   * Get detailed regen status for debugging
+   */
+  private getRegenStatus(
+    player: Player,
+    now: number,
+  ): {
+    shouldRegen: boolean;
+    alive: boolean;
+    healthFull: boolean;
+    inCombat: boolean;
+    cooldownExpired: boolean;
+  } {
+    const alive = player.alive !== false;
+    const currentHealth = player.health?.current ?? 0;
+    const maxHealth = player.health?.max ?? 100;
+    const healthFull = currentHealth >= maxHealth;
+    const inCombat = this.combatSystem?.isInCombat(player.id) ?? false;
+
+    const playerEntity = this.world.entities?.get(player.id);
+    const lastDamageTime = this.getLastDamageTime(playerEntity);
+    const cooldownExpired =
+      lastDamageTime === null || now - lastDamageTime >= this.regenCooldown;
+
+    return {
+      shouldRegen: alive && !healthFull && !inCombat && cooldownExpired,
+      alive,
+      healthFull,
+      inCombat,
+      cooldownExpired,
+    };
+  }
+
+  /**
+   * Apply health regeneration to a player
+   */
+  private applyRegen(player: Player): void {
+    if (!this.playerSystem) return;
+
+    const currentHealth = player.health?.current ?? 0;
+    const maxHealth = player.health?.max ?? 100;
+
+    // Only apply if there's meaningful healing to do
+    if (currentHealth >= maxHealth) return;
+
+    // Use PlayerSystem.healPlayer() - this properly updates health AND emits network events
+    // Heal exactly regenRate HP per tick (default: 1 HP every 60 seconds)
+    this.playerSystem.healPlayer(player.id, this.regenRate);
+  }
+
+  /**
+   * Get last damage time from entity
+   */
+  private getLastDamageTime(entity: unknown): number | null {
+    if (!entity || typeof entity !== "object") return null;
+
+    const entityObj = entity as Record<string, unknown>;
+
+    // Try direct property
+    if (typeof entityObj.lastDamageTime === "number") {
+      return entityObj.lastDamageTime;
+    }
+
+    // Try health component data
+    if (entityObj.health && typeof entityObj.health === "object") {
+      const healthObj = entityObj.health as Record<string, unknown>;
+      if (typeof healthObj.lastDamageTime === "number") {
+        return healthObj.lastDamageTime;
+      }
+    }
+
+    // Try components Map/object
+    if (entityObj.components && typeof entityObj.components === "object") {
+      const components = entityObj.components as Record<string, unknown>;
+      const healthComp = components.health as
+        | Record<string, unknown>
+        | undefined;
+      if (healthComp) {
+        if (typeof healthComp.lastDamageTime === "number") {
+          return healthComp.lastDamageTime;
+        }
+        // Try data property of component
+        const data = healthComp.data as Record<string, unknown> | undefined;
+        if (data && typeof data.lastDamageTime === "number") {
+          return data.lastDamageTime;
+        }
+      }
+    }
+
+    // Try getComponent method
+    if (
+      typeof (entityObj as { getComponent?: (name: string) => unknown })
+        .getComponent === "function"
+    ) {
+      const healthComp = (
+        entityObj as { getComponent: (name: string) => unknown }
+      ).getComponent("health");
+      if (healthComp && typeof healthComp === "object") {
+        const hc = healthComp as Record<string, unknown>;
+        if (typeof hc.lastDamageTime === "number") {
+          return hc.lastDamageTime;
+        }
+        // Try data property
+        const data = hc.data as Record<string, unknown> | undefined;
+        if (data && typeof data.lastDamageTime === "number") {
+          return data.lastDamageTime;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get system statistics for debugging
+   */
+  getStats(): {
+    regenRate: number;
+    regenCooldown: number;
+    regenInterval: number;
+  } {
+    return {
+      regenRate: this.regenRate,
+      regenCooldown: this.regenCooldown,
+      regenInterval: this.regenInterval,
+    };
+  }
+}

--- a/packages/shared/src/systems/shared/character/PlayerSystem.ts
+++ b/packages/shared/src/systems/shared/character/PlayerSystem.ts
@@ -716,9 +716,9 @@ export class PlayerSystem extends SystemBase {
       );
       player.health.current = player.health.max;
     } else {
-      player.health.current = Math.max(
-        0,
-        Math.min(validCurrentHealth, player.health.max),
+      // Floor to ensure health is always an integer (RuneScape-style)
+      player.health.current = Math.floor(
+        Math.max(0, Math.min(validCurrentHealth, player.health.max)),
       );
     }
 
@@ -786,8 +786,10 @@ export class PlayerSystem extends SystemBase {
       return;
     }
 
-    // Apply damage
-    const newHealth = Math.max(0, player.health.current - data.damage);
+    // Apply damage - floor to ensure health is always an integer (RuneScape-style)
+    const newHealth = Math.floor(
+      Math.max(0, player.health.current - data.damage),
+    );
     player.health.current = newHealth;
 
     // Update player entity if it exists
@@ -938,9 +940,9 @@ export class PlayerSystem extends SystemBase {
     if (!player || !player.alive) return false;
 
     const oldHealth = player.health.current;
-    player.health.current = Math.min(
-      player.health.max,
-      player.health.current + amount,
+    // Floor to ensure health is always an integer (RuneScape-style)
+    player.health.current = Math.floor(
+      Math.min(player.health.max, player.health.current + amount),
     );
 
     if (player.health.current !== oldHealth) {
@@ -1106,7 +1108,10 @@ export class PlayerSystem extends SystemBase {
         ? player.health.current
         : player.health.max;
 
-    player.health.current = Math.max(0, currentHealth - validAmount);
+    // Floor to ensure health is always an integer (RuneScape-style)
+    player.health.current = Math.floor(
+      Math.max(0, currentHealth - validAmount),
+    );
 
     // Sync damage to PlayerEntity if it exists
     const playerEntity = this.world.getPlayer?.(

--- a/packages/shared/src/systems/shared/character/SkillsSystem.ts
+++ b/packages/shared/src/systems/shared/character/SkillsSystem.ts
@@ -576,8 +576,8 @@ export class SkillsSystem extends SystemBase {
       // Update hitpoints max
       const newMax = this.calculateMaxHitpoints(newLevel);
       stats.health.max = newMax;
-      // If current HP is higher than new max, cap it
-      stats.health.current = Math.min(stats.health.current, newMax);
+      // If current HP is higher than new max, cap it (floor for integer health)
+      stats.health.current = Math.floor(Math.min(stats.health.current, newMax));
     }
 
     // Special handling for Prayer level up - skipping for MVP

--- a/packages/shared/src/systems/shared/character/index.ts
+++ b/packages/shared/src/systems/shared/character/index.ts
@@ -1,9 +1,10 @@
 /**
  * Character Systems
- * Player character management, equipment, inventory, and skills
+ * Player character management, equipment, inventory, skills, and health
  */
 
 export * from "./PlayerSystem";
 export * from "./EquipmentSystem";
 export * from "./InventorySystem";
 export * from "./SkillsSystem";
+export * from "./HealthRegenSystem";

--- a/packages/shared/src/utils/game/CombatUtils.ts
+++ b/packages/shared/src/utils/game/CombatUtils.ts
@@ -113,7 +113,10 @@ export function applyDamage(
   if (!stats || damage <= 0) return false;
 
   if (stats.health) {
-    stats.health.current = Math.max(0, stats.health.current - damage);
+    // Floor to ensure health is always an integer
+    stats.health.current = Math.floor(
+      Math.max(0, stats.health.current - damage),
+    );
   }
 
   // Emit damage event for systems to handle
@@ -143,9 +146,9 @@ export function healEntity(
 
   const oldHealth = stats.health?.current || 0;
   if (stats.health) {
-    stats.health.current = Math.min(
-      stats.health.max,
-      stats.health.current + healAmount,
+    // Floor to ensure health is always an integer
+    stats.health.current = Math.floor(
+      Math.min(stats.health.max, stats.health.current + healAmount),
     );
   }
   const actualHeal = (stats.health?.current || 0) - oldHealth;


### PR DESCRIPTION
## Summary
Implements passive health regeneration system that works for both human players and AI agents.

## Changes
- **HealthRegenSystem**: New server-authoritative system that regenerates 1 HP every 60 seconds when out of combat (10-second cooldown after taking damage)
- **Real-time HUD updates**: Fixed EventBridge payload structure mismatch that prevented health changes from syncing to client UI
- **Integer health enforcement**: Added `Math.floor()` to all health modification points (healPlayer, damagePlayer, takeDamage, updateHealth, CombatUtils) to prevent database errors with fractional values
- **Debug log cleanup**: Removed verbose logging from ClientNetwork, DamageSplatSystem, and DeathStateManager

## Testing
- Health regenerates correctly after combat ends
- HUD health bar updates in real-time
- No more "invalid input syntax for type integer" database errors

Fixes #315