### PR TITLE
fix(docs): use static branch name for Mintlify updates

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -139,7 +139,7 @@ jobs:
             ].join('\n');
 
             const payload = {
-              branch: `mintlify/docs-update-${Date.now()}`,
+              branch: 'mintlify/docs-update',
               messages: [
                 {
                   role: 'system',


### PR DESCRIPTION
## Summary

Fixes the Mintlify documentation workflow to use a static branch name instead of a dynamic timestamp-based one.

## Problem

The previous implementation created a new PR for every push to main:

```javascript
branch: `mintlify/docs-update-${Date.now()}`
```

This resulted in 47+ separate PRs being created in the docs repository.

## Solution

Use a static branch name so Mintlify updates the same PR:

```javascript
branch: 'mintlify/docs-update'
```

## Behavior After This Change

1. **First run after PR merge**: Creates new branch `mintlify/docs-update` and opens a new PR
2. **Subsequent runs**: Pushes to existing branch, updating the open PR
3. **After PR merge**: Branch is deleted, next run starts the cycle over

## Related

- Consolidated all 47 existing PRs into HyperscapeAI/docs#74
- Closed PRs #27 through #73 in the docs repository