### PR TITLE
fix: migration duplicates and add equipment feedback to chat

### DIFF
--- a/packages/client/src/game/chat/Chat.tsx
+++ b/packages/client/src/game/chat/Chat.tsx
@@ -87,6 +87,18 @@ export function Chat({ world }: { world: ChatWorld }) {
     };
   }, [active, setActive, setCollapsed, world]);
 
+  // Auto-open chat when system messages arrive (equipment feedback, combat info, etc.)
+  useEffect(() => {
+    const onShowChat = () => {
+      setActive(true);
+      setCollapsed(false);
+    };
+    world.on("ui:chat:show" as EventType, onShowChat);
+    return () => {
+      world.off("ui:chat:show" as EventType, onShowChat);
+    };
+  }, [setActive, setCollapsed, world]);
+
   useEffect(() => {
     const onPrefsChange = (changes: { chatVisible?: { value: boolean } }) => {
       if (changes.chatVisible !== undefined) {

--- a/packages/server/src/database/client.ts
+++ b/packages/server/src/database/client.ts
@@ -146,24 +146,33 @@ export async function initializeDatabase(connectionString: string) {
     await migrate(db, { migrationsFolder });
   } catch (error) {
     // If tables already exist (42P07), that's fine - the database is already set up
-    const hasCode =
-      error &&
-      typeof error === "object" &&
-      "cause" in error &&
-      error.cause &&
-      typeof error.cause === "object" &&
-      "code" in error.cause;
-    const hasMessage = error && typeof error === "object" && "message" in error;
-    const errorWithCause = error as {
-      cause?: { code?: string };
+    // Extract error details for precise matching
+    const errorObj = error as {
+      cause?: { code?: string; message?: string };
       message?: string;
+      code?: string;
     };
+
+    // Check for PostgreSQL error codes indicating objects already exist
+    const pgErrorCode =
+      errorObj.cause?.code || errorObj.code; // Nested in cause (DrizzleQueryError) // Direct on error
+
+    const isTableExistsError = pgErrorCode === "42P07"; // relation already exists
+    const isColumnExistsError = pgErrorCode === "42701"; // column already exists
+    const isConstraintExistsError = pgErrorCode === "42710"; // constraint already exists
+
+    // Only match "already exists" at the START of the cause message (PostgreSQL error format)
+    // This prevents false positives from unrelated errors that mention "already exists"
+    const causeMessage = errorObj.cause?.message || "";
+    const isAlreadyExistsMessage =
+      causeMessage.startsWith("relation") &&
+      causeMessage.includes("already exists");
+
     const isExistsError =
-      (hasCode && errorWithCause.cause?.code === "42P07") || // Table already exists
-      (hasCode && errorWithCause.cause?.code === "42701") || // Column already exists
-      (hasMessage &&
-        typeof errorWithCause.message === "string" &&
-        errorWithCause.message.includes("already exists"));
+      isTableExistsError ||
+      isColumnExistsError ||
+      isConstraintExistsError ||
+      isAlreadyExistsMessage;
 
     if (isExistsError) {
       console.log(

--- a/packages/server/src/database/migrations/0012_great_outlaw_kid.sql
+++ b/packages/server/src/database/migrations/0012_great_outlaw_kid.sql
@@ -8,22 +8,7 @@ CREATE TABLE "bank_placeholders" (
 	CONSTRAINT "bank_placeholders_playerId_tabIndex_slot_unique" UNIQUE("playerId","tabIndex","slot")
 );
 --> statement-breakpoint
-CREATE TABLE "bank_tabs" (
-	"id" serial PRIMARY KEY NOT NULL,
-	"playerId" text NOT NULL,
-	"tabIndex" integer NOT NULL,
-	"iconItemId" text,
-	"createdAt" bigint DEFAULT (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT NOT NULL,
-	CONSTRAINT "bank_tabs_playerId_tabIndex_unique" UNIQUE("playerId","tabIndex")
-);
---> statement-breakpoint
-ALTER TABLE "bank_storage" DROP CONSTRAINT "bank_storage_playerId_slot_unique";--> statement-breakpoint
-ALTER TABLE "bank_storage" ADD COLUMN "tabIndex" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
 ALTER TABLE "characters" ADD COLUMN "alwaysSetPlaceholder" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
 ALTER TABLE "bank_placeholders" ADD CONSTRAINT "bank_placeholders_playerId_characters_id_fk" FOREIGN KEY ("playerId") REFERENCES "public"."characters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "bank_tabs" ADD CONSTRAINT "bank_tabs_playerId_characters_id_fk" FOREIGN KEY ("playerId") REFERENCES "public"."characters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "idx_bank_placeholders_player" ON "bank_placeholders" USING btree ("playerId");--> statement-breakpoint
-CREATE INDEX "idx_bank_placeholders_player_item" ON "bank_placeholders" USING btree ("playerId","itemId");--> statement-breakpoint
-CREATE INDEX "idx_bank_tabs_player" ON "bank_tabs" USING btree ("playerId");--> statement-breakpoint
-CREATE INDEX "idx_bank_storage_player_tab" ON "bank_storage" USING btree ("playerId","tabIndex");--> statement-breakpoint
-ALTER TABLE "bank_storage" ADD CONSTRAINT "bank_storage_playerId_tabIndex_slot_unique" UNIQUE("playerId","tabIndex","slot");
+CREATE INDEX "idx_bank_placeholders_player_item" ON "bank_placeholders" USING btree ("playerId","itemId");

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -840,6 +840,9 @@ export class ClientNetwork extends SystemBase {
       createdAt: new Date().toISOString(),
     };
     this.world.chat.add(chatMessage, false);
+
+    // Auto-open chat when system message arrives so user sees feedback
+    this.world.emit("ui:chat:show" as EventType, {});
   };
 
   onEntityAdded = (data: EntityData) => {


### PR DESCRIPTION
- Remove duplicate bank_tabs operations from migration 0012 that were already handled by migration 0011, preventing "already exists" errors
- Improve database migration error handling with better PostgreSQL error code detection (42P07, 42701, 42710)
- Auto-open chat panel when system messages arrive so players see equipment requirement warnings and other feedback immediately