### PR TITLE
fix: normalize path separators for Windows

### DIFF
--- a/packages/shared/src/data/DataManager.ts
+++ b/packages/shared/src/data/DataManager.ts
@@ -264,18 +264,15 @@ export class DataManager {
     } else {
       // cwd is typically packages/server when running the server
       const cwd = process.cwd();
+      // Normalize path separators for cross-platform compatibility (Windows uses \, Unix uses /)
+      const normalizedCwd = cwd.replace(/\\/g, "/");
       if (
-        cwd.endsWith("/packages/server") ||
-        cwd.includes("/packages/server/")
+        normalizedCwd.endsWith("/packages/server") ||
+        normalizedCwd.includes("/packages/server/")
       ) {
         // Running from packages/server - assets are in world/assets/
-        manifestsDir = path.join(
-          cwd.replace(/\/packages\/server.*$/, "/packages/server"),
-          "world",
-          "assets",
-          "manifests",
-        );
-      } else if (cwd.includes("/packages/")) {
+        manifestsDir = path.join(cwd, "world", "assets", "manifests");
+      } else if (normalizedCwd.includes("/packages/")) {
         // Running from another package - navigate to server assets
         const workspaceRoot = path.resolve(cwd, "../..");
         manifestsDir = path.join(


### PR DESCRIPTION
otherwise, Hyperscape will not start in Windows. 

Before fix:
`@hyperscape/server:dev: [World] Creating server world...
@hyperscape/server:dev: [DataManager] Loading manifests from filesystem: C:\Users\cruze\Documents\GitHub\hyperscape\packages\server\packages\server\world\assets\manifests
@hyperscape/server:dev: [DataManager] ❌ Failed to load manifests from filesystem: ENOENT: no such file or directory, open 'C:\Users\cruze\Documents\GitHub\hyperscape\packages\server\packages\server\world\assets\manifests\items.json'
@hyperscape/server:dev:     path: "C:\\Users\\cruze\\Documents\\GitHub\\hyperscape\\packages\\server\\packages\\server\\world\\assets\\manifests\\items.json",
@hyperscape/server:dev:  syscall: "open",
@hyperscape/server:dev:    errno: -2,
@hyperscape/server:dev:     code: "ENOENT"
@hyperscape/server:dev:
@hyperscape/server:dev:
@hyperscape/server:dev: ============================================================
@hyperscape/server:dev: ❌ FATAL ERROR DURING STARTUP
@hyperscape/server:dev: ============================================================
@hyperscape/server:dev: ENOENT: no such file or directory, open 'C:\Users\cruze\Documents\GitHub\hyperscape\packages\server\packages\server\world\assets\manifests\items.json'
@hyperscape/server:dev:     path: "C:\\Users\\cruze\\Documents\\GitHub\\hyperscape\\packages\\server\\packages\\server\\world\\assets\\manifests\\items.json",
@hyperscape/server:dev:  syscall: "open",
@hyperscape/server:dev:    errno: -2,
@hyperscape/server:dev:     code: "ENOENT"
@hyperscape/server:dev:
@hyperscape/server:dev:
@hyperscape/server:dev: ============================================================
@hyperscape/server:dev: Server exited (code: 1, signal: null)
@hyperscape/server:dev: Server crashed. Fix the error and save a file to rebuild.`


After fix: 
Server starts on Windows! 