### PR TITLE
fix(ci): install Tauri system dependencies for Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             libglib2.0-dev
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -131,7 +131,7 @@ jobs:
             libglib2.0-dev
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Install required Tauri system dependencies on Linux CI runners so the `@hyperscape/app` package can build properly.

## Problem

The CI was failing because the Tauri app requires GTK/glib system dependencies that are not available on Linux CI runners by default:

```
error: failed to run custom build command for `glib-sys v0.18.1`
The system library `glib-2.0` required by crate `glib-sys` was not found.
```

## Solution

Added installation of required system dependencies to the `test` and `build` jobs:

- `libgtk-3-dev`
- `libwebkit2gtk-4.1-dev`
- `libappindicator3-dev`
- `librsvg2-dev`
- `patchelf`
- `libglib2.0-dev`
- Rust stable toolchain (via `dtolnay/rust-action`)

## Test plan

- [ ] CI lint job passes
- [ ] CI test job passes (with Tauri deps installed)
- [ ] CI build job passes (with Tauri deps installed)
- [ ] Tauri app builds successfully in CI