### PR TITLE
fix(client): remove duplicate code causing syntax error in usePlayerData

### DIFF
--- a/packages/client/src/hooks/usePlayerData.ts
+++ b/packages/client/src/hooks/usePlayerData.ts
@@ -79,9 +79,6 @@ export function usePlayerData(world: ClientWorld | null): PlayerDataState {
         console.warn("[usePlayerData] Invalid inventory update event:", data);
         return;
       }
-      setInventory(data.items || []);
-      if (typeof data.coins === "number") {
-        setCoins(data.coins);
       const invData = data as {
         playerId: string;
         items: InventorySlotViewItem[];


### PR DESCRIPTION
## Summary
- Fixes build-breaking syntax error in `usePlayerData.ts`
- Removes 3 duplicate lines that were left from an incomplete edit/merge
- The unclosed `if` block was causing: `Expected ";" but found ")"`

## Test plan
- [x] Build passes without syntax errors
- [x] Linter shows no errors on the file