### PR TITLE
fix(plugin-hyperscape): resolve 70 TypeScript build errors with type …

### DIFF
--- a/packages/plugin-hyperscape/src/systems/avatar.ts
+++ b/packages/plugin-hyperscape/src/systems/avatar.ts
@@ -22,7 +22,7 @@
  */
 
 import { logger } from "@elizaos/core";
-import { THREE } from "@hyperscape/shared";
+import { Vector3, Quaternion, Matrix4, Object3D } from "three";
 import type { World, Player } from "../types/core-types";
 
 // Animation state constants
@@ -56,38 +56,34 @@ interface PlayerEffect {
   emote?: string | null;
 }
 
-interface ParentNode extends THREE.Object3D {
-  position: THREE.Vector3;
-  quaternion: THREE.Quaternion;
+interface ParentNode extends Object3D {
+  position: Vector3;
+  quaternion: Quaternion;
   base?: {
-    position: THREE.Vector3;
-    quaternion: THREE.Quaternion;
+    position: Vector3;
+    quaternion: Quaternion;
   };
 }
 
 interface AvatarInstance {
   setEmote(emote: string | null): void;
-  move(matrix: THREE.Matrix4): void;
+  move(matrix: Matrix4): void;
   destroy(): void;
   height?: number;
   headToHeight?: number;
-  getBoneTransform?(boneName: string): THREE.Matrix4 | null;
+  getBoneTransform?(boneName: string): Matrix4 | null;
   disableRateCheck?(): void;
 }
 
 interface AvatarFactory {
-  create(
-    matrix: THREE.Matrix4,
-    hooks?: unknown,
-    node?: unknown,
-  ): AvatarInstance;
+  create(matrix: Matrix4, hooks?: unknown, node?: unknown): AvatarInstance;
   applyStats?(stats: unknown): void;
 }
 
 /**
  * Base Node class implementation for the avatar system
  */
-class Node extends THREE.Object3D {
+class Node extends Object3D {
   ctx: NodeContext;
   dirty: boolean = false;
   proxy: unknown = null;
@@ -129,8 +125,8 @@ export class AgentAvatar extends Node {
   overrideEmote: string | null = null;
 
   // Movement tracking
-  private lastPosition: THREE.Vector3 = new THREE.Vector3();
-  private velocity: THREE.Vector3 = new THREE.Vector3();
+  private lastPosition: Vector3 = new Vector3();
+  private velocity: Vector3 = new Vector3();
   private movementStartTime: number = 0;
 
   // Emote management
@@ -308,11 +304,7 @@ export class AgentAvatar extends Node {
       | undefined;
 
     if (playerPos) {
-      const currentPos = new THREE.Vector3(
-        playerPos.x,
-        playerPos.y,
-        playerPos.z,
-      );
+      const currentPos = new Vector3(playerPos.x, playerPos.y, playerPos.z);
       this.velocity
         .subVectors(currentPos, this.lastPosition)
         .divideScalar(delta);
@@ -389,7 +381,7 @@ export class AgentAvatar extends Node {
   /**
    * Get bone transform for attachment points
    */
-  getBoneTransform(boneName: string): THREE.Matrix4 | null {
+  getBoneTransform(boneName: string): Matrix4 | null {
     return this.instance?.getBoneTransform?.(boneName) ?? null;
   }
 

--- a/packages/plugin-hyperscape/src/systems/liveKit.ts
+++ b/packages/plugin-hyperscape/src/systems/liveKit.ts
@@ -19,8 +19,16 @@
 
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { System } from "../types/core-types";
-import type { World } from "@hyperscape/shared";
+import type { World } from "../types/core-types";
+
+// Base System class for this module
+abstract class System {
+  protected world: World;
+
+  constructor(world: World) {
+    this.world = world;
+  }
+}
 
 export interface LiveKitInitOptions {
   wsUrl: string;

--- a/packages/plugin-hyperscape/src/types/core-interfaces.ts
+++ b/packages/plugin-hyperscape/src/types/core-interfaces.ts
@@ -9,20 +9,28 @@ import type {
   IAgentRuntime,
   Memory,
   State,
-  HandlerCallback,
   Action,
   Provider,
   Service,
   UUID,
 } from "@elizaos/core";
 
-import { World, Entity, System } from "./core-types.js";
+// Import types from local core-types (not @hyperscape/shared)
 import type {
+  World,
+  Entity,
+  System,
   Player,
   Vector3,
   Quaternion,
   Component,
-} from "@hyperscape/shared";
+  Physics,
+  Entities,
+  Events,
+  WorldOptions,
+  Position,
+  ContentInstance,
+} from "./core-types.js";
 
 // Core agent interfaces for Hyperscape integration
 export interface AgentContext {
@@ -42,12 +50,12 @@ export interface IHyperscapeService extends Service {
   disconnect(): Promise<void>;
 
   // Game state access
-  getPlayerEntity(): any;
-  getNearbyEntities(): any[];
-  getGameState(): any;
+  getPlayerEntity(): Player | null;
+  getNearbyEntities(): Entity[];
+  getGameState(): unknown;
 
   // Command execution
-  executeMove(command: { target: any; runMode?: boolean }): Promise<void>;
+  executeMove(command: { target: Position; runMode?: boolean }): Promise<void>;
   executeAttack(command: { targetEntityId: string }): Promise<void>;
   executeChatMessage(command: { message: string }): Promise<void>;
 }
@@ -59,15 +67,15 @@ export interface AgentState {
   rotation?: Quaternion;
   isConnected: boolean;
   lastActivity: Date;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface WorldState {
   worldId: string;
   connectedAgents: UUID[];
-  entities: Record<string, any>;
+  entities: Record<string, Entity>;
   lastUpdate: Date;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface AgentMemory extends Memory {
@@ -76,7 +84,7 @@ export interface AgentMemory extends Memory {
   position?: Vector3;
   rotation?: Quaternion;
   lastAction?: string;
-  relationships?: Record<UUID, any>;
+  relationships?: Record<UUID, unknown>;
 }
 
 export interface HyperscapeAction extends Action {
@@ -107,7 +115,7 @@ export interface MessageContext {
 // Event interfaces for Hyperscape integration
 export interface HyperscapeEvent {
   type: string;
-  data: any;
+  data: unknown;
   timestamp: number;
   agentId?: UUID;
   worldId?: string;
@@ -125,15 +133,15 @@ export interface AgentConnection {
 // Utility interfaces
 export interface ProviderResult {
   success: boolean;
-  data?: any;
+  data?: unknown;
   error?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ActionResult {
   success: boolean;
   message?: string;
-  data?: any;
+  data?: unknown;
   error?: string;
 }
 
@@ -147,8 +155,6 @@ export interface IGameSystem {
   update?(deltaTime: number): void;
   destroy?(): void;
   shutdown?(): Promise<void>;
-
-  // Optional properties for system configuration
   enabled?: boolean;
   priority?: number;
 }
@@ -171,7 +177,7 @@ export interface ICharacterController {
 // Network interfaces for multiplayer functionality
 export interface NetworkMessage {
   type: string;
-  data: any;
+  data: unknown;
   sender?: UUID;
   recipients?: UUID[];
   timestamp: number;
@@ -184,15 +190,11 @@ export interface NetworkHandler {
   broadcast(message: NetworkMessage): Promise<void>;
 }
 
-// Re-export ChatMessage for use in plugin
-// export type { ChatMessage } from '@hyperscape/shared'
-
-// Re-export core types and classes for convenience
-// World and System are classes from @hyperscape/shared
-export { World, System } from "./core-types.js";
-// Entity is a type alias
-export type { Entity } from "./core-types.js";
+// Re-export types for convenience
 export type {
+  World,
+  Entity,
+  System,
   Player,
   Vector3,
   Quaternion,
@@ -203,6 +205,4 @@ export type {
   WorldOptions,
   Position,
   ContentInstance,
-} from "./core-types.js";
-
-// Note: HyperscapeAction and HyperscapeProvider are already exported above in this file
+};

--- a/packages/plugin-hyperscape/src/types/core-types.ts
+++ b/packages/plugin-hyperscape/src/types/core-types.ts
@@ -1,28 +1,147 @@
 // Core types for plugin-hyperscape - imports from @hyperscape/shared and @elizaos/core
 import { Action, IAgentRuntime, Provider, Service, UUID } from "@elizaos/core";
-
-// Import classes and types from hyperscape package
-import { System, World } from "@hyperscape/shared";
-
 import type {
-  Component,
-  Events as BaseEvents,
-  Physics as BasePhysics,
-  Quaternion,
-  Vector3,
-  WorldOptions,
+  Vector3 as THREEVector3,
+  Quaternion as THREEQuaternion,
+  Object3D as THREEObject3D,
+} from "three";
+
+// Import classes from hyperscape (these are values)
+import {
+  SystemClass,
+  World as WorldClass,
+  Entity as EntityClass,
+  Entities as EntitiesClass,
+  EventBus,
+  THREE,
 } from "@hyperscape/shared";
 
-// Import Entity and Entities from the main package but alias them to avoid conflicts
-import type {
-  Entity as HyperscapeEntity,
-  Entities as HyperscapeEntities,
-} from "@hyperscape/shared";
+// Define local type aliases for THREE types
+export type Vector3 = THREEVector3;
+export type Quaternion = THREEQuaternion;
+export type Object3D = THREEObject3D;
 
-// Import additional types that may not be in the built package
-import type { PlayerInput, PlayerStats } from "@hyperscape/shared";
+// Define World type as instance type of WorldClass
+export type World = InstanceType<typeof WorldClass>;
 
-// Define missing types locally
+// Define System type based on SystemClass
+export type System = InstanceType<typeof SystemClass>;
+
+// Define Entity interface locally
+export interface Entity {
+  id: string;
+  type: string;
+  data?: Record<string, unknown>;
+  node: {
+    position: Vector3;
+    quaternion: Quaternion;
+    visible?: boolean;
+    children?: unknown[];
+    parent?: unknown | null;
+  };
+  base?: {
+    position: Vector3;
+    visible?: boolean;
+    children?: unknown[];
+    parent?: unknown | null;
+  };
+  velocity?: Vector3;
+  speed?: number;
+  isMoving?: boolean;
+  targetPosition?: Vector3;
+  movementPath?: Vector3[];
+}
+
+// Define Entities interface
+export interface Entities {
+  player?: Entity;
+  players?: Map<string, Entity>;
+  items?: Map<string, Entity>;
+  get(id: string): Entity | null;
+  add(data: EntityData, local?: boolean): Entity;
+  remove(id: string): boolean;
+  getAll(): Entity[];
+  getAllPlayers(): Entity[];
+}
+
+// Define EntityData interface
+export interface EntityData {
+  id?: string;
+  type: string;
+  position?: { x: number; y: number; z: number };
+  rotation?: { x: number; y: number; z: number; w: number };
+  [key: string]: unknown;
+}
+
+// Define Component interface
+export interface Component {
+  type: string;
+  data?: Record<string, unknown>;
+}
+
+// Define Events type
+export type Events = typeof EventBus;
+
+// Define WorldOptions interface locally
+export interface WorldOptions {
+  storage?: unknown;
+  assetsDir?: string;
+  assetsUrl?: string;
+  physics?: boolean;
+  renderer?: "webgpu" | "headless";
+  networkRate?: number;
+  maxDeltaTime?: number;
+  fixedDeltaTime?: number;
+  db?: unknown;
+  wsUrl?: string;
+  name?: string;
+  avatar?: string;
+}
+
+// Define PlayerInput interface locally
+export interface PlayerInput {
+  movement: Vector3;
+  rotation: Quaternion;
+  actions: Set<string>;
+  mouse: { x: number; y: number };
+}
+
+// Define PlayerStats interface locally
+export interface PlayerStats {
+  health: number;
+  maxHealth: number;
+  mana?: number;
+  maxMana?: number;
+  stamina?: number;
+  maxStamina?: number;
+  level?: number;
+  experience?: number;
+  [key: string]: unknown;
+}
+
+// Define Player interface locally
+export interface Player extends Entity {
+  username?: string;
+  input?: PlayerInput;
+  stats?: PlayerStats;
+  health?: {
+    current: number;
+    max: number;
+  };
+  inventory?: unknown;
+  equipment?: unknown;
+  position?: Vector3;
+  avatarUrl?: string;
+  walkToward?: (
+    targetPosition: { x: number; y?: number; z: number },
+    speed?: number,
+  ) => Position;
+  walk?: (direction: { x: number; z: number }, speed?: number) => Position;
+  teleport?: (options: { position?: Position; rotationY?: number }) => void;
+  modify?: (data: { name?: string; [key: string]: unknown }) => void;
+}
+
+// Define RigidBody interface
 export interface RigidBody {
   type: "static" | "dynamic" | "kinematic";
   mass: number;
@@ -46,8 +165,6 @@ export interface ChatListener {
   (messages: ChatMessage[]): void;
 }
 
-// Remove duplicate definitions - these are defined in other type files
-
 // Define ChatMessage interface locally since it's not exported from the built package
 export interface ChatMessage {
   id: string;
@@ -67,42 +184,15 @@ export interface ChatMessage {
   playerName?: string;
 }
 
-// Re-export hyperscape classes and types for plugin use
-export { System, World };
-export type {
-  Component,
-  BaseEvents as Events,
-  Quaternion,
-  Vector3,
-  WorldOptions,
-  PlayerInput,
-  PlayerStats,
-};
-
-// Re-export the aliased Entity type
-export type Entity = HyperscapeEntity & {
-  base?: {
-    position: Vector3;
-    visible?: boolean;
-    children?: unknown[];
-    parent?: unknown | null;
-  };
-};
-
-// Re-export the aliased Entities type
-export type Entities = HyperscapeEntities;
-
-// Plugin-specific Physics interface - don't extend BasePhysics to avoid conflicts
-export interface ExtendedPhysics {
+// Plugin-specific Physics interface
+export interface Physics {
   enabled: boolean;
   gravity: Vector3;
   timeStep: number;
   substeps?: number;
   world?: unknown | null;
   controllers: Map<string, CharacterController>;
-  rigidBodies: Map<string, any>;
-
-  // Physics methods from BasePhysics
+  rigidBodies: Map<string, unknown>;
   createRigidBody: (
     type: "static" | "dynamic" | "kinematic",
     position?: Vector3,
@@ -140,28 +230,8 @@ export interface ExtendedPhysics {
     layerMask?: number,
   ) => unknown | null;
   simulate: (deltaTime: number) => void;
-
-  // Additional methods
   step?: (deltaTime: number) => void;
 }
-
-// Use the extended physics type
-export type Physics = ExtendedPhysics;
-
-// Extended Player type with movement methods for plugin use
-export type Player = import("@hyperscape/shared").Player & {
-  // Movement methods for AI agent control
-  walkToward?: (
-    targetPosition: { x: number; y?: number; z: number },
-    speed?: number,
-  ) => Position;
-  walk?: (direction: { x: number; z: number }, speed?: number) => Position;
-  teleport?: (options: { position?: Position; rotationY?: number }) => void;
-  modify?: (data: { name?: string; [key: string]: unknown }) => void;
-};
-
-// Note: HyperscapeAction and HyperscapeProvider are in core-interfaces.ts
-// Import them directly from there to avoid circular dependencies
 
 // Position type (alias for Vector3 for backwards compatibility)
 export type Position = Vector3;
@@ -206,7 +276,6 @@ export interface EventSystem {
   emit: (eventName: string, data?: unknown) => void;
   on: (eventName: string, callback: (data: unknown) => void) => void;
   off: (eventName: string, callback?: (data: unknown) => void) => void;
-  // Additional array-like methods used in the service
   push?: (callback: (data: unknown) => void) => void;
   indexOf?: (callback: (data: unknown) => void) => number;
   splice?: (index: number, count: number) => void;
@@ -219,13 +288,6 @@ export interface WorldConfig extends WorldOptions {
   ui?: HTMLElement | MockElement;
   initialAuthToken?: string;
   loadPhysX?: () => Promise<unknown>;
-  name?: string;
-  avatar?: string;
-  // Explicitly include properties from WorldOptions for TypeScript resolution
-  wsUrl?: string;
-  physics?: boolean;
-  assetsUrl?: string;
-  networkRate?: number;
 }
 
 export interface MockElement {
@@ -347,7 +409,7 @@ export interface ServiceError extends Error {
   details?: unknown;
 }
 
-// Model type enum (from core-interfaces.ts)
+// Model type enum
 export enum ModelType {
   SMALL = "small",
   MEDIUM = "medium",
@@ -375,14 +437,12 @@ export interface CharacterController {
   getVelocity: () => Position;
 }
 
-// CharacterControllerOptions is defined in content-types.ts
-
 // Control and InputState types for plugin compatibility
 export interface Control {
   id: string;
   playerId: string;
   enabled: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface InputState {
@@ -400,3 +460,6 @@ export interface BaseObject {
 export interface AppearanceComponent extends Component {
   type: "appearance";
 }
+
+// Re-export the THREE namespace and classes for convenience
+export { THREE, WorldClass, EntityClass, EntitiesClass, SystemClass, EventBus };

--- a/packages/plugin-hyperscape/src/types/core.ts
+++ b/packages/plugin-hyperscape/src/types/core.ts
@@ -1,8 +1,6 @@
-// Re-export core types and classes for convenience
-// World and System are classes from @hyperscape/shared
-export { World, System } from "./core-types";
-// Entity is a type alias
-export type { Entity } from "./core-types";
+// Re-export core types for convenience
+// World and System are type aliases in core-types
+export type { World, System, Entity } from "./core-types";
 export type {
   Player,
   Vector3,

--- a/packages/plugin-hyperscape/src/types/external-libs.ts
+++ b/packages/plugin-hyperscape/src/types/external-libs.ts
@@ -1,23 +1,51 @@
-import {
-  THREE,
-  type PxVec3,
-  type PxTransform,
-  type PxQuat,
-} from "@hyperscape/shared";
+// Import THREE types directly from 'three' package
+import type {
+  Vector3,
+  Quaternion,
+  Matrix4,
+  Object3D,
+  Group,
+  Camera,
+  AnimationClip,
+  AnimationAction,
+  AnimationMixer as THREEAnimationMixer,
+  AnimationObjectGroup,
+  ShaderMaterial as THREEShaderMaterial,
+  Uniform,
+} from "three";
+
+// PhysX types defined locally since they may not be exported from shared
+export interface PxVec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface PxQuat {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+export interface PxTransform {
+  p: PxVec3;
+  q: PxQuat;
+}
 
 // THREE.js Extensions
-export interface EnhancedVector3 extends THREE.Vector3 {
+export interface EnhancedVector3 extends Vector3 {
   fromPxVec3(pxVec3: PxVec3): this;
   toPxVec3(pxVec3?: PxVec3): PxVec3;
   toPxExtVec3(pxExtVec3?: PxVec3): PxVec3;
   toPxTransform(pxTransform: PxTransform): void;
 }
 
-export interface EnhancedQuaternion extends THREE.Quaternion {
+export interface EnhancedQuaternion extends Quaternion {
   toPxTransform(pxTransform: PxTransform): void;
 }
 
-export interface EnhancedMatrix4 extends THREE.Matrix4 {
+export interface EnhancedMatrix4 extends Matrix4 {
   toPxTransform(pxTransform: PxTransform): void;
 }
 
@@ -88,14 +116,6 @@ export interface PHYSX {
   };
 }
 
-declare global {
-  namespace THREE {
-    interface Vector3 extends EnhancedVector3 {}
-    interface Quaternion extends EnhancedQuaternion {}
-    interface Matrix4 extends EnhancedMatrix4 {}
-  }
-}
-
 // D3.js types for curve manager
 export interface D3Selection<T = Element> {
   data<D>(data: D[], key?: (d: D) => string | number): D3Selection<T>;
@@ -115,10 +135,10 @@ export interface D3Selection<T = Element> {
 
 // GLTFLoader types
 export interface GLTFResult {
-  scene: THREE.Group;
-  scenes: THREE.Group[];
-  animations: THREE.AnimationClip[];
-  cameras: THREE.Camera[];
+  scene: Group;
+  scenes: Group[];
+  animations: AnimationClip[];
+  cameras: Camera[];
   asset: {
     generator?: string;
     version?: string;
@@ -159,25 +179,25 @@ export interface GLTFLoader {
 
 // Animation Mixer types
 export interface AnimationMixer
-  extends Omit<THREE.AnimationMixer, "existingAction"> {
+  extends Omit<THREEAnimationMixer, "existingAction"> {
   existingAction?:
-    | THREE.AnimationAction
+    | AnimationAction
     | ((
-        clip: THREE.AnimationClip,
-        root?: THREE.Object3D | THREE.AnimationObjectGroup,
-      ) => THREE.AnimationAction);
+        clip: AnimationClip,
+        root?: Object3D | AnimationObjectGroup,
+      ) => AnimationAction);
 }
 
 // Material shader compilation types (legacy - TSL node materials are preferred)
 export interface ShaderMaterial
-  extends Omit<THREE.ShaderMaterial, "onBeforeCompile"> {
+  extends Omit<THREEShaderMaterial, "onBeforeCompile"> {
   onBeforeCompile?: (shader: ShaderCompileParameters) => void;
 }
 
 export interface ShaderCompileParameters {
   vertexShader: string;
   fragmentShader: string;
-  uniforms: { [key: string]: THREE.Uniform };
+  uniforms: { [key: string]: Uniform };
 }
 
 export {};

--- a/packages/plugin-hyperscape/src/types/hyperscape-types.ts
+++ b/packages/plugin-hyperscape/src/types/hyperscape-types.ts
@@ -1,12 +1,14 @@
 // Hyperscape-specific types and interfaces
-import { World, Entity, System } from "./core-types";
 import type {
+  World,
+  Entity,
+  System,
   Player,
   Vector3,
   Quaternion,
   Component,
   WorldOptions,
-} from "@hyperscape/shared";
+} from "./core-types";
 
 import type { UUID } from "@elizaos/core";
 
@@ -20,9 +22,9 @@ export interface MockWorldConfig {
   persistence?: boolean;
   assets?: string[];
   environment?: {
-    lighting?: any;
+    lighting?: unknown;
     skybox?: string;
-    terrain?: any;
+    terrain?: unknown;
   };
 }
 
@@ -47,7 +49,7 @@ export interface AgentSpawnConfig {
   rotation?: Quaternion;
   avatar?: string;
   permissions?: string[];
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 // World event types
@@ -62,7 +64,7 @@ export interface WorldEvent {
   worldId: string;
   entityId?: string;
   playerId?: UUID;
-  data?: any;
+  data?: unknown;
   timestamp: number;
 }
 
@@ -161,13 +163,13 @@ export interface EntityTemplate {
   position?: Vector3;
   rotation?: Quaternion;
   scale?: Vector3;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 // Component template
 export interface ComponentTemplate {
   type: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
 }
 
 // Agent behavior configuration
@@ -175,14 +177,14 @@ export interface AgentBehaviorConfig {
   agentId: UUID;
   behaviors: BehaviorTemplate[];
   priorities: Record<string, number>;
-  conditions: Record<string, any>;
+  conditions: Record<string, unknown>;
 }
 
 // Behavior template
 export interface BehaviorTemplate {
   name: string;
   type: "movement" | "interaction" | "communication" | "combat" | "idle";
-  config: Record<string, any>;
+  config: Record<string, unknown>;
   triggers: string[];
   cooldown?: number;
 }

--- a/packages/plugin-hyperscape/src/types/system-types.ts
+++ b/packages/plugin-hyperscape/src/types/system-types.ts
@@ -2,9 +2,13 @@
  * Specific system types for Hyperscape plugin
  */
 
-import { THREE } from "@hyperscape/shared";
-import { System } from "./core-types";
-import type { ClientInput } from "@hyperscape/shared";
+import type { System } from "./core-types";
+
+// ClientInput interface defined locally
+interface ClientInput {
+  // Standard input properties
+  enabled: boolean;
+}
 
 // Client Input system interface with agent control methods
 // ClientInput now provides both hardware input and programmatic agent control
@@ -21,9 +25,14 @@ export interface ClientInputSystem extends System {
 
 // Type guard for ClientInput with agent methods
 export function isClientInputSystem(
-  system: System,
+  system: unknown,
 ): system is ClientInputSystem {
-  return system.constructor.name === "ClientInput" && "goto" in system;
+  return (
+    system !== null &&
+    typeof system === "object" &&
+    system.constructor.name === "ClientInput" &&
+    "goto" in system
+  );
 }
 
 // Backward compatibility alias (deprecated, use ClientInputSystem)

--- a/packages/plugin-hyperscape/src/types/test-mocks.ts
+++ b/packages/plugin-hyperscape/src/types/test-mocks.ts
@@ -7,8 +7,7 @@ import {
   State,
   Character,
 } from "@elizaos/core";
-import { Entity, World } from "./core-types";
-import type { Player } from "@hyperscape/shared";
+import type { Entity, World, Player } from "./core-types";
 
 // Real test configuration interface
 export interface TestRuntimeConfig {
@@ -83,6 +82,8 @@ export function createMockWorld(overrides: Partial<World> = {}): World {
       getPlayer: vi.fn(),
       getLocalPlayer: vi.fn(),
       getPlayers: vi.fn(() => []),
+      getAll: vi.fn(() => []),
+      getAllPlayers: vi.fn(() => []),
     },
 
     events: {
@@ -116,12 +117,8 @@ export function createMockWorld(overrides: Partial<World> = {}): World {
     }),
 
     // Server/client detection
-    get isServer() {
-      return mockWorld.network.isServer || false;
-    },
-    get isClient() {
-      return mockWorld.network.isClient || true;
-    },
+    isServer: false,
+    isClient: true,
 
     // EventEmitter methods
     emit: vi.fn(),
@@ -136,29 +133,33 @@ export function createMockWorld(overrides: Partial<World> = {}): World {
 }
 
 // Create real player instance for testing
-export function createMockPlayer(config = {}): Player {
+export function createMockPlayer(config: Partial<Player> = {}): Player {
   return {
     id: "player-1",
+    type: "player",
     data: {
       id: "player-1",
       name: "Test Player",
     },
-    isPlayer: true,
-    type: "player",
-    position: { x: 0, y: 0, z: 0 },
+    node: {
+      position: { x: 0, y: 0, z: 0 } as Player["node"]["position"],
+      quaternion: { x: 0, y: 0, z: 0, w: 1 } as Player["node"]["quaternion"],
+    },
     ...config,
   } as Player;
 }
 
 // Create real entity instance for testing
-export function createMockEntity(config = {}): Entity {
+export function createMockEntity(config: Partial<Entity> = {}): Entity {
   return {
     id: generateTestUUID(),
-    name: "Test Entity",
     type: "entity",
-    isPlayer: false,
     data: {
       name: "Test Entity",
+    },
+    node: {
+      position: { x: 0, y: 0, z: 0 } as Entity["node"]["position"],
+      quaternion: { x: 0, y: 0, z: 0, w: 1 } as Entity["node"]["quaternion"],
     },
     ...config,
   } as Entity;


### PR DESCRIPTION
…imports

## Problem
The @hyperscape/plugin-hyperscape package was failing to build with 70 TypeScript errors related to type imports from @hyperscape/shared. The main issues were:

1. Types like Player, Vector3, Quaternion, WorldOptions, PlayerInput, Events were not being properly exported from the built @hyperscape/shared package
2. THREE namespace usage (THREE.Vector3, THREE.Object3D) didn't work because THREE is exported as a default value, not as a namespace with type members
3. World, System, Entity are class values that were being used as types without proper handling for isolatedModules

## Solution
- Define core types (World, Entity, System, Player, etc.) locally in core-types.ts instead of importing from @hyperscape/shared
- Import THREE types directly from 'three' package (Vector3, Quaternion, Object3D, etc.)
- Define PhysX types (PxVec3, PxTransform, PxQuat) locally in external-libs.ts
- Use 'export type' instead of 'export' for type re-exports to satisfy isolatedModules
- Update all system files (avatar.ts, actions.ts, liveKit.ts, PlayerMovementSystem.ts) to use the new local type definitions

## Files Changed
- src/types/core-types.ts - Complete rewrite with local type definitions
- src/types/core-interfaces.ts - Import types from local core-types
- src/types/external-libs.ts - Import from 'three' directly, define PhysX types locally
- src/types/core.ts - Use 'export type' for re-exports
- src/types/hyperscape-types.ts - Import from local core-types
- src/types/system-types.ts - Use local System type
- src/types/test-mocks.ts - Import from local core-types
- src/systems/avatar.ts - Import THREE types directly
- src/systems/actions.ts - Import from 'three' and local types
- src/systems/liveKit.ts - Use local World type and System base class
- src/systems/PlayerMovementSystem.ts - Use local types