### PR TITLE
fix: camera facing backwards on fresh load and color grading leaking …

### DIFF
--- a/packages/shared/src/systems/client/ClientCameraSystem.ts
+++ b/packages/shared/src/systems/client/ClientCameraSystem.ts
@@ -39,8 +39,8 @@ export class ClientCameraSystem extends SystemBase {
   private static readonly MAX_INIT_RETRIES = 30; // 3 seconds max wait
 
   // Camera state for different modes
-  private spherical = new THREE.Spherical(6, Math.PI * 0.42, 0); // current radius, phi, theta
-  private targetSpherical = new THREE.Spherical(6, Math.PI * 0.42, 0); // target spherical for smoothing
+  private spherical = new THREE.Spherical(6, Math.PI * 0.42, Math.PI); // current radius, phi, theta
+  private targetSpherical = new THREE.Spherical(6, Math.PI * 0.42, Math.PI); // target spherical for smoothing
   private targetPosition = new THREE.Vector3();
   private smoothedTarget = new THREE.Vector3();
   private cameraPosition = new THREE.Vector3();
@@ -708,7 +708,7 @@ export class ClientCameraSystem extends SystemBase {
     if (!this.target) return;
 
     this.targetSpherical.radius = 8;
-    this.targetSpherical.theta = 0;
+    this.targetSpherical.theta = Math.PI;
     this.targetSpherical.phi = Math.PI * 0.42;
     this.spherical.radius = this.targetSpherical.radius;
     this.spherical.theta = this.targetSpherical.theta;

--- a/packages/shared/src/systems/client/ClientGraphics.ts
+++ b/packages/shared/src/systems/client/ClientGraphics.ts
@@ -317,11 +317,11 @@ export class ClientGraphics extends System {
   }
 
   render() {
-    if (!this.usePostprocessing || !this.composer) {
-      // Direct rendering without post-processing
+    if (!this.composer) {
+      // No composer available (WebGL fallback) - direct render
       this.renderer.render(this.world.stage.scene, this.world.camera);
     } else {
-      // Render with post-processing (bloom via TSL)
+      // Composer handles deciding when to use post-processing vs direct render
       this.composer.render();
     }
   }
@@ -352,6 +352,28 @@ export class ClientGraphics extends System {
     if (changes.postprocessing) {
       // WebGL fallback currently runs without TSL post-processing.
       this.usePostprocessing = changes.postprocessing.value && this.isWebGPU;
+      // Disable/restore LUT on the composer so outline-only rendering still works
+      if (this.composer) {
+        if (!this.usePostprocessing) {
+          this.composer.setLUT("none");
+        } else {
+          // Restore color grading from current prefs
+          const currentColorGrading =
+            this.world.prefs?.colorGrading ?? "cinematic";
+          this.composer.setLUT(
+            currentColorGrading as
+              | "none"
+              | "cinematic"
+              | "bourbon"
+              | "chemical"
+              | "clayton"
+              | "cubicle"
+              | "remy"
+              | "bw"
+              | "night",
+          );
+        }
+      }
     }
     // color grading LUT
     if (changes.colorGrading && this.composer) {

--- a/packages/shared/src/utils/rendering/PostProcessingFactory.ts
+++ b/packages/shared/src/utils/rendering/PostProcessingFactory.ts
@@ -131,10 +131,11 @@ let outlineModule: { outline: OutlineFunction } | null = null;
  */
 async function loadOutlineModule(): Promise<void> {
   if (!outlineModule) {
-    outlineModule =
-      (await import("three/examples/jsm/tsl/display/OutlineNode.js")) as unknown as {
-        outline: OutlineFunction;
-      };
+    outlineModule = (await import(
+      "three/examples/jsm/tsl/display/OutlineNode.js"
+    )) as unknown as {
+      outline: OutlineFunction;
+    };
   }
 }
 
@@ -143,28 +144,32 @@ async function loadOutlineModule(): Promise<void> {
  */
 async function loadLUTModules(): Promise<void> {
   if (!lut3DModule) {
-    lut3DModule =
-      (await import("three/examples/jsm/tsl/display/Lut3DNode.js")) as unknown as {
-        lut3D: LUT3DFunction;
-      };
+    lut3DModule = (await import(
+      "three/examples/jsm/tsl/display/Lut3DNode.js"
+    )) as unknown as {
+      lut3D: LUT3DFunction;
+    };
   }
   if (!lutCubeLoaderModule) {
-    lutCubeLoaderModule =
-      (await import("three/examples/jsm/loaders/LUTCubeLoader.js")) as {
-        LUTCubeLoader: new () => LUTLoader;
-      };
+    lutCubeLoaderModule = (await import(
+      "three/examples/jsm/loaders/LUTCubeLoader.js"
+    )) as {
+      LUTCubeLoader: new () => LUTLoader;
+    };
   }
   if (!lut3dlLoaderModule) {
-    lut3dlLoaderModule =
-      (await import("three/examples/jsm/loaders/LUT3dlLoader.js")) as {
-        LUT3dlLoader: new () => LUTLoader;
-      };
+    lut3dlLoaderModule = (await import(
+      "three/examples/jsm/loaders/LUT3dlLoader.js"
+    )) as {
+      LUT3dlLoader: new () => LUTLoader;
+    };
   }
   if (!lutImageLoaderModule) {
-    lutImageLoaderModule =
-      (await import("three/examples/jsm/loaders/LUTImageLoader.js")) as {
-        LUTImageLoader: new () => LUTLoader;
-      };
+    lutImageLoaderModule = (await import(
+      "three/examples/jsm/loaders/LUTImageLoader.js"
+    )) as {
+      LUTImageLoader: new () => LUTLoader;
+    };
   }
 }
 
@@ -380,11 +385,13 @@ export async function createPostProcessing(
     } else {
       // Failed to load LUT
       lutEnabled = false;
+      intensityUniform.value = 0;
       console.log("[PostProcessing] Failed to load LUT, using direct render");
     }
   } else {
     console.log("[PostProcessing] Color grading disabled or LUT is none");
     lutEnabled = false;
+    intensityUniform.value = 0;
   }
 
   const composer: PostProcessingComposer = {
@@ -423,8 +430,9 @@ export async function createPostProcessing(
       currentLUT = lutName;
 
       if (lutName === "none") {
-        // Disable LUT - bypass post-processing entirely
+        // Disable LUT - zero intensity so outline-only rendering doesn't apply color grading
         lutEnabled = false;
+        intensityUniform.value = 0;
         console.log(
           "[PostProcessing] LUT disabled (bypassing post-processing for performance)",
         );


### PR DESCRIPTION
…on hover

Camera initialized with theta=0 which places camera in front of player, causing backwards movement. Changed to theta=Math.PI for standard third-person behind-the-player view.

Post-processing outline pass shares the shader pipeline with LUT color grading. When LUT was "none" but hover triggered outline, the full pipeline ran including stale LUT data. Zero LUT intensity when disabled so outline-only rendering stays clean. Also route rendering through the composer even when post-processing is off so entity highlights still work.