### PR TITLE
fix: support both docker compose V2 and standalone docker-compose

### DIFF
--- a/packages/server/scripts/dev-final.mjs
+++ b/packages/server/scripts/dev-final.mjs
@@ -314,6 +314,23 @@ function isDockerAvailable() {
   }
 }
 
+// Get the appropriate docker compose command (V2 vs standalone)
+function getDockerComposeCommand() {
+  // Try docker compose (newer Docker versions) first
+  try {
+    execSync('docker compose version', { stdio: 'ignore' })
+    return 'docker compose'
+  } catch {
+    // Fall back to docker-compose (older versions or standalone)
+    try {
+      execSync('docker-compose version', { stdio: 'ignore' })
+      return 'docker-compose'
+    } catch {
+      throw new Error('Neither "docker compose" nor "docker-compose" is available')
+    }
+  }
+}
+
 // Start CDN container if not running
 async function ensureCDNRunning() {
   if (!isDockerAvailable()) {
@@ -333,7 +350,8 @@ async function ensureCDNRunning() {
 
     // Start CDN
     console.log(`${colors.blue}Starting CDN container...${colors.reset}`)
-    execSync('docker-compose up -d cdn', { 
+    const dockerComposeCmd = getDockerComposeCommand()
+    execSync(`${dockerComposeCmd} up -d cdn`, {
       stdio: 'inherit',
       cwd: rootDir
     })
@@ -367,10 +385,11 @@ async function ensureCDNRunning() {
 // Stop CDN container
 function stopCDN() {
   if (!isDockerAvailable()) return
-  
+
   try {
     console.log(`${colors.dim}Stopping CDN container...${colors.reset}`)
-    execSync('docker-compose down cdn', { 
+    const dockerComposeCmd = getDockerComposeCommand()
+    execSync(`${dockerComposeCmd} down cdn`, {
       stdio: 'ignore',
       cwd: rootDir
     })

--- a/scripts/cdn.mjs
+++ b/scripts/cdn.mjs
@@ -32,6 +32,22 @@ function isDockerAvailable() {
   }
 }
 
+function getDockerComposeCommand() {
+  // Try docker compose (newer Docker versions) first
+  try {
+    execSync('docker compose version', { stdio: 'ignore' })
+    return 'docker compose'
+  } catch {
+    // Fall back to docker-compose (older versions or standalone)
+    try {
+      execSync('docker-compose version', { stdio: 'ignore' })
+      return 'docker-compose'
+    } catch {
+      throw new Error('Neither "docker compose" nor "docker-compose" is available')
+    }
+  }
+}
+
 async function ensureCDNRunning() {
   if (!isDockerAvailable()) {
     console.log(`${colors.yellow}⚠️  Docker not available - CDN will not start${colors.reset}`)
@@ -67,7 +83,8 @@ async function ensureCDNRunning() {
 
     // Start CDN
     console.log(`${colors.blue}Starting CDN container...${colors.reset}`)
-    execSync('docker-compose up -d cdn', { 
+    const dockerComposeCmd = getDockerComposeCommand()
+    execSync(`${dockerComposeCmd} up -d cdn`, { 
       stdio: 'inherit',
       cwd: serverDir
     })


### PR DESCRIPTION
## Summary
- Adds `getDockerComposeCommand()` helper that detects whether to use `docker compose` (V2) or `docker-compose` (standalone)
- Fixes "docker-compose: command not found" error on systems with Docker Desktop 4.x+

## Problem
Newer Docker Desktop versions (4.x+) use `docker compose` as a built-in subcommand (V2), while older setups use the standalone `docker-compose` binary. The scripts were hardcoded to use `docker-compose`, which fails on newer Docker installations.

## Changes
- `scripts/cdn.mjs` - Added `getDockerComposeCommand()` and updated CDN start command
- `packages/server/scripts/dev-final.mjs` - Same fix for dev server CDN management