### PR TITLE
feat(steam-deck): add gamepad input system and Steam Deck support

### DIFF
--- a/packages/app/src-tauri/src/lib.rs
+++ b/packages/app/src-tauri/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Core application logic for both desktop and mobile platforms.
 //! Uses Tauri v2 for native windowing and system integration.
+//! Includes Steam Deck optimizations for fullscreen gaming.
 
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, LogicalSize, PhysicalSize};
 
 /// Initialize and configure all Tauri plugins
 fn setup_plugins(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {
@@ -60,19 +61,50 @@ fn setup_deep_link_handler(app: &AppHandle) {
     }
 }
 
+/// Check if we should run in Steam Deck mode
+fn should_use_steam_deck_mode() -> bool {
+    std::env::var("SteamOS").is_ok()
+        || std::env::var("SteamDeck").is_ok()
+        || std::env::var("STEAM_DECK").is_ok()
+        || std::env::var("SteamGamepadUI").is_ok()
+        || is_steam_deck_hardware()
+}
+
 /// Application setup hook - runs after window creation
 fn setup(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     // Configure deep link handler for OAuth
     setup_deep_link_handler(app);
     
     // Log platform info
-    log::info!("Hyperscape starting on {} {}", 
+    let is_steam_deck = should_use_steam_deck_mode();
+    log::info!("Hyperscape starting on {} {} (Steam Deck: {})", 
         std::env::consts::OS, 
-        std::env::consts::ARCH
+        std::env::consts::ARCH,
+        is_steam_deck
     );
 
-    // Log WebGPU status from the webview
+    // Configure window for Steam Deck
     if let Some(window) = app.get_webview_window("main") {
+        if is_steam_deck {
+            log::info!("[Hyperscape] Configuring for Steam Deck mode");
+            
+            // Steam Deck native resolution: 1280x800
+            let _ = window.set_size(LogicalSize::new(1280, 800));
+            
+            // Fullscreen for Game Mode, borderless for better UX
+            let _ = window.set_fullscreen(true);
+            let _ = window.set_decorations(false);
+            
+            // Disable cursor in Game Mode (Steam handles virtual cursor)
+            let _ = window.eval(r#"
+                document.body.style.cursor = 'none';
+                document.documentElement.classList.add('steam-deck-mode');
+                document.documentElement.classList.add('gamepad-mode');
+                console.log('[Hyperscape] Steam Deck mode enabled');
+            "#);
+        }
+
+        // Log WebGPU status from the webview
         let _ = window.eval(r#"
             (async () => {
                 if (navigator.gpu) {
@@ -92,15 +124,50 @@ fn setup(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Tauri command: Check WebGPU availability message
-/// Called from frontend to show appropriate error if WebGPU unavailable
+/// Tauri command: Get platform information including Steam Deck detection
+/// Called from frontend to detect platform and apply appropriate settings
 #[tauri::command]
 fn get_platform_info() -> serde_json::Value {
+    // Detect Steam Deck via environment variables set by SteamOS
+    let is_steam_deck = std::env::var("SteamOS").is_ok()
+        || std::env::var("SteamDeck").is_ok()
+        || std::env::var("STEAM_DECK").is_ok()
+        || is_steam_deck_hardware();
+
+    // Detect if running in Steam Game Mode
+    let is_steam_game_mode = std::env::var("SteamGamepadUI").is_ok()
+        || std::env::var("STEAM_RUNTIME").is_ok();
+
     serde_json::json!({
         "os": std::env::consts::OS,
         "arch": std::env::consts::ARCH,
         "family": std::env::consts::FAMILY,
+        "isSteamDeck": is_steam_deck,
+        "isSteamGameMode": is_steam_game_mode,
     })
+}
+
+/// Check if running on Steam Deck hardware by checking for AMD APU characteristics
+fn is_steam_deck_hardware() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        // Check for Steam Deck's specific CPU model in /proc/cpuinfo
+        if let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo") {
+            // Steam Deck uses AMD Custom APU 0405 (Van Gogh)
+            if cpuinfo.contains("AMD Custom APU 0405") {
+                return true;
+            }
+        }
+
+        // Check DMI product name
+        if let Ok(product_name) = std::fs::read_to_string("/sys/class/dmi/id/product_name") {
+            if product_name.trim().contains("Jupiter") || product_name.trim().contains("Galileo") {
+                return true; // Steam Deck LCD or OLED
+            }
+        }
+    }
+
+    false
 }
 
 /// Tauri command: Open external URL in system browser

--- a/packages/app/steam/controller_config.vdf
+++ b/packages/app/steam/controller_config.vdf
@@ -1,0 +1,542 @@
+"controller_mappings"
+{
+    "version"       "3"
+    "title"         "Hyperscape - Default Configuration"
+    "description"   "MMORPG controls for Steam Deck and Xbox controllers"
+    "creator"       "HyperscapeAI"
+    
+    "actions"
+    {
+        "Menu"
+        {
+            "title"         "#Menu"
+            "StickPadGyro"
+            {
+                "Move"
+                {
+                    "title"         "#Menu_Move"
+                    "input_mode"    "joystick_move"
+                }
+            }
+            "Button"
+            {
+                "menu_select"
+                {
+                    "title"         "#Menu_Select"
+                    "input_mode"    "button"
+                }
+                "menu_cancel"
+                {
+                    "title"         "#Menu_Cancel"
+                    "input_mode"    "button"
+                }
+                "menu_up"
+                {
+                    "title"         "#Menu_Up"
+                    "input_mode"    "button"
+                }
+                "menu_down"
+                {
+                    "title"         "#Menu_Down"
+                    "input_mode"    "button"
+                }
+                "menu_left"
+                {
+                    "title"         "#Menu_Left"
+                    "input_mode"    "button"
+                }
+                "menu_right"
+                {
+                    "title"         "#Menu_Right"
+                    "input_mode"    "button"
+                }
+            }
+        }
+        "InGame"
+        {
+            "title"         "#InGame"
+            "StickPadGyro"
+            {
+                "Move"
+                {
+                    "title"         "#InGame_Move"
+                    "input_mode"    "joystick_move"
+                }
+                "Camera"
+                {
+                    "title"         "#InGame_Camera"
+                    "input_mode"    "joystick_camera"
+                }
+            }
+            "Button"
+            {
+                "interact"
+                {
+                    "title"         "#InGame_Interact"
+                    "input_mode"    "button"
+                }
+                "attack"
+                {
+                    "title"         "#InGame_Attack"
+                    "input_mode"    "button"
+                }
+                "special_attack"
+                {
+                    "title"         "#InGame_SpecialAttack"
+                    "input_mode"    "button"
+                }
+                "cancel"
+                {
+                    "title"         "#InGame_Cancel"
+                    "input_mode"    "button"
+                }
+                "inventory"
+                {
+                    "title"         "#InGame_Inventory"
+                    "input_mode"    "button"
+                }
+                "equipment"
+                {
+                    "title"         "#InGame_Equipment"
+                    "input_mode"    "button"
+                }
+                "skills"
+                {
+                    "title"         "#InGame_Skills"
+                    "input_mode"    "button"
+                }
+                "prayer"
+                {
+                    "title"         "#InGame_Prayer"
+                    "input_mode"    "button"
+                }
+                "menu"
+                {
+                    "title"         "#InGame_Menu"
+                    "input_mode"    "button"
+                }
+                "run_toggle"
+                {
+                    "title"         "#InGame_RunToggle"
+                    "input_mode"    "button"
+                }
+                "zoom_in"
+                {
+                    "title"         "#InGame_ZoomIn"
+                    "input_mode"    "trigger"
+                }
+                "zoom_out"
+                {
+                    "title"         "#InGame_ZoomOut"
+                    "input_mode"    "trigger"
+                }
+                "cycle_target_left"
+                {
+                    "title"         "#InGame_CycleTargetLeft"
+                    "input_mode"    "button"
+                }
+                "cycle_target_right"
+                {
+                    "title"         "#InGame_CycleTargetRight"
+                    "input_mode"    "button"
+                }
+                "hotbar_1"
+                {
+                    "title"         "#InGame_Hotbar1"
+                    "input_mode"    "button"
+                }
+                "hotbar_2"
+                {
+                    "title"         "#InGame_Hotbar2"
+                    "input_mode"    "button"
+                }
+                "hotbar_3"
+                {
+                    "title"         "#InGame_Hotbar3"
+                    "input_mode"    "button"
+                }
+                "hotbar_4"
+                {
+                    "title"         "#InGame_Hotbar4"
+                    "input_mode"    "button"
+                }
+            }
+            "AnalogTrigger"
+            {
+                "zoom"
+                {
+                    "title"         "#InGame_Zoom"
+                    "input_mode"    "trigger"
+                }
+            }
+        }
+    }
+    
+    "action_layers"
+    {
+    }
+    
+    "localization"
+    {
+        "english"
+        {
+            "title"                     "Hyperscape - Default Configuration"
+            
+            "#Menu"                     "Menu"
+            "#Menu_Move"                "Navigate Menu"
+            "#Menu_Select"              "Select"
+            "#Menu_Cancel"              "Back"
+            "#Menu_Up"                  "Up"
+            "#Menu_Down"                "Down"
+            "#Menu_Left"                "Left"
+            "#Menu_Right"               "Right"
+            
+            "#InGame"                   "In Game"
+            "#InGame_Move"              "Move Character"
+            "#InGame_Camera"            "Camera Control"
+            "#InGame_Interact"          "Interact / Confirm"
+            "#InGame_Attack"            "Attack"
+            "#InGame_SpecialAttack"     "Special Attack"
+            "#InGame_Cancel"            "Cancel / Back"
+            "#InGame_Inventory"         "Open Inventory"
+            "#InGame_Equipment"         "Open Equipment"
+            "#InGame_Skills"            "Open Skills"
+            "#InGame_Prayer"            "Open Prayer"
+            "#InGame_Menu"              "Open Menu"
+            "#InGame_RunToggle"         "Toggle Run"
+            "#InGame_ZoomIn"            "Zoom In"
+            "#InGame_ZoomOut"           "Zoom Out"
+            "#InGame_CycleTargetLeft"   "Previous Target"
+            "#InGame_CycleTargetRight"  "Next Target"
+            "#InGame_Hotbar1"           "Hotbar Slot 1"
+            "#InGame_Hotbar2"           "Hotbar Slot 2"
+            "#InGame_Hotbar3"           "Hotbar Slot 3"
+            "#InGame_Hotbar4"           "Hotbar Slot 4"
+            "#InGame_Zoom"              "Camera Zoom"
+        }
+    }
+    
+    "presets"
+    {
+        "id"        "0"
+        "name"      "Default"
+        "group_source_bindings"
+        {
+            "7"     "switch active"
+            "0"     "button_diamond active"
+            "3"     "left_trigger active"
+            "4"     "right_trigger active"
+            "1"     "left_bumper active"
+            "2"     "right_bumper active"
+            "11"    "dpad active"
+            "8"     "joystick active"
+            "9"     "right_joystick active"
+        }
+    }
+    
+    "group"
+    {
+        "id"        "0"
+        "mode"      "button_diamond"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "button_a"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame interact"
+                        }
+                    }
+                }
+            }
+            "button_b"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame cancel"
+                        }
+                    }
+                }
+            }
+            "button_x"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame attack"
+                        }
+                    }
+                }
+            }
+            "button_y"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame special_attack"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "group"
+    {
+        "id"        "1"
+        "mode"      "left_bumper"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "click"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame cycle_target_left"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "group"
+    {
+        "id"        "2"
+        "mode"      "right_bumper"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "click"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame cycle_target_right"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "group"
+    {
+        "id"        "3"
+        "mode"      "left_trigger"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "click"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame zoom_out"
+                        }
+                    }
+                }
+            }
+        }
+        "settings"
+        {
+            "output_trigger"        "1"
+        }
+    }
+    "group"
+    {
+        "id"        "4"
+        "mode"      "right_trigger"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "click"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame zoom_in"
+                        }
+                    }
+                }
+            }
+        }
+        "settings"
+        {
+            "output_trigger"        "2"
+        }
+    }
+    "group"
+    {
+        "id"        "7"
+        "mode"      "switch"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "button_escape"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame inventory"
+                        }
+                    }
+                }
+            }
+            "button_menu"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame menu"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    "group"
+    {
+        "id"        "8"
+        "mode"      "joystick_move"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "click"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame run_toggle"
+                        }
+                    }
+                }
+            }
+        }
+        "settings"
+        {
+            "output_joystick"       "0"
+        }
+    }
+    "group"
+    {
+        "id"        "9"
+        "mode"      "joystick_camera"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+        }
+        "settings"
+        {
+            "output_joystick"       "1"
+        }
+    }
+    "group"
+    {
+        "id"        "11"
+        "mode"      "dpad"
+        "name"      ""
+        "description"       ""
+        "inputs"
+        {
+            "dpad_north"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame equipment"
+                        }
+                    }
+                }
+            }
+            "dpad_south"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame prayer"
+                        }
+                    }
+                }
+            }
+            "dpad_east"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame hotbar_2"
+                        }
+                    }
+                }
+            }
+            "dpad_west"
+            {
+                "activators"
+                {
+                    "Full_Press"
+                    {
+                        "bindings"
+                        {
+                            "binding"       "game_action InGame skills"
+                        }
+                    }
+                }
+            }
+        }
+        "settings"
+        {
+            "requires_click"        "0"
+        }
+    }
+}

--- a/packages/client/src/components/GamepadButtonHint.tsx
+++ b/packages/client/src/components/GamepadButtonHint.tsx
@@ -1,0 +1,343 @@
+/**
+ * GamepadButtonHint.tsx - Controller Button Hint Components
+ *
+ * Displays gamepad button glyphs and action prompts for Steam Deck and controllers.
+ * Shows appropriate button hints based on connected controller type.
+ *
+ * @example
+ * ```tsx
+ * // Single button hint
+ * <GamepadButtonHint button="A" />
+ *
+ * // Button with label
+ * <GamepadButtonHint button="X" label="Attack" />
+ *
+ * // Action bar with multiple hints
+ * <GamepadActionBar actions={[
+ *   { button: 'A', label: 'Interact' },
+ *   { button: 'B', label: 'Cancel' },
+ * ]} />
+ * ```
+ */
+
+import React, { useEffect, useState } from "react";
+import { isGamepadConnected, getGamepadType } from "../lib/tauri-integration";
+
+/**
+ * Gamepad button names matching GamepadButton enum
+ */
+export type GamepadButtonName =
+  | "A"
+  | "B"
+  | "X"
+  | "Y"
+  | "LB"
+  | "RB"
+  | "LT"
+  | "RT"
+  | "SELECT"
+  | "START"
+  | "L3"
+  | "R3"
+  | "DPAD_UP"
+  | "DPAD_DOWN"
+  | "DPAD_LEFT"
+  | "DPAD_RIGHT";
+
+/**
+ * Button glyphs for different controller types
+ */
+const BUTTON_GLYPHS: Record<
+  string,
+  Record<GamepadButtonName, { glyph: string; className: string }>
+> = {
+  xbox: {
+    A: { glyph: "A", className: "button-a" },
+    B: { glyph: "B", className: "button-b" },
+    X: { glyph: "X", className: "button-x" },
+    Y: { glyph: "Y", className: "button-y" },
+    LB: { glyph: "LB", className: "button-lb" },
+    RB: { glyph: "RB", className: "button-rb" },
+    LT: { glyph: "LT", className: "button-lt" },
+    RT: { glyph: "RT", className: "button-rt" },
+    SELECT: { glyph: "⎚", className: "button-select" },
+    START: { glyph: "☰", className: "button-start" },
+    L3: { glyph: "L3", className: "button-lb" },
+    R3: { glyph: "R3", className: "button-rb" },
+    DPAD_UP: { glyph: "▲", className: "dpad" },
+    DPAD_DOWN: { glyph: "▼", className: "dpad" },
+    DPAD_LEFT: { glyph: "◀", className: "dpad" },
+    DPAD_RIGHT: { glyph: "▶", className: "dpad" },
+  },
+  playstation: {
+    A: { glyph: "✕", className: "button-a" },
+    B: { glyph: "○", className: "button-b" },
+    X: { glyph: "□", className: "button-x" },
+    Y: { glyph: "△", className: "button-y" },
+    LB: { glyph: "L1", className: "button-lb" },
+    RB: { glyph: "R1", className: "button-rb" },
+    LT: { glyph: "L2", className: "button-lt" },
+    RT: { glyph: "R2", className: "button-rt" },
+    SELECT: { glyph: "Share", className: "button-select" },
+    START: { glyph: "Options", className: "button-start" },
+    L3: { glyph: "L3", className: "button-lb" },
+    R3: { glyph: "R3", className: "button-rb" },
+    DPAD_UP: { glyph: "▲", className: "dpad" },
+    DPAD_DOWN: { glyph: "▼", className: "dpad" },
+    DPAD_LEFT: { glyph: "◀", className: "dpad" },
+    DPAD_RIGHT: { glyph: "▶", className: "dpad" },
+  },
+  nintendo: {
+    A: { glyph: "A", className: "button-b" }, // Nintendo A is on the right
+    B: { glyph: "B", className: "button-a" },
+    X: { glyph: "X", className: "button-y" },
+    Y: { glyph: "Y", className: "button-x" },
+    LB: { glyph: "L", className: "button-lb" },
+    RB: { glyph: "R", className: "button-rb" },
+    LT: { glyph: "ZL", className: "button-lt" },
+    RT: { glyph: "ZR", className: "button-rt" },
+    SELECT: { glyph: "-", className: "button-select" },
+    START: { glyph: "+", className: "button-start" },
+    L3: { glyph: "L", className: "button-lb" },
+    R3: { glyph: "R", className: "button-rb" },
+    DPAD_UP: { glyph: "▲", className: "dpad" },
+    DPAD_DOWN: { glyph: "▼", className: "dpad" },
+    DPAD_LEFT: { glyph: "◀", className: "dpad" },
+    DPAD_RIGHT: { glyph: "▶", className: "dpad" },
+  },
+  generic: {
+    A: { glyph: "1", className: "button-a" },
+    B: { glyph: "2", className: "button-b" },
+    X: { glyph: "3", className: "button-x" },
+    Y: { glyph: "4", className: "button-y" },
+    LB: { glyph: "L1", className: "button-lb" },
+    RB: { glyph: "R1", className: "button-rb" },
+    LT: { glyph: "L2", className: "button-lt" },
+    RT: { glyph: "R2", className: "button-rt" },
+    SELECT: { glyph: "Sel", className: "button-select" },
+    START: { glyph: "Str", className: "button-start" },
+    L3: { glyph: "L3", className: "button-lb" },
+    R3: { glyph: "R3", className: "button-rb" },
+    DPAD_UP: { glyph: "▲", className: "dpad" },
+    DPAD_DOWN: { glyph: "▼", className: "dpad" },
+    DPAD_LEFT: { glyph: "◀", className: "dpad" },
+    DPAD_RIGHT: { glyph: "▶", className: "dpad" },
+  },
+};
+
+/**
+ * Hook to track gamepad connection state
+ */
+export function useGamepadConnected(): boolean {
+  const [connected, setConnected] = useState(isGamepadConnected());
+
+  useEffect(() => {
+    const handleConnect = () => setConnected(true);
+    const handleDisconnect = () => {
+      // Check if any gamepads still connected
+      setConnected(isGamepadConnected());
+    };
+
+    window.addEventListener("gamepadconnected", handleConnect);
+    window.addEventListener("gamepaddisconnected", handleDisconnect);
+
+    return () => {
+      window.removeEventListener("gamepadconnected", handleConnect);
+      window.removeEventListener("gamepaddisconnected", handleDisconnect);
+    };
+  }, []);
+
+  return connected;
+}
+
+/**
+ * Hook to get the connected gamepad type
+ */
+export function useGamepadType():
+  | "xbox"
+  | "playstation"
+  | "nintendo"
+  | "generic" {
+  const [type, setType] = useState<
+    "xbox" | "playstation" | "nintendo" | "generic"
+  >(() => getGamepadType() || "xbox");
+
+  useEffect(() => {
+    const updateType = () => {
+      setType(getGamepadType() || "xbox");
+    };
+
+    window.addEventListener("gamepadconnected", updateType);
+    window.addEventListener("gamepaddisconnected", updateType);
+
+    return () => {
+      window.removeEventListener("gamepadconnected", updateType);
+      window.removeEventListener("gamepaddisconnected", updateType);
+    };
+  }, []);
+
+  return type;
+}
+
+/**
+ * Props for GamepadButtonHint component
+ */
+interface GamepadButtonHintProps {
+  /** Button to display */
+  button: GamepadButtonName;
+  /** Optional label to show next to button */
+  label?: string;
+  /** Additional CSS classes */
+  className?: string;
+  /** Force specific controller type (default: auto-detect) */
+  controllerType?: "xbox" | "playstation" | "nintendo" | "generic";
+}
+
+/**
+ * Single gamepad button hint with optional label
+ */
+export function GamepadButtonHint({
+  button,
+  label,
+  className = "",
+  controllerType,
+}: GamepadButtonHintProps): React.ReactElement | null {
+  const gamepadConnected = useGamepadConnected();
+  const detectedType = useGamepadType();
+  const type = controllerType || detectedType;
+
+  // Don't render if no gamepad connected and not forced
+  if (!gamepadConnected && !controllerType) {
+    return null;
+  }
+
+  const buttonInfo =
+    BUTTON_GLYPHS[type]?.[button] || BUTTON_GLYPHS.xbox[button];
+
+  if (label) {
+    return (
+      <span className={`controller-hint gamepad-hint ${className}`}>
+        <span className={`gamepad-button-glyph ${buttonInfo.className}`}>
+          {buttonInfo.glyph}
+        </span>
+        <span className="controller-hint-label">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`gamepad-button-glyph gamepad-hint ${buttonInfo.className} ${className}`}
+    >
+      {buttonInfo.glyph}
+    </span>
+  );
+}
+
+/**
+ * Props for GamepadActionBar component
+ */
+interface GamepadActionBarProps {
+  /** Actions to display */
+  actions: Array<{
+    button: GamepadButtonName;
+    label: string;
+  }>;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Action bar showing multiple button hints
+ * Typically displayed at bottom of screen
+ */
+export function GamepadActionBar({
+  actions,
+  className = "",
+}: GamepadActionBarProps): React.ReactElement | null {
+  const gamepadConnected = useGamepadConnected();
+
+  if (!gamepadConnected) {
+    return null;
+  }
+
+  return (
+    <div className={`gamepad-action-bar ${className}`}>
+      {actions.map((action) => (
+        <div key={action.button} className="action-item">
+          <GamepadButtonHint button={action.button} />
+          <span>{action.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Props for AdaptiveHint component
+ */
+interface AdaptiveHintProps {
+  /** Keyboard key to show when no gamepad */
+  keyboardKey: string;
+  /** Gamepad button to show when gamepad connected */
+  gamepadButton: GamepadButtonName;
+  /** Label for the action */
+  label?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Adaptive hint that shows keyboard or gamepad hint based on input device
+ */
+export function AdaptiveHint({
+  keyboardKey,
+  gamepadButton,
+  label,
+  className = "",
+}: AdaptiveHintProps): React.ReactElement {
+  const gamepadConnected = useGamepadConnected();
+
+  if (gamepadConnected) {
+    return (
+      <GamepadButtonHint
+        button={gamepadButton}
+        label={label}
+        className={className}
+      />
+    );
+  }
+
+  // Keyboard hint
+  return (
+    <span className={`controller-hint keyboard-hint ${className}`}>
+      <kbd className="px-2 py-1 bg-gray-700 rounded text-sm font-mono">
+        {keyboardKey}
+      </kbd>
+      {label && <span className="controller-hint-label ml-2">{label}</span>}
+    </span>
+  );
+}
+
+/**
+ * Common action hints for the game
+ */
+export const CommonHints = {
+  Interact: () => (
+    <AdaptiveHint keyboardKey="E" gamepadButton="A" label="Interact" />
+  ),
+  Cancel: () => (
+    <AdaptiveHint keyboardKey="Esc" gamepadButton="B" label="Cancel" />
+  ),
+  Attack: () => (
+    <AdaptiveHint keyboardKey="Space" gamepadButton="X" label="Attack" />
+  ),
+  Inventory: () => (
+    <AdaptiveHint keyboardKey="I" gamepadButton="SELECT" label="Inventory" />
+  ),
+  Menu: () => (
+    <AdaptiveHint keyboardKey="Esc" gamepadButton="START" label="Menu" />
+  ),
+};
+
+export default GamepadButtonHint;

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -16,3 +16,14 @@ export { MouseRightIcon } from "./MouseRightIcon";
 export { MouseWheelIcon } from "./MouseWheelIcon";
 export { CurvePane } from "./CurvePane";
 export { CurvePreview } from "./CurvePreview";
+
+// Gamepad / Steam Deck support
+export {
+  GamepadButtonHint,
+  GamepadActionBar,
+  AdaptiveHint,
+  CommonHints,
+  useGamepadConnected,
+  useGamepadType,
+} from "./GamepadButtonHint";
+export type { GamepadButtonName } from "./GamepadButtonHint";

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -99,3 +99,280 @@ div[data-privy-backdrop] {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background-color: rgba(242, 208, 138, 0.8);
 }
+
+/* ========================================
+   STEAM DECK / GAMEPAD MODE STYLES
+   ======================================== */
+
+/**
+ * Steam Deck Mode
+ * Applied when running on Steam Deck hardware
+ * Optimizes UI for 1280x800 resolution and controller input
+ */
+.steam-deck-mode {
+  /* Larger base font for 7" screen readability */
+  font-size: 18px !important;
+
+  /* Hide cursor in Game Mode (Steam handles virtual cursor) */
+  cursor: none !important;
+}
+
+.steam-deck-mode * {
+  /* Increase touch/focus targets */
+  min-height: 44px;
+}
+
+.steam-deck-mode button,
+.steam-deck-mode [role="button"],
+.steam-deck-mode a,
+.steam-deck-mode input,
+.steam-deck-mode select {
+  /* Steam Deck Verified requirement: 48px minimum touch targets */
+  min-height: 48px;
+  min-width: 48px;
+  padding: 12px 16px;
+}
+
+/**
+ * Gamepad Mode
+ * Applied when a gamepad is connected
+ * Shows controller button hints and adjusts focus styling
+ */
+.gamepad-mode {
+  /* Enhanced focus visibility for controller navigation */
+  --focus-ring-color: rgba(242, 208, 138, 0.8);
+  --focus-ring-width: 3px;
+}
+
+.gamepad-mode :focus,
+.gamepad-mode [data-focused="true"] {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color) !important;
+  outline-offset: 2px;
+}
+
+.gamepad-mode :focus:not(:focus-visible) {
+  outline: none !important;
+}
+
+.gamepad-mode :focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color) !important;
+  outline-offset: 2px;
+}
+
+/* Hide keyboard hints when gamepad connected */
+.gamepad-mode .keyboard-hint {
+  display: none !important;
+}
+
+/* Show gamepad hints when gamepad connected */
+.gamepad-hint {
+  display: none;
+}
+
+.gamepad-mode .gamepad-hint {
+  display: inline-flex !important;
+}
+
+/**
+ * Gamepad Button Glyph Styling
+ * Xbox/Steam Deck button icons for UI hints
+ */
+.gamepad-button-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 6px;
+  margin: 0 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(180deg, #4a4a4a 0%, #2a2a2a 100%);
+  border: 2px solid #5a5a5a;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* Face buttons (A, B, X, Y) */
+.gamepad-button-glyph.button-a {
+  background: linear-gradient(180deg, #4caf50 0%, #2e7d32 100%);
+  border-color: #66bb6a;
+}
+
+.gamepad-button-glyph.button-b {
+  background: linear-gradient(180deg, #f44336 0%, #c62828 100%);
+  border-color: #ef5350;
+}
+
+.gamepad-button-glyph.button-x {
+  background: linear-gradient(180deg, #2196f3 0%, #1565c0 100%);
+  border-color: #42a5f5;
+}
+
+.gamepad-button-glyph.button-y {
+  background: linear-gradient(180deg, #ffeb3b 0%, #f9a825 100%);
+  border-color: #ffee58;
+  color: #000000;
+  text-shadow: none;
+}
+
+/* Bumpers and Triggers */
+.gamepad-button-glyph.button-lb,
+.gamepad-button-glyph.button-rb,
+.gamepad-button-glyph.button-lt,
+.gamepad-button-glyph.button-rt {
+  background: linear-gradient(180deg, #616161 0%, #424242 100%);
+  border-color: #757575;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+/* D-Pad */
+.gamepad-button-glyph.dpad {
+  background: linear-gradient(180deg, #555555 0%, #333333 100%);
+  border-color: #666666;
+  font-size: 16px;
+}
+
+/* Start/Select */
+.gamepad-button-glyph.button-start,
+.gamepad-button-glyph.button-select {
+  background: linear-gradient(180deg, #424242 0%, #212121 100%);
+  border-color: #555555;
+  min-width: 24px;
+  height: 24px;
+  font-size: 12px;
+}
+
+/**
+ * Controller Hint Container
+ * Displays button prompt with label
+ */
+.controller-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 8px;
+  font-size: 14px;
+  color: #ffffff;
+}
+
+.controller-hint-label {
+  opacity: 0.8;
+}
+
+/**
+ * Quick Action Bar for Gamepad
+ * Shows available actions with button prompts
+ */
+.gamepad-action-bar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 16px;
+  padding: 12px 24px;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(242, 208, 138, 0.3);
+  border-radius: 12px;
+  z-index: 100;
+}
+
+.gamepad-action-bar .action-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ffffff;
+  font-size: 14px;
+}
+
+/* Hide action bar when no gamepad */
+.gamepad-action-bar {
+  display: none;
+}
+
+.gamepad-mode .gamepad-action-bar {
+  display: flex;
+}
+
+/**
+ * Virtual Joystick Overlay (Touch Fallback)
+ * For Steam Deck Desktop Mode or touch fallback
+ */
+.virtual-joystick {
+  position: fixed;
+  bottom: 80px;
+  left: 40px;
+  width: 120px;
+  height: 120px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  display: none;
+}
+
+.virtual-joystick-thumb {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50px;
+  height: 50px;
+  background: rgba(242, 208, 138, 0.8);
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+/* Show virtual joystick on touch devices without gamepad */
+@media (hover: none) and (pointer: coarse) {
+  .virtual-joystick:not(.gamepad-mode .virtual-joystick) {
+    display: block;
+  }
+}
+
+/**
+ * Resolution-specific adjustments for Steam Deck
+ * 1280x800 native, but also handle docked mode
+ */
+@media screen and (max-width: 1280px) and (max-height: 800px) {
+  .steam-deck-mode {
+    /* Compact UI spacing for smaller screen */
+    --ui-padding: 8px;
+    --ui-gap: 6px;
+  }
+
+  .steam-deck-mode .ui-panel {
+    padding: var(--ui-padding);
+    gap: var(--ui-gap);
+  }
+
+  /* Scale down large UI elements */
+  .steam-deck-mode .dialog,
+  .steam-deck-mode .modal {
+    max-width: 90vw;
+    max-height: 85vh;
+  }
+}
+
+/* Docked mode (external display) - restore normal sizing */
+@media screen and (min-width: 1920px) {
+  .steam-deck-mode {
+    font-size: 16px !important;
+  }
+
+  .steam-deck-mode button,
+  .steam-deck-mode [role="button"],
+  .steam-deck-mode a,
+  .steam-deck-mode input,
+  .steam-deck-mode select {
+    min-height: 40px;
+    min-width: 40px;
+    padding: 8px 12px;
+  }
+}

--- a/packages/client/src/lib/index.ts
+++ b/packages/client/src/lib/index.ts
@@ -7,3 +7,16 @@ export { windowManager } from "./responsiveWindowManager";
 export { ErrorBoundary } from "./ErrorBoundary";
 export * from "./error-reporting";
 export { injectFarcasterMetaTags } from "./farcaster-frame-config";
+export {
+  isTauriApp,
+  getPlatformInfo,
+  openExternalUrl,
+  onDeepLink,
+  parseOAuthCallback,
+  isSteamDeck,
+  isSteamGameMode,
+  isGamepadConnected,
+  getGamepadType,
+  clearPlatformInfoCache,
+} from "./tauri-integration";
+export type { PlatformInfo } from "./tauri-integration";

--- a/packages/client/src/lib/tauri-integration.ts
+++ b/packages/client/src/lib/tauri-integration.ts
@@ -77,6 +77,8 @@ export type PlatformInfo = {
   os: string;
   arch: string;
   family: string;
+  isSteamDeck?: boolean;
+  isSteamGameMode?: boolean;
 };
 
 /**
@@ -154,4 +156,130 @@ export function parseOAuthCallback(url: string): {
   } catch {
     return { code: null, state: null, error: "Invalid URL" };
   }
+}
+
+// ========================================
+// STEAM DECK DETECTION
+// ========================================
+
+// Cache platform info to avoid repeated IPC calls
+let cachedPlatformInfo: PlatformInfo | null = null;
+
+/**
+ * Check if running on Steam Deck
+ * Returns true if:
+ * - Running in Tauri with isSteamDeck flag
+ * - Running in browser with Steam Deck user agent hints
+ */
+export async function isSteamDeck(): Promise<boolean> {
+  // Check cached platform info first
+  if (cachedPlatformInfo?.isSteamDeck !== undefined) {
+    return cachedPlatformInfo.isSteamDeck;
+  }
+
+  // Try to get from Tauri
+  const platformInfo = await getPlatformInfo();
+  if (platformInfo) {
+    cachedPlatformInfo = platformInfo;
+    return platformInfo.isSteamDeck ?? false;
+  }
+
+  // Fallback: Check browser user agent for Linux + gamepad
+  if (typeof navigator !== "undefined") {
+    const isLinux = /Linux/.test(navigator.userAgent);
+    const hasGamepad =
+      "getGamepads" in navigator &&
+      navigator.getGamepads().some((gp) => gp !== null);
+
+    // Heuristic: Linux with gamepad connected is likely Steam Deck
+    // This is not 100% accurate but provides reasonable detection in browser
+    if (isLinux && hasGamepad) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if running in Steam Game Mode (Big Picture on Steam Deck)
+ */
+export async function isSteamGameMode(): Promise<boolean> {
+  if (cachedPlatformInfo?.isSteamGameMode !== undefined) {
+    return cachedPlatformInfo.isSteamGameMode;
+  }
+
+  const platformInfo = await getPlatformInfo();
+  if (platformInfo) {
+    cachedPlatformInfo = platformInfo;
+    return platformInfo.isSteamGameMode ?? false;
+  }
+
+  return false;
+}
+
+/**
+ * Clear the cached platform info (for testing)
+ */
+export function clearPlatformInfoCache(): void {
+  cachedPlatformInfo = null;
+}
+
+/**
+ * Detect if a gamepad is connected (useful for showing controller hints)
+ */
+export function isGamepadConnected(): boolean {
+  if (typeof navigator === "undefined" || !("getGamepads" in navigator)) {
+    return false;
+  }
+
+  const gamepads = navigator.getGamepads();
+  return gamepads.some((gp) => gp !== null);
+}
+
+/**
+ * Get the type of connected gamepad (for button glyph display)
+ */
+export function getGamepadType():
+  | "xbox"
+  | "playstation"
+  | "nintendo"
+  | "generic"
+  | null {
+  if (typeof navigator === "undefined" || !("getGamepads" in navigator)) {
+    return null;
+  }
+
+  const gamepads = navigator.getGamepads();
+  const gamepad = gamepads.find((gp) => gp !== null);
+
+  if (!gamepad) return null;
+
+  const id = gamepad.id.toLowerCase();
+
+  if (id.includes("xbox") || id.includes("microsoft")) {
+    return "xbox";
+  }
+  if (
+    id.includes("playstation") ||
+    id.includes("sony") ||
+    id.includes("dualshock") ||
+    id.includes("dualsense")
+  ) {
+    return "playstation";
+  }
+  if (
+    id.includes("nintendo") ||
+    id.includes("joy-con") ||
+    id.includes("pro controller")
+  ) {
+    return "nintendo";
+  }
+
+  // Steam Deck presents as Xbox controller
+  if (id.includes("steam") || id.includes("valve")) {
+    return "xbox";
+  }
+
+  return "generic";
 }

--- a/packages/shared/src/systems/client/ClientInput.ts
+++ b/packages/shared/src/systems/client/ClientInput.ts
@@ -115,6 +115,12 @@ import type {
   CustomPointerEvent,
 } from "../../types";
 import { InputButtons } from "../../types/network/networking";
+import {
+  GamepadInput,
+  GamepadButton,
+  type StickState,
+  type GameAction,
+} from "./GamepadInput";
 
 // Pre-allocated temp objects to avoid per-frame allocations
 const _v3_1 = new THREE.Vector3();
@@ -311,6 +317,10 @@ export class ClientInput extends SystemBase {
   private buttons = 0;
   private viewAngles = new THREE.Quaternion();
 
+  // Gamepad input system
+  private gamepadInput: GamepadInput | null = null;
+  private gamepadMoveVector = new THREE.Vector2();
+
   constructor(world: World) {
     super(world, {
       name: "client-input",
@@ -354,6 +364,9 @@ export class ClientInput extends SystemBase {
     window.addEventListener("resize", this.onResize);
     window.addEventListener("focus", this.onFocus);
     window.addEventListener("blur", this.onBlur);
+
+    // Initialize gamepad input system
+    this.initGamepad();
   }
 
   start() {
@@ -376,6 +389,9 @@ export class ClientInput extends SystemBase {
   }
 
   update(delta: number) {
+    // Update gamepad state (must be called every frame)
+    this.updateGamepad();
+
     // Update pointer state
     this.pointerState.update(
       this.screenHit,
@@ -1356,6 +1372,303 @@ export class ClientInput extends SystemBase {
     window.removeEventListener("resize", this.onResize);
     window.removeEventListener("focus", this.onFocus);
     window.removeEventListener("blur", this.onBlur);
+
+    // Clean up gamepad input
+    this.gamepadInput?.destroy();
+    this.gamepadInput = null;
+  }
+
+  // ========================================
+  // GAMEPAD INPUT METHODS
+  // ========================================
+
+  /**
+   * Initialize gamepad input system
+   */
+  private initGamepad(): void {
+    if (typeof navigator === "undefined" || !navigator.getGamepads) {
+      console.log("[ClientInput] Gamepad API not available");
+      return;
+    }
+
+    this.gamepadInput = new GamepadInput();
+
+    // Listen for gamepad events
+    this.gamepadInput.on("connected", (gamepad) => {
+      console.log(`[ClientInput] Gamepad connected: ${gamepad.id}`);
+      this.emit("gamepadConnected", { id: gamepad.id, index: gamepad.index });
+    });
+
+    this.gamepadInput.on("disconnected", (gamepad) => {
+      console.log(`[ClientInput] Gamepad disconnected: ${gamepad.id}`);
+      this.emit("gamepadDisconnected", {
+        id: gamepad.id,
+        index: gamepad.index,
+      });
+    });
+
+    // Map gamepad button events to control bindings
+    this.gamepadInput.on("buttonDown", (button, action) => {
+      this.handleGamepadButtonDown(button, action);
+    });
+
+    this.gamepadInput.on("buttonUp", (button, action) => {
+      this.handleGamepadButtonUp(button, action);
+    });
+  }
+
+  /**
+   * Update gamepad state - called every frame
+   */
+  private updateGamepad(): void {
+    if (!this.gamepadInput || !this._controlsEnabled) return;
+
+    // Poll gamepad state
+    this.gamepadInput.update();
+
+    // Update movement from left stick
+    const leftStick = this.gamepadInput.getLeftStick();
+    if (leftStick.x !== 0 || leftStick.y !== 0) {
+      this.gamepadMoveVector.set(leftStick.x, leftStick.y);
+
+      // Apply to movement buttons
+      if (leftStick.y < -0.3) {
+        this.buttons |= InputButtons.FORWARD;
+      } else {
+        this.buttons &= ~InputButtons.FORWARD;
+      }
+      if (leftStick.y > 0.3) {
+        this.buttons |= InputButtons.BACKWARD;
+      } else {
+        this.buttons &= ~InputButtons.BACKWARD;
+      }
+      if (leftStick.x < -0.3) {
+        this.buttons |= InputButtons.LEFT;
+      } else {
+        this.buttons &= ~InputButtons.LEFT;
+      }
+      if (leftStick.x > 0.3) {
+        this.buttons |= InputButtons.RIGHT;
+      } else {
+        this.buttons &= ~InputButtons.RIGHT;
+      }
+    } else {
+      // Clear movement if no gamepad input and no keyboard input
+      if (!this.buttonsDown.has("keyW") && !this.buttonsDown.has("arrowUp")) {
+        this.buttons &= ~InputButtons.FORWARD;
+      }
+      if (!this.buttonsDown.has("keyS") && !this.buttonsDown.has("arrowDown")) {
+        this.buttons &= ~InputButtons.BACKWARD;
+      }
+      if (!this.buttonsDown.has("keyA") && !this.buttonsDown.has("arrowLeft")) {
+        this.buttons &= ~InputButtons.LEFT;
+      }
+      if (
+        !this.buttonsDown.has("keyD") &&
+        !this.buttonsDown.has("arrowRight")
+      ) {
+        this.buttons &= ~InputButtons.RIGHT;
+      }
+    }
+
+    // Camera zoom from triggers
+    const triggers = this.gamepadInput.getTriggers();
+    if (triggers.left > 0.1 || triggers.right > 0.1) {
+      this.scroll.delta += (triggers.right - triggers.left) * 10;
+    }
+  }
+
+  /**
+   * Handle gamepad button press
+   */
+  private handleGamepadButtonDown(
+    button: GamepadButton,
+    action: GameAction | null,
+  ): void {
+    // CRITICAL: Block ALL input during death
+    const player = this.world.getPlayer();
+    if (
+      player &&
+      ((player as { isDying?: boolean }).isDying ||
+        (player.data as { isDying?: boolean })?.isDying)
+    ) {
+      return;
+    }
+
+    // Map specific buttons to keyboard equivalents for control bindings
+    switch (button) {
+      case GamepadButton.A:
+        this.simulateButtonPress("space");
+        break;
+      case GamepadButton.B:
+        this.simulateButtonPress("escape");
+        break;
+      case GamepadButton.X:
+        this.simulateButtonPress("keyE");
+        break;
+      case GamepadButton.Y:
+        this.simulateButtonPress("keyQ");
+        break;
+      case GamepadButton.START:
+        this.simulateButtonPress("escape");
+        break;
+      case GamepadButton.SELECT:
+        this.simulateButtonPress("keyI");
+        break;
+      case GamepadButton.L3:
+        this.buttons |= InputButtons.SPRINT;
+        break;
+      case GamepadButton.DPAD_UP:
+        this.simulateButtonPress("digit1");
+        break;
+      case GamepadButton.DPAD_RIGHT:
+        this.simulateButtonPress("digit2");
+        break;
+      case GamepadButton.DPAD_DOWN:
+        this.simulateButtonPress("digit3");
+        break;
+      case GamepadButton.DPAD_LEFT:
+        this.simulateButtonPress("digit4");
+        break;
+    }
+
+    // Emit generic gamepad event
+    this.emit("gamepadButtonDown", { button, action });
+  }
+
+  /**
+   * Handle gamepad button release
+   */
+  private handleGamepadButtonUp(
+    button: GamepadButton,
+    action: GameAction | null,
+  ): void {
+    switch (button) {
+      case GamepadButton.A:
+        this.simulateButtonRelease("space");
+        break;
+      case GamepadButton.B:
+        this.simulateButtonRelease("escape");
+        break;
+      case GamepadButton.X:
+        this.simulateButtonRelease("keyE");
+        break;
+      case GamepadButton.Y:
+        this.simulateButtonRelease("keyQ");
+        break;
+      case GamepadButton.START:
+        this.simulateButtonRelease("escape");
+        break;
+      case GamepadButton.SELECT:
+        this.simulateButtonRelease("keyI");
+        break;
+      case GamepadButton.L3:
+        this.buttons &= ~InputButtons.SPRINT;
+        break;
+      case GamepadButton.DPAD_UP:
+        this.simulateButtonRelease("digit1");
+        break;
+      case GamepadButton.DPAD_RIGHT:
+        this.simulateButtonRelease("digit2");
+        break;
+      case GamepadButton.DPAD_DOWN:
+        this.simulateButtonRelease("digit3");
+        break;
+      case GamepadButton.DPAD_LEFT:
+        this.simulateButtonRelease("digit4");
+        break;
+    }
+
+    // Emit generic gamepad event
+    this.emit("gamepadButtonUp", { button, action });
+  }
+
+  /**
+   * Simulate a button press for control bindings
+   */
+  private simulateButtonPress(prop: string): void {
+    this.buttonsDown.add(prop);
+    for (const control of this.controls) {
+      const button = control.entries[prop] as ButtonEntry;
+      if (button) {
+        button.pressed = true;
+        button.down = true;
+        const capture = button.onPress?.();
+        if (capture || button.capture) break;
+      }
+    }
+  }
+
+  /**
+   * Simulate a button release for control bindings
+   */
+  private simulateButtonRelease(prop: string): void {
+    this.buttonsDown.delete(prop);
+    for (const control of this.controls) {
+      const button = control.entries[prop] as ButtonEntry;
+      if (button?.down) {
+        button.down = false;
+        button.released = true;
+        button.onRelease?.();
+      }
+    }
+  }
+
+  // ========================================
+  // GAMEPAD PUBLIC API
+  // ========================================
+
+  /**
+   * Check if a gamepad is connected
+   */
+  isGamepadConnected(): boolean {
+    return this.gamepadInput?.isConnected() ?? false;
+  }
+
+  /**
+   * Get gamepad info
+   */
+  getGamepadInfo(): { id: string; index: number } | null {
+    return this.gamepadInput?.getGamepadInfo() ?? null;
+  }
+
+  /**
+   * Get left stick state
+   */
+  getLeftStick(): StickState {
+    return this.gamepadInput?.getLeftStick() ?? { x: 0, y: 0 };
+  }
+
+  /**
+   * Get right stick state
+   */
+  getRightStick(): StickState {
+    return this.gamepadInput?.getRightStick() ?? { x: 0, y: 0 };
+  }
+
+  /**
+   * Check if a gamepad button is pressed
+   */
+  isGamepadButtonPressed(button: GamepadButton): boolean {
+    return this.gamepadInput?.isButtonPressed(button) ?? false;
+  }
+
+  /**
+   * Vibrate the gamepad
+   */
+  vibrateGamepad(
+    duration: number,
+    weakMagnitude?: number,
+    strongMagnitude?: number,
+  ): void {
+    this.gamepadInput?.vibrate(duration, weakMagnitude, strongMagnitude);
+  }
+
+  /**
+   * Get the gamepad input instance for advanced usage
+   */
+  getGamepadInput(): GamepadInput | null {
+    return this.gamepadInput;
   }
 }
 

--- a/packages/shared/src/systems/client/GamepadInput.ts
+++ b/packages/shared/src/systems/client/GamepadInput.ts
@@ -1,0 +1,566 @@
+/**
+ * GamepadInput.ts - Gamepad/Controller Input System
+ *
+ * Handles gamepad input for Steam Deck and standard controllers.
+ * Polls the Gamepad API and maps controller inputs to game actions.
+ *
+ * Key Features:
+ * - **Controller Detection**: Auto-detects connected gamepads
+ * - **Button Mapping**: Standard Xbox/Steam Deck button layout
+ * - **Analog Sticks**: Left stick for movement, right for camera
+ * - **Deadzone Handling**: Configurable deadzone for analog inputs
+ * - **Event System**: Dispatches events for button press/release
+ *
+ * Steam Deck presents as an Xbox controller via Steam Input, so we use
+ * the standard Xbox button mapping (A=0, B=1, X=2, Y=3, etc.)
+ *
+ * Usage:
+ * ```typescript
+ * const gamepad = new GamepadInput();
+ *
+ * // Check button state
+ * if (gamepad.isButtonPressed(GamepadButton.A)) {
+ *   player.interact();
+ * }
+ *
+ * // Get analog stick values
+ * const leftStick = gamepad.getLeftStick();
+ * player.move(leftStick.x, leftStick.y);
+ * ```
+ *
+ * @see ClientInput.ts for integration with the main input system
+ */
+
+import { EventEmitter } from "eventemitter3";
+
+/**
+ * Standard gamepad button indices (Xbox/Steam Deck layout)
+ */
+export enum GamepadButton {
+  A = 0, // South button (confirm)
+  B = 1, // East button (back/cancel)
+  X = 2, // West button
+  Y = 3, // North button
+  LB = 4, // Left bumper
+  RB = 5, // Right bumper
+  LT = 6, // Left trigger (analog, but also has pressed state)
+  RT = 7, // Right trigger (analog, but also has pressed state)
+  SELECT = 8, // Back/View/Select
+  START = 9, // Start/Menu
+  L3 = 10, // Left stick press
+  R3 = 11, // Right stick press
+  DPAD_UP = 12,
+  DPAD_DOWN = 13,
+  DPAD_LEFT = 14,
+  DPAD_RIGHT = 15,
+  HOME = 16, // Xbox/Steam button (may not be available)
+}
+
+/**
+ * Gamepad axis indices
+ */
+export enum GamepadAxis {
+  LEFT_X = 0,
+  LEFT_Y = 1,
+  RIGHT_X = 2,
+  RIGHT_Y = 3,
+}
+
+/**
+ * Game action names for button mapping
+ */
+export type GameAction =
+  | "interact"
+  | "cancel"
+  | "attack"
+  | "specialAttack"
+  | "inventory"
+  | "equipment"
+  | "skills"
+  | "prayer"
+  | "magic"
+  | "menu"
+  | "run"
+  | "jump"
+  | "zoomIn"
+  | "zoomOut"
+  | "cycleLeft"
+  | "cycleRight";
+
+/**
+ * Button state for tracking press/release
+ */
+interface ButtonState {
+  pressed: boolean;
+  value: number;
+  justPressed: boolean;
+  justReleased: boolean;
+}
+
+/**
+ * Stick state with x/y values
+ */
+export interface StickState {
+  x: number;
+  y: number;
+}
+
+/**
+ * Events emitted by GamepadInput
+ */
+export interface GamepadInputEvents {
+  connected: (gamepad: Gamepad) => void;
+  disconnected: (gamepad: Gamepad) => void;
+  buttonDown: (button: GamepadButton, action: GameAction | null) => void;
+  buttonUp: (button: GamepadButton, action: GameAction | null) => void;
+}
+
+/**
+ * Default button-to-action mapping for Hyperscape
+ * Based on common RPG controller layouts
+ */
+export const DEFAULT_ACTION_MAPPING: Partial<
+  Record<GamepadButton, GameAction>
+> = {
+  [GamepadButton.A]: "interact",
+  [GamepadButton.B]: "cancel",
+  [GamepadButton.X]: "attack",
+  [GamepadButton.Y]: "specialAttack",
+  [GamepadButton.LB]: "cycleLeft",
+  [GamepadButton.RB]: "cycleRight",
+  [GamepadButton.LT]: "zoomOut",
+  [GamepadButton.RT]: "zoomIn",
+  [GamepadButton.SELECT]: "inventory",
+  [GamepadButton.START]: "menu",
+  [GamepadButton.L3]: "run",
+  [GamepadButton.R3]: "jump",
+  [GamepadButton.DPAD_UP]: "equipment",
+  [GamepadButton.DPAD_DOWN]: "prayer",
+  [GamepadButton.DPAD_LEFT]: "skills",
+  [GamepadButton.DPAD_RIGHT]: "magic",
+};
+
+/**
+ * GamepadInput - Gamepad/Controller Input Handler
+ *
+ * Manages gamepad input polling, button state tracking, and action mapping.
+ */
+export class GamepadInput extends EventEmitter<GamepadInputEvents> {
+  /** Currently active gamepad (first connected) */
+  private gamepad: Gamepad | null = null;
+
+  /** Gamepad index to track */
+  private gamepadIndex: number = -1;
+
+  /** Button states for tracking press/release */
+  private buttonStates: Map<GamepadButton, ButtonState> = new Map();
+
+  /** Action mapping (button -> action) */
+  private actionMapping: Partial<Record<GamepadButton, GameAction>> = {
+    ...DEFAULT_ACTION_MAPPING,
+  };
+
+  /** Deadzone for analog sticks (0-1) */
+  private deadzone: number = 0.15;
+
+  /** Whether gamepad input is enabled */
+  private enabled: boolean = true;
+
+  /** Pre-allocated stick states to avoid GC */
+  private leftStickState: StickState = { x: 0, y: 0 };
+  private rightStickState: StickState = { x: 0, y: 0 };
+
+  constructor() {
+    super();
+    this.initializeButtonStates();
+    this.setupEventListeners();
+  }
+
+  /**
+   * Initialize button states for all buttons
+   */
+  private initializeButtonStates(): void {
+    for (let i = 0; i <= 16; i++) {
+      this.buttonStates.set(i as GamepadButton, {
+        pressed: false,
+        value: 0,
+        justPressed: false,
+        justReleased: false,
+      });
+    }
+  }
+
+  /**
+   * Setup gamepad connection event listeners
+   */
+  private setupEventListeners(): void {
+    if (typeof window === "undefined") return;
+
+    window.addEventListener("gamepadconnected", this.onGamepadConnected);
+    window.addEventListener("gamepaddisconnected", this.onGamepadDisconnected);
+
+    // Check for already-connected gamepads (Chrome requires polling first)
+    this.checkForGamepads();
+  }
+
+  /**
+   * Check for already-connected gamepads
+   */
+  private checkForGamepads(): void {
+    const gamepads = navigator.getGamepads();
+    for (let i = 0; i < gamepads.length; i++) {
+      const gp = gamepads[i];
+      if (gp && this.gamepadIndex === -1) {
+        this.gamepad = gp;
+        this.gamepadIndex = gp.index;
+        console.log(`[GamepadInput] Found gamepad: ${gp.id}`);
+        this.emit("connected", gp);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Handle gamepad connection
+   */
+  private onGamepadConnected = (e: GamepadEvent): void => {
+    console.log(`[GamepadInput] Gamepad connected: ${e.gamepad.id}`);
+
+    // Use first gamepad if none connected
+    if (this.gamepadIndex === -1) {
+      this.gamepad = e.gamepad;
+      this.gamepadIndex = e.gamepad.index;
+      this.emit("connected", e.gamepad);
+    }
+  };
+
+  /**
+   * Handle gamepad disconnection
+   */
+  private onGamepadDisconnected = (e: GamepadEvent): void => {
+    console.log(`[GamepadInput] Gamepad disconnected: ${e.gamepad.id}`);
+
+    if (e.gamepad.index === this.gamepadIndex) {
+      this.emit("disconnected", e.gamepad);
+      this.gamepad = null;
+      this.gamepadIndex = -1;
+
+      // Reset all button states
+      this.initializeButtonStates();
+
+      // Check for other gamepads
+      this.checkForGamepads();
+    }
+  };
+
+  /**
+   * Update gamepad state - call this every frame
+   */
+  update(): void {
+    if (!this.enabled || this.gamepadIndex === -1) return;
+
+    // Must re-fetch gamepad state each frame (Gamepad API requirement)
+    const gamepads = navigator.getGamepads();
+    this.gamepad = gamepads[this.gamepadIndex];
+
+    if (!this.gamepad) return;
+
+    // Clear justPressed/justReleased flags from previous frame
+    for (const state of this.buttonStates.values()) {
+      state.justPressed = false;
+      state.justReleased = false;
+    }
+
+    // Update button states
+    this.updateButtons();
+  }
+
+  /**
+   * Update button states and emit events
+   */
+  private updateButtons(): void {
+    if (!this.gamepad) return;
+
+    for (let i = 0; i < this.gamepad.buttons.length && i <= 16; i++) {
+      const button = this.gamepad.buttons[i];
+      const buttonId = i as GamepadButton;
+      const state = this.buttonStates.get(buttonId);
+
+      if (!state) continue;
+
+      const wasPressed = state.pressed;
+      const isPressed = button.pressed || button.value > 0.5;
+
+      state.value = button.value;
+      state.pressed = isPressed;
+
+      // Detect press/release transitions
+      if (isPressed && !wasPressed) {
+        state.justPressed = true;
+        const action = this.actionMapping[buttonId] ?? null;
+        this.emit("buttonDown", buttonId, action);
+      } else if (!isPressed && wasPressed) {
+        state.justReleased = true;
+        const action = this.actionMapping[buttonId] ?? null;
+        this.emit("buttonUp", buttonId, action);
+      }
+    }
+  }
+
+  /**
+   * Apply deadzone to analog value
+   */
+  private applyDeadzone(value: number): number {
+    if (Math.abs(value) < this.deadzone) return 0;
+    // Rescale value to 0-1 range after deadzone
+    const sign = value > 0 ? 1 : -1;
+    return sign * ((Math.abs(value) - this.deadzone) / (1 - this.deadzone));
+  }
+
+  // ========================================
+  // PUBLIC API
+  // ========================================
+
+  /**
+   * Check if a gamepad is connected
+   */
+  isConnected(): boolean {
+    return this.gamepad !== null;
+  }
+
+  /**
+   * Get the connected gamepad info
+   */
+  getGamepadInfo(): { id: string; index: number } | null {
+    if (!this.gamepad) return null;
+    return { id: this.gamepad.id, index: this.gamepad.index };
+  }
+
+  /**
+   * Check if a button is currently pressed
+   */
+  isButtonPressed(button: GamepadButton): boolean {
+    return this.buttonStates.get(button)?.pressed ?? false;
+  }
+
+  /**
+   * Check if a button was just pressed this frame
+   */
+  isButtonJustPressed(button: GamepadButton): boolean {
+    return this.buttonStates.get(button)?.justPressed ?? false;
+  }
+
+  /**
+   * Check if a button was just released this frame
+   */
+  isButtonJustReleased(button: GamepadButton): boolean {
+    return this.buttonStates.get(button)?.justReleased ?? false;
+  }
+
+  /**
+   * Get the analog value of a button (0-1 for triggers)
+   */
+  getButtonValue(button: GamepadButton): number {
+    return this.buttonStates.get(button)?.value ?? 0;
+  }
+
+  /**
+   * Get left analog stick state
+   */
+  getLeftStick(): StickState {
+    if (!this.gamepad) {
+      this.leftStickState.x = 0;
+      this.leftStickState.y = 0;
+      return this.leftStickState;
+    }
+
+    this.leftStickState.x = this.applyDeadzone(
+      this.gamepad.axes[GamepadAxis.LEFT_X] ?? 0,
+    );
+    this.leftStickState.y = this.applyDeadzone(
+      this.gamepad.axes[GamepadAxis.LEFT_Y] ?? 0,
+    );
+
+    return this.leftStickState;
+  }
+
+  /**
+   * Get right analog stick state
+   */
+  getRightStick(): StickState {
+    if (!this.gamepad) {
+      this.rightStickState.x = 0;
+      this.rightStickState.y = 0;
+      return this.rightStickState;
+    }
+
+    this.rightStickState.x = this.applyDeadzone(
+      this.gamepad.axes[GamepadAxis.RIGHT_X] ?? 0,
+    );
+    this.rightStickState.y = this.applyDeadzone(
+      this.gamepad.axes[GamepadAxis.RIGHT_Y] ?? 0,
+    );
+
+    return this.rightStickState;
+  }
+
+  /**
+   * Get trigger values (0-1)
+   */
+  getTriggers(): { left: number; right: number } {
+    return {
+      left: this.getButtonValue(GamepadButton.LT),
+      right: this.getButtonValue(GamepadButton.RT),
+    };
+  }
+
+  /**
+   * Check if any D-pad button is pressed
+   */
+  getDPad(): { up: boolean; down: boolean; left: boolean; right: boolean } {
+    return {
+      up: this.isButtonPressed(GamepadButton.DPAD_UP),
+      down: this.isButtonPressed(GamepadButton.DPAD_DOWN),
+      left: this.isButtonPressed(GamepadButton.DPAD_LEFT),
+      right: this.isButtonPressed(GamepadButton.DPAD_RIGHT),
+    };
+  }
+
+  /**
+   * Get the action mapped to a button
+   */
+  getActionForButton(button: GamepadButton): GameAction | null {
+    return this.actionMapping[button] ?? null;
+  }
+
+  /**
+   * Set custom action mapping
+   */
+  setActionMapping(mapping: Partial<Record<GamepadButton, GameAction>>): void {
+    this.actionMapping = { ...mapping };
+  }
+
+  /**
+   * Reset action mapping to defaults
+   */
+  resetActionMapping(): void {
+    this.actionMapping = { ...DEFAULT_ACTION_MAPPING };
+  }
+
+  /**
+   * Set deadzone value (0-1)
+   */
+  setDeadzone(value: number): void {
+    this.deadzone = Math.max(0, Math.min(0.5, value));
+  }
+
+  /**
+   * Get current deadzone value
+   */
+  getDeadzone(): number {
+    return this.deadzone;
+  }
+
+  /**
+   * Enable/disable gamepad input
+   */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Check if gamepad input is enabled
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Vibrate the gamepad (if supported)
+   */
+  vibrate(
+    duration: number,
+    weakMagnitude: number = 0.5,
+    strongMagnitude: number = 0.5,
+  ): void {
+    if (!this.gamepad) return;
+
+    // Check for vibration actuator support
+    const vibrationActuator = (
+      this.gamepad as Gamepad & {
+        vibrationActuator?: {
+          playEffect: (
+            type: string,
+            params: {
+              duration: number;
+              weakMagnitude: number;
+              strongMagnitude: number;
+            },
+          ) => Promise<string>;
+        };
+      }
+    ).vibrationActuator;
+
+    if (vibrationActuator) {
+      vibrationActuator
+        .playEffect("dual-rumble", {
+          duration,
+          weakMagnitude,
+          strongMagnitude,
+        })
+        .catch(() => {
+          // Vibration not supported or failed
+        });
+    }
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  destroy(): void {
+    // Remove window event listeners if in browser
+    if (typeof window !== "undefined") {
+      window.removeEventListener("gamepadconnected", this.onGamepadConnected);
+      window.removeEventListener(
+        "gamepaddisconnected",
+        this.onGamepadDisconnected,
+      );
+    }
+
+    // Always clean up EventEmitter listeners and state
+    this.removeAllListeners();
+    this.gamepad = null;
+    this.gamepadIndex = -1;
+  }
+}
+
+/**
+ * Button glyphs for UI display
+ * These match the Steam Deck / Xbox controller layout
+ */
+export const GAMEPAD_BUTTON_GLYPHS: Record<GamepadButton, string> = {
+  [GamepadButton.A]: "Ⓐ",
+  [GamepadButton.B]: "Ⓑ",
+  [GamepadButton.X]: "Ⓧ",
+  [GamepadButton.Y]: "Ⓨ",
+  [GamepadButton.LB]: "LB",
+  [GamepadButton.RB]: "RB",
+  [GamepadButton.LT]: "LT",
+  [GamepadButton.RT]: "RT",
+  [GamepadButton.SELECT]: "⎚",
+  [GamepadButton.START]: "☰",
+  [GamepadButton.L3]: "L3",
+  [GamepadButton.R3]: "R3",
+  [GamepadButton.DPAD_UP]: "▲",
+  [GamepadButton.DPAD_DOWN]: "▼",
+  [GamepadButton.DPAD_LEFT]: "◀",
+  [GamepadButton.DPAD_RIGHT]: "▶",
+  [GamepadButton.HOME]: "⌂",
+};
+
+/**
+ * Get button glyph for UI display
+ */
+export function getButtonGlyph(button: GamepadButton): string {
+  return GAMEPAD_BUTTON_GLYPHS[button] ?? "?";
+}

--- a/packages/shared/src/systems/client/__tests__/GamepadInput.test.ts
+++ b/packages/shared/src/systems/client/__tests__/GamepadInput.test.ts
@@ -1,0 +1,317 @@
+/**
+ * GamepadInput.test.ts - Tests for Gamepad Input System
+ *
+ * Tests the gamepad input system including:
+ * - Button state tracking
+ * - Analog stick handling
+ * - Action mapping
+ * - Event emission
+ *
+ * Note: Full gamepad integration tests require a browser environment.
+ * These tests focus on the logic that can be tested in Node.js.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  GamepadInput,
+  GamepadButton,
+  GamepadAxis,
+  DEFAULT_ACTION_MAPPING,
+  GAMEPAD_BUTTON_GLYPHS,
+  getButtonGlyph,
+} from "../GamepadInput";
+
+// Check if we're in a browser-like environment
+const isBrowserEnv =
+  typeof window !== "undefined" &&
+  typeof navigator !== "undefined" &&
+  typeof navigator.getGamepads === "function";
+
+// Mock gamepad data
+function createMockGamepad(overrides: Partial<Gamepad> = {}): Gamepad {
+  const buttons: GamepadButton[] = [];
+  for (let i = 0; i < 17; i++) {
+    buttons.push({
+      pressed: false,
+      touched: false,
+      value: 0,
+    } as GamepadButton);
+  }
+
+  return {
+    id: "Mock Gamepad (STANDARD GAMEPAD Vendor: 045e Product: 028e)",
+    index: 0,
+    connected: true,
+    timestamp: performance.now(),
+    mapping: "standard",
+    axes: [0, 0, 0, 0],
+    buttons,
+    hapticActuators: [],
+    ...overrides,
+  } as Gamepad;
+}
+
+describe("GamepadInput", () => {
+  let gamepadInput: GamepadInput;
+
+  beforeEach(() => {
+    gamepadInput = new GamepadInput();
+  });
+
+  afterEach(() => {
+    gamepadInput.destroy();
+    vi.restoreAllMocks();
+  });
+
+  describe("initialization", () => {
+    it("should initialize with no gamepad connected", () => {
+      expect(gamepadInput.isConnected()).toBe(false);
+      expect(gamepadInput.getGamepadInfo()).toBeNull();
+    });
+
+    it("should initialize with default action mapping", () => {
+      expect(gamepadInput.getActionForButton(GamepadButton.A)).toBe("interact");
+      expect(gamepadInput.getActionForButton(GamepadButton.B)).toBe("cancel");
+    });
+
+    it("should have default deadzone of 0.15", () => {
+      expect(gamepadInput.getDeadzone()).toBe(0.15);
+    });
+  });
+
+  // Browser-specific tests are skipped in Node.js environment
+  describe.skipIf(!isBrowserEnv)("gamepad connection (browser only)", () => {
+    it("should detect gamepad on connection event", () => {
+      const mockGamepad = createMockGamepad();
+      const connectHandler = vi.fn();
+
+      gamepadInput.on("connected", connectHandler);
+
+      // Simulate gamepad connection
+      const event = new GamepadEvent("gamepadconnected", {
+        gamepad: mockGamepad,
+      });
+      window.dispatchEvent(event);
+
+      expect(connectHandler).toHaveBeenCalledWith(mockGamepad);
+    });
+
+    it("should detect gamepad disconnection", () => {
+      const mockGamepad = createMockGamepad();
+      const disconnectHandler = vi.fn();
+
+      gamepadInput.on("disconnected", disconnectHandler);
+
+      // Connect first
+      const connectEvent = new GamepadEvent("gamepadconnected", {
+        gamepad: mockGamepad,
+      });
+      window.dispatchEvent(connectEvent);
+
+      // Then disconnect
+      const disconnectEvent = new GamepadEvent("gamepaddisconnected", {
+        gamepad: mockGamepad,
+      });
+      window.dispatchEvent(disconnectEvent);
+
+      expect(disconnectHandler).toHaveBeenCalledWith(mockGamepad);
+    });
+  });
+
+  describe("analog stick handling (no gamepad)", () => {
+    it("should return zero when no gamepad connected", () => {
+      const leftStick = gamepadInput.getLeftStick();
+      const rightStick = gamepadInput.getRightStick();
+
+      expect(leftStick).toEqual({ x: 0, y: 0 });
+      expect(rightStick).toEqual({ x: 0, y: 0 });
+    });
+
+    it("should allow setting custom deadzone", () => {
+      gamepadInput.setDeadzone(0.3);
+      expect(gamepadInput.getDeadzone()).toBe(0.3);
+    });
+
+    it("should clamp deadzone to valid range", () => {
+      gamepadInput.setDeadzone(0.8); // Above max (0.5)
+      expect(gamepadInput.getDeadzone()).toBe(0.5);
+
+      gamepadInput.setDeadzone(-0.1); // Below min (0)
+      expect(gamepadInput.getDeadzone()).toBe(0);
+    });
+  });
+
+  describe("D-pad handling (no gamepad)", () => {
+    it("should return all false when no gamepad connected", () => {
+      const dpad = gamepadInput.getDPad();
+
+      expect(dpad.up).toBe(false);
+      expect(dpad.right).toBe(false);
+      expect(dpad.down).toBe(false);
+      expect(dpad.left).toBe(false);
+    });
+  });
+
+  describe("trigger handling (no gamepad)", () => {
+    it("should return zero triggers when no gamepad connected", () => {
+      const triggers = gamepadInput.getTriggers();
+
+      expect(triggers.left).toBe(0);
+      expect(triggers.right).toBe(0);
+    });
+  });
+
+  describe("action mapping", () => {
+    it("should use default action mapping", () => {
+      expect(gamepadInput.getActionForButton(GamepadButton.A)).toBe(
+        DEFAULT_ACTION_MAPPING[GamepadButton.A],
+      );
+    });
+
+    it("should allow setting custom action mapping", () => {
+      gamepadInput.setActionMapping({
+        [GamepadButton.A]: "jump",
+        [GamepadButton.B]: "attack",
+      });
+
+      expect(gamepadInput.getActionForButton(GamepadButton.A)).toBe("jump");
+      expect(gamepadInput.getActionForButton(GamepadButton.B)).toBe("attack");
+    });
+
+    it("should reset action mapping to defaults", () => {
+      gamepadInput.setActionMapping({
+        [GamepadButton.A]: "jump",
+      });
+
+      gamepadInput.resetActionMapping();
+
+      expect(gamepadInput.getActionForButton(GamepadButton.A)).toBe("interact");
+    });
+
+    it("should return null for unmapped buttons", () => {
+      gamepadInput.setActionMapping({});
+
+      expect(gamepadInput.getActionForButton(GamepadButton.A)).toBeNull();
+    });
+  });
+
+  describe("enable/disable", () => {
+    it("should be enabled by default", () => {
+      expect(gamepadInput.isEnabled()).toBe(true);
+    });
+
+    it("should toggle enabled state", () => {
+      gamepadInput.setEnabled(false);
+      expect(gamepadInput.isEnabled()).toBe(false);
+
+      gamepadInput.setEnabled(true);
+      expect(gamepadInput.isEnabled()).toBe(true);
+    });
+  });
+
+  describe("button glyphs", () => {
+    it("should have glyphs for all buttons", () => {
+      for (let i = 0; i <= 16; i++) {
+        expect(GAMEPAD_BUTTON_GLYPHS[i as GamepadButton]).toBeDefined();
+      }
+    });
+
+    it("should return correct glyph via helper function", () => {
+      expect(getButtonGlyph(GamepadButton.A)).toBe("Ⓐ");
+      expect(getButtonGlyph(GamepadButton.B)).toBe("Ⓑ");
+      expect(getButtonGlyph(GamepadButton.X)).toBe("Ⓧ");
+      expect(getButtonGlyph(GamepadButton.Y)).toBe("Ⓨ");
+    });
+
+    it("should return correct glyphs for bumpers and triggers", () => {
+      expect(getButtonGlyph(GamepadButton.LB)).toBe("LB");
+      expect(getButtonGlyph(GamepadButton.RB)).toBe("RB");
+      expect(getButtonGlyph(GamepadButton.LT)).toBe("LT");
+      expect(getButtonGlyph(GamepadButton.RT)).toBe("RT");
+    });
+
+    it("should return correct glyphs for D-pad", () => {
+      expect(getButtonGlyph(GamepadButton.DPAD_UP)).toBe("▲");
+      expect(getButtonGlyph(GamepadButton.DPAD_DOWN)).toBe("▼");
+      expect(getButtonGlyph(GamepadButton.DPAD_LEFT)).toBe("◀");
+      expect(getButtonGlyph(GamepadButton.DPAD_RIGHT)).toBe("▶");
+    });
+  });
+
+  describe("event emitter", () => {
+    it("should allow adding event handlers", () => {
+      const handler = vi.fn();
+      gamepadInput.on("buttonDown", handler);
+
+      // Manually emit to test (simulating internal behavior)
+      gamepadInput.emit("buttonDown", GamepadButton.A, "interact");
+
+      expect(handler).toHaveBeenCalledWith(GamepadButton.A, "interact");
+    });
+
+    it("should clear all event handlers on destroy", () => {
+      const handler = vi.fn();
+      gamepadInput.on("buttonDown", handler);
+
+      // Verify handler is registered
+      expect(gamepadInput.listenerCount("buttonDown")).toBe(1);
+
+      gamepadInput.destroy();
+
+      // All listeners should be removed
+      expect(gamepadInput.listenerCount("buttonDown")).toBe(0);
+    });
+  });
+
+  describe("button state without gamepad", () => {
+    it("should return false for button pressed when no gamepad", () => {
+      expect(gamepadInput.isButtonPressed(GamepadButton.A)).toBe(false);
+      expect(gamepadInput.isButtonPressed(GamepadButton.B)).toBe(false);
+    });
+
+    it("should return false for just pressed when no gamepad", () => {
+      expect(gamepadInput.isButtonJustPressed(GamepadButton.A)).toBe(false);
+    });
+
+    it("should return false for just released when no gamepad", () => {
+      expect(gamepadInput.isButtonJustReleased(GamepadButton.A)).toBe(false);
+    });
+
+    it("should return 0 for button value when no gamepad", () => {
+      expect(gamepadInput.getButtonValue(GamepadButton.A)).toBe(0);
+      expect(gamepadInput.getButtonValue(GamepadButton.LT)).toBe(0);
+    });
+  });
+});
+
+describe("GamepadAxis enum", () => {
+  it("should have correct axis indices", () => {
+    expect(GamepadAxis.LEFT_X).toBe(0);
+    expect(GamepadAxis.LEFT_Y).toBe(1);
+    expect(GamepadAxis.RIGHT_X).toBe(2);
+    expect(GamepadAxis.RIGHT_Y).toBe(3);
+  });
+});
+
+describe("GamepadButton enum", () => {
+  it("should have correct button indices for face buttons", () => {
+    expect(GamepadButton.A).toBe(0);
+    expect(GamepadButton.B).toBe(1);
+    expect(GamepadButton.X).toBe(2);
+    expect(GamepadButton.Y).toBe(3);
+  });
+
+  it("should have correct button indices for bumpers and triggers", () => {
+    expect(GamepadButton.LB).toBe(4);
+    expect(GamepadButton.RB).toBe(5);
+    expect(GamepadButton.LT).toBe(6);
+    expect(GamepadButton.RT).toBe(7);
+  });
+
+  it("should have correct button indices for D-pad", () => {
+    expect(GamepadButton.DPAD_UP).toBe(12);
+    expect(GamepadButton.DPAD_DOWN).toBe(13);
+    expect(GamepadButton.DPAD_LEFT).toBe(14);
+    expect(GamepadButton.DPAD_RIGHT).toBe(15);
+  });
+});

--- a/packages/shared/src/systems/client/index.ts
+++ b/packages/shared/src/systems/client/index.ts
@@ -8,6 +8,19 @@ export { ClientAudio } from "./ClientAudio";
 export { ClientCameraSystem } from "./ClientCameraSystem";
 export { ClientGraphics } from "./ClientGraphics";
 export { ClientInput } from "./ClientInput";
+export {
+  GamepadInput,
+  GamepadButton,
+  GamepadAxis,
+  DEFAULT_ACTION_MAPPING,
+  GAMEPAD_BUTTON_GLYPHS,
+  getButtonGlyph,
+} from "./GamepadInput";
+export type {
+  StickState,
+  GameAction,
+  GamepadInputEvents,
+} from "./GamepadInput";
 export { ClientInterface } from "./ClientInterface";
 export { ClientLiveKit } from "./ClientLiveKit";
 export { ClientLoader } from "./ClientLoader";


### PR DESCRIPTION
- Add GamepadInput system with controller polling and button mapping
- Integrate gamepad input into ClientInput system
- Add Steam Deck hardware detection in Tauri backend
- Configure Tauri window settings for Steam Deck (1280x800, fullscreen)
- Create Steam Input controller configuration file
- Add gamepad mode CSS and button glyph React components
- Add comprehensive tests for GamepadInput system

Features:
- Full Xbox/Steam Deck controller support via Gamepad API
- Configurable button-to-action mapping
- Analog stick deadzone handling
- D-pad and trigger support
- Controller vibration (haptic feedback)
- Adaptive UI hints (keyboard/gamepad)
- Steam Deck-optimized touch targets and fonts