### PR TITLE
perf: GPU-instanced fishing spot particles via centralized ParticleManager

### DIFF
--- a/packages/shared/src/entities/managers/index.ts
+++ b/packages/shared/src/entities/managers/index.ts
@@ -11,3 +11,4 @@ export * from "./RespawnManager";
 export * from "./MobVisualManager";
 export * from "./MobMovementManager";
 export * from "./MobHealthBarManager";
+export * from "./particleManager";

--- a/packages/shared/src/entities/managers/particleManager/ParticleManager.ts
+++ b/packages/shared/src/entities/managers/particleManager/ParticleManager.ts
@@ -1,0 +1,150 @@
+/**
+ * ParticleManager - Central Particle Manager Router
+ *
+ * Single entry point for all particle systems. ResourceSystem (and other systems)
+ * send events here; the manager routes them to the correct specialised sub-manager
+ * based on resource type or particle category.
+ *
+ * Currently manages:
+ *   - WaterParticleManager  (fishing spots: splash, bubble, shimmer, ripple)
+ *
+ * To add a new particle type (e.g. fire, magic, dust):
+ *   1. Create a new sub-manager class in this folder
+ *   2. Instantiate it in the ParticleManager constructor
+ *   3. Add routing logic in the register / unregister / move / handleEvent methods
+ *   4. Call its update() from ParticleManager.update()
+ *   5. Call its dispose() from ParticleManager.dispose()
+ *
+ * @module ParticleManager
+ */
+
+import * as THREE from "../../../extras/three/three";
+import { WaterParticleManager } from "./WaterParticleManager";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface ParticleSpotConfig {
+  entityId: string;
+  position: { x: number; y: number; z: number };
+  resourceType: string;
+  resourceId: string;
+}
+
+export interface ParticleResourceEvent {
+  id?: string;
+  type?: string;
+  position?: { x: number; y: number; z: number };
+}
+
+// =============================================================================
+// PARTICLE MANAGER
+// =============================================================================
+
+export class ParticleManager {
+  private waterManager: WaterParticleManager;
+  // Future managers go here:
+  // private fireManager: FireParticleManager;
+  // private magicManager: MagicParticleManager;
+
+  constructor(scene: THREE.Scene) {
+    this.waterManager = new WaterParticleManager(scene);
+    console.log("[ParticleManager] Initialized with WaterParticleManager");
+  }
+
+  // ===========================================================================
+  // SPOT LIFECYCLE (called by entities)
+  // ===========================================================================
+
+  /**
+   * Register a particle-emitting spot. Routes to the correct manager
+   * based on `config.resourceType`.
+   */
+  registerSpot(config: ParticleSpotConfig): void {
+    if (this.isWaterType(config.resourceType)) {
+      this.waterManager.registerSpot({
+        entityId: config.entityId,
+        position: config.position,
+        resourceId: config.resourceId,
+      });
+      return;
+    }
+    // Future: route to other managers based on resourceType
+  }
+
+  /**
+   * Unregister a spot. Tries every manager that could own it.
+   */
+  unregisterSpot(entityId: string, resourceType: string): void {
+    if (this.isWaterType(resourceType)) {
+      this.waterManager.unregisterSpot(entityId);
+      return;
+    }
+    // Future: route to other managers
+  }
+
+  /**
+   * Move an existing spot's position. Called when fishing spots relocate.
+   */
+  moveSpot(
+    entityId: string,
+    resourceType: string,
+    newPos: { x: number; y: number; z: number },
+  ): void {
+    if (this.isWaterType(resourceType)) {
+      this.waterManager.moveSpot(entityId, newPos);
+      return;
+    }
+    // Future: route to other managers
+  }
+
+  // ===========================================================================
+  // EVENT ROUTING (called by systems)
+  // ===========================================================================
+
+  /**
+   * Handle a resource event (e.g. RESOURCE_SPAWNED) and route to the
+   * appropriate particle manager. Systems call this instead of knowing
+   * about individual managers.
+   */
+  handleResourceEvent(data: ParticleResourceEvent): void {
+    if (!data.id || !data.type || !data.position) return;
+
+    if (this.isWaterType(data.type)) {
+      this.waterManager.moveSpot(data.id, data.position);
+      return;
+    }
+    // Future: route to other managers
+  }
+
+  // ===========================================================================
+  // PER-FRAME UPDATE
+  // ===========================================================================
+
+  /**
+   * Drive all particle managers. Called once per frame by the owning system.
+   */
+  update(dt: number, camera: THREE.Camera): void {
+    this.waterManager.update(dt, camera);
+    // Future: this.fireManager.update(dt, camera);
+  }
+
+  // ===========================================================================
+  // CLEANUP
+  // ===========================================================================
+
+  dispose(): void {
+    this.waterManager.dispose();
+    // Future: this.fireManager.dispose();
+    console.log("[ParticleManager] Disposed all particle managers");
+  }
+
+  // ===========================================================================
+  // HELPERS
+  // ===========================================================================
+
+  private isWaterType(resourceType: string): boolean {
+    return resourceType === "fishing_spot";
+  }
+}

--- a/packages/shared/src/entities/managers/particleManager/WaterParticleManager.ts
+++ b/packages/shared/src/entities/managers/particleManager/WaterParticleManager.ts
@@ -1,0 +1,888 @@
+/**
+ * WaterParticleManager - GPU-Instanced Water / Fishing Spot Effects
+ *
+ * Centralises all fishing-spot particle + ripple rendering into 4 InstancedMeshes
+ * (splash, bubble, shimmer, ripple) driven by TSL NodeMaterials.
+ *
+ * Per-instance data is stored in named InstancedBufferAttributes:
+ *   spotPos     (vec3)  – fishing spot world center
+ *   ageLifetime (vec2)  – current age (x), total lifetime (y)
+ *   angleRadius (vec2)  – polar angle (x), radial distance (y)
+ *   dynamics    (vec4)  – peakHeight (x), size (y), speed (z), direction (w)
+ *
+ * Vertex buffer budget per particle layer = 7 of 8 max:
+ *   position(1) + uv(1) + instanceMatrix(1) + spotPos(1) + ageLifetime(1) + angleRadius(1) + dynamics(1)
+ *
+ * Ripple layer = 5 of 8 max:
+ *   position(1) + uv(1) + instanceMatrix(1) + spotPos(1) + rippleParams(1)
+ *
+ * @module WaterParticleManager
+ */
+
+import * as THREE from "../../../extras/three/three";
+import {
+  attribute,
+  uniform,
+  MeshBasicNodeMaterial,
+  uv,
+  texture,
+  float,
+  vec3,
+  mul,
+  add,
+  sub,
+  div,
+  sin,
+  cos,
+  pow,
+  min,
+  max,
+  fract,
+  step,
+  mix,
+  time,
+  positionLocal,
+} from "../../../extras/three/three";
+import type { ShaderNode } from "../../../extras/three/three";
+
+// =============================================================================
+// POOL SIZES
+// =============================================================================
+
+const MAX_SPLASH = 96;
+const MAX_BUBBLE = 72;
+const MAX_SHIMMER = 72;
+const MAX_RIPPLE = 24;
+
+// =============================================================================
+// INTERFACES
+// =============================================================================
+
+export interface FishingSpotVariant {
+  color: number;
+  rippleSpeed: number;
+  rippleCount: number;
+  splashCount: number;
+  bubbleCount: number;
+  shimmerCount: number;
+  splashColor: number;
+  bubbleColor: number;
+  shimmerColor: number;
+  burstIntervalMin: number;
+  burstIntervalMax: number;
+  burstSplashCount: number;
+}
+
+interface ActiveSpot {
+  entityId: string;
+  position: { x: number; y: number; z: number };
+  variant: FishingSpotVariant;
+  splashSlots: number[];
+  bubbleSlots: number[];
+  shimmerSlots: number[];
+  rippleSlots: number[];
+  burstTimer: number;
+}
+
+interface ParticleLayer {
+  mesh: THREE.InstancedMesh;
+  maxInstances: number;
+  freeSlots: number[];
+  spotPosArr: Float32Array;
+  ageLifetimeArr: Float32Array;
+  angleRadiusArr: Float32Array;
+  dynamicsArr: Float32Array;
+  spotPosAttr: THREE.InstancedBufferAttribute;
+  ageLifetimeAttr: THREE.InstancedBufferAttribute;
+  angleRadiusAttr: THREE.InstancedBufferAttribute;
+  dynamicsAttr: THREE.InstancedBufferAttribute;
+}
+
+interface RippleLayer {
+  mesh: THREE.InstancedMesh;
+  maxInstances: number;
+  freeSlots: number[];
+  spotPosArr: Float32Array;
+  rippleParamsArr: Float32Array;
+  spotPosAttr: THREE.InstancedBufferAttribute;
+  rippleParamsAttr: THREE.InstancedBufferAttribute;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function hexToVec3(hex: number): [number, number, number] {
+  return [
+    ((hex >> 16) & 0xff) / 255,
+    ((hex >> 8) & 0xff) / 255,
+    (hex & 0xff) / 255,
+  ];
+}
+
+export function getFishingSpotVariant(resourceId: string): FishingSpotVariant {
+  if (resourceId.includes("net")) {
+    return {
+      color: 0x88ccff,
+      rippleSpeed: 0.8,
+      rippleCount: 2,
+      splashCount: 4,
+      bubbleCount: 3,
+      shimmerCount: 3,
+      splashColor: 0xddeeff,
+      bubbleColor: 0x99ccee,
+      shimmerColor: 0xeef4ff,
+      burstIntervalMin: 5,
+      burstIntervalMax: 10,
+      burstSplashCount: 2,
+    };
+  } else if (resourceId.includes("fly")) {
+    return {
+      color: 0xaaddff,
+      rippleSpeed: 1.5,
+      rippleCount: 2,
+      splashCount: 8,
+      bubbleCount: 5,
+      shimmerCount: 5,
+      splashColor: 0xeef5ff,
+      bubbleColor: 0xaaddee,
+      shimmerColor: 0xf5faff,
+      burstIntervalMin: 2,
+      burstIntervalMax: 5,
+      burstSplashCount: 4,
+    };
+  }
+  return {
+    color: 0x66bbff,
+    rippleSpeed: 1.0,
+    rippleCount: 2,
+    splashCount: 5,
+    bubbleCount: 4,
+    shimmerCount: 4,
+    splashColor: 0xddeeff,
+    bubbleColor: 0x88ccee,
+    shimmerColor: 0xeef4ff,
+    burstIntervalMin: 3,
+    burstIntervalMax: 7,
+    burstSplashCount: 3,
+  };
+}
+
+// =============================================================================
+// MAIN CLASS
+// =============================================================================
+
+export class WaterParticleManager {
+  private scene: THREE.Scene;
+  private activeSpots = new Map<string, ActiveSpot>();
+
+  private glowTexture: THREE.DataTexture;
+  private ringTexture: THREE.DataTexture;
+
+  private uCameraRight: { value: THREE.Vector3 };
+  private uCameraUp: { value: THREE.Vector3 };
+
+  private splashLayer!: ParticleLayer;
+  private bubbleLayer!: ParticleLayer;
+  private shimmerLayer!: ParticleLayer;
+  private rippleLayer!: RippleLayer;
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+
+    this.glowTexture = this.createGlowTexture(64, 2.0);
+    this.ringTexture = this.createRingTexture(64, 0.65, 0.22);
+
+    const uRight = uniform(new THREE.Vector3(1, 0, 0));
+    const uUp = uniform(new THREE.Vector3(0, 1, 0));
+    this.uCameraRight = uRight as unknown as { value: THREE.Vector3 };
+    this.uCameraUp = uUp as unknown as { value: THREE.Vector3 };
+
+    this.splashLayer = this.createParticleLayer(MAX_SPLASH, 0xddeeff, "splash");
+    this.bubbleLayer = this.createParticleLayer(MAX_BUBBLE, 0x88ccee, "bubble");
+    this.shimmerLayer = this.createParticleLayer(
+      MAX_SHIMMER,
+      0xeef4ff,
+      "shimmer",
+    );
+    this.rippleLayer = this.createRippleLayer(MAX_RIPPLE, 0x66bbff);
+
+    console.log(
+      `[WaterParticleManager] Initialized: 4 InstancedMeshes, TSL materials`,
+    );
+  }
+
+  // ===========================================================================
+  // TEXTURE GENERATION
+  // ===========================================================================
+
+  private createGlowTexture(
+    size: number,
+    sharpness: number,
+  ): THREE.DataTexture {
+    const data = new Uint8Array(size * size * 4);
+    const half = size / 2;
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const dx = (x + 0.5 - half) / half;
+        const dy = (y + 0.5 - half) / half;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const falloff = Math.max(0, 1 - dist);
+        const strength = Math.pow(falloff, sharpness);
+        const idx = (y * size + x) * 4;
+        data[idx] = 255;
+        data[idx + 1] = 255;
+        data[idx + 2] = 255;
+        data[idx + 3] = Math.round(255 * strength);
+      }
+    }
+    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+    tex.magFilter = THREE.LinearFilter;
+    tex.minFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+    return tex;
+  }
+
+  private createRingTexture(
+    size: number,
+    ringRadius: number,
+    ringWidth: number,
+  ): THREE.DataTexture {
+    const data = new Uint8Array(size * size * 4);
+    const half = size / 2;
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const dx = (x + 0.5 - half) / half;
+        const dy = (y + 0.5 - half) / half;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const ringDist = Math.abs(dist - ringRadius) / ringWidth;
+        const strength = Math.exp(-ringDist * ringDist * 4);
+        const edgeFade = Math.min(Math.max((1 - dist) * 5, 0), 1);
+        const alpha = strength * edgeFade;
+        const idx = (y * size + x) * 4;
+        data[idx] = 255;
+        data[idx + 1] = 255;
+        data[idx + 2] = 255;
+        data[idx + 3] = Math.round(255 * alpha);
+      }
+    }
+    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
+    tex.magFilter = THREE.LinearFilter;
+    tex.minFilter = THREE.LinearFilter;
+    tex.needsUpdate = true;
+    return tex;
+  }
+
+  // ===========================================================================
+  // LAYER CREATION
+  // ===========================================================================
+
+  private createParticleLayer(
+    maxInstances: number,
+    colorHex: number,
+    layerType: "splash" | "bubble" | "shimmer",
+  ): ParticleLayer {
+    const geometry = new THREE.PlaneGeometry(1, 1);
+    geometry.deleteAttribute("normal");
+
+    const spotPosArr = new Float32Array(maxInstances * 3);
+    const ageLifetimeArr = new Float32Array(maxInstances * 2);
+    const angleRadiusArr = new Float32Array(maxInstances * 2);
+    const dynamicsArr = new Float32Array(maxInstances * 4);
+
+    for (let i = 0; i < maxInstances; i++) {
+      ageLifetimeArr[i * 2 + 1] = 1.0;
+    }
+
+    const spotPosAttr = new THREE.InstancedBufferAttribute(spotPosArr, 3);
+    const ageLifetimeAttr = new THREE.InstancedBufferAttribute(
+      ageLifetimeArr,
+      2,
+    );
+    const angleRadiusAttr = new THREE.InstancedBufferAttribute(
+      angleRadiusArr,
+      2,
+    );
+    const dynamicsAttr = new THREE.InstancedBufferAttribute(dynamicsArr, 4);
+
+    spotPosAttr.setUsage(THREE.DynamicDrawUsage);
+    ageLifetimeAttr.setUsage(THREE.DynamicDrawUsage);
+    angleRadiusAttr.setUsage(THREE.DynamicDrawUsage);
+    dynamicsAttr.setUsage(THREE.DynamicDrawUsage);
+
+    geometry.setAttribute("spotPos", spotPosAttr);
+    geometry.setAttribute("ageLifetime", ageLifetimeAttr);
+    geometry.setAttribute("angleRadius", angleRadiusAttr);
+    geometry.setAttribute("dynamics", dynamicsAttr);
+
+    const material = this.createParticleMaterial(
+      colorHex,
+      layerType,
+      this.glowTexture,
+    );
+
+    const mesh = new THREE.InstancedMesh(geometry, material, maxInstances);
+    mesh.frustumCulled = false;
+    mesh.count = maxInstances;
+
+    const identity = new THREE.Matrix4();
+    for (let i = 0; i < maxInstances; i++) {
+      mesh.setMatrixAt(i, identity);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+
+    this.scene.add(mesh);
+
+    const freeSlots: number[] = [];
+    for (let i = maxInstances - 1; i >= 0; i--) freeSlots.push(i);
+
+    return {
+      mesh,
+      maxInstances,
+      freeSlots,
+      spotPosArr,
+      ageLifetimeArr,
+      angleRadiusArr,
+      dynamicsArr,
+      spotPosAttr,
+      ageLifetimeAttr,
+      angleRadiusAttr,
+      dynamicsAttr,
+    };
+  }
+
+  private createRippleLayer(
+    maxInstances: number,
+    colorHex: number,
+  ): RippleLayer {
+    const geometry = new THREE.CircleGeometry(0.5, 24);
+    geometry.deleteAttribute("normal");
+
+    const spotPosArr = new Float32Array(maxInstances * 3);
+    const rippleParamsArr = new Float32Array(maxInstances * 2);
+
+    const spotPosAttr = new THREE.InstancedBufferAttribute(spotPosArr, 3);
+    const rippleParamsAttr = new THREE.InstancedBufferAttribute(
+      rippleParamsArr,
+      2,
+    );
+    spotPosAttr.setUsage(THREE.DynamicDrawUsage);
+    rippleParamsAttr.setUsage(THREE.DynamicDrawUsage);
+
+    geometry.setAttribute("spotPos", spotPosAttr);
+    geometry.setAttribute("rippleParams", rippleParamsAttr);
+
+    const material = this.createRippleMaterial(colorHex, this.ringTexture);
+
+    const mesh = new THREE.InstancedMesh(geometry, material, maxInstances);
+    mesh.frustumCulled = false;
+    mesh.count = maxInstances;
+
+    const identity = new THREE.Matrix4();
+    for (let i = 0; i < maxInstances; i++) {
+      mesh.setMatrixAt(i, identity);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+
+    this.scene.add(mesh);
+
+    const freeSlots: number[] = [];
+    for (let i = maxInstances - 1; i >= 0; i--) freeSlots.push(i);
+
+    return {
+      mesh,
+      maxInstances,
+      freeSlots,
+      spotPosArr,
+      rippleParamsArr,
+      spotPosAttr,
+      rippleParamsAttr,
+    };
+  }
+
+  // ===========================================================================
+  // TSL MATERIALS
+  // ===========================================================================
+
+  private createParticleMaterial(
+    colorHex: number,
+    layerType: "splash" | "bubble" | "shimmer",
+    glowTex: THREE.DataTexture,
+  ): InstanceType<typeof MeshBasicNodeMaterial> {
+    const material = new MeshBasicNodeMaterial();
+    material.transparent = true;
+    material.blending = THREE.AdditiveBlending;
+    material.depthWrite = false;
+    material.side = THREE.DoubleSide;
+
+    const spotPos = attribute("spotPos", "vec3");
+    const ageLifetime = attribute("ageLifetime", "vec2");
+    const age = ageLifetime.x;
+    const lifetime = ageLifetime.y;
+    const t = div(age, lifetime);
+
+    const angleRadius = attribute("angleRadius", "vec2");
+    const angle = angleRadius.x;
+    const radius = angleRadius.y;
+
+    const dynamics = attribute("dynamics", "vec4");
+    const peakHeight = dynamics.x;
+    const size = dynamics.y;
+    const speed = dynamics.z;
+    const direction = dynamics.w;
+
+    const camRight = this.uCameraRight as unknown as ReturnType<typeof uniform>;
+    const camUp = this.uCameraUp as unknown as ReturnType<typeof uniform>;
+
+    let particleCenter: ShaderNode;
+
+    if (layerType === "splash") {
+      const arcY = mul(peakHeight, mul(float(4), mul(t, sub(float(1), t))));
+      const ox = mul(cos(angle), radius);
+      const oz = mul(sin(angle), radius);
+      particleCenter = add(spotPos, vec3(ox, add(float(0.08), arcY), oz));
+    } else if (layerType === "bubble") {
+      const riseY = mul(t, peakHeight);
+      const wobbleFreq = mul(direction, float(4.0));
+      const drift = mul(sin(add(angle, mul(t, wobbleFreq))), radius);
+      const driftZ = mul(
+        cos(add(angle, mul(t, float(2.5)))),
+        mul(radius, float(0.6)),
+      );
+      particleCenter = add(
+        spotPos,
+        vec3(drift, add(float(0.03), riseY), driftZ),
+      );
+    } else {
+      const freq = mul(speed, mul(direction, float(6)));
+      const wanderX = mul(cos(add(angle, mul(t, freq))), radius);
+      const wanderZ = mul(sin(add(angle, mul(t, freq))), radius);
+      particleCenter = add(spotPos, vec3(wanderX, float(0.06), wanderZ));
+    }
+
+    const localXY = positionLocal.xy;
+    const billboardOffset = add(
+      mul(mul(localXY.x, size), camRight),
+      mul(mul(localXY.y, size), camUp),
+    );
+    material.positionNode = add(particleCenter, billboardOffset);
+
+    const [r, g, b] = hexToVec3(colorHex);
+    material.colorNode = vec3(float(r), float(g), float(b));
+
+    const texAlpha = texture(glowTex, uv()).a;
+
+    if (layerType === "splash") {
+      const fadeIn = min(mul(t, float(12)), float(1));
+      const fadeOut = pow(sub(float(1), t), float(1.2));
+      material.opacityNode = mul(
+        texAlpha,
+        mul(float(0.9), mul(fadeIn, fadeOut)),
+      );
+    } else if (layerType === "bubble") {
+      const fadeIn = min(mul(t, float(6)), float(1));
+      const fadeOut = pow(sub(float(1), t), float(1.2));
+      material.opacityNode = mul(
+        texAlpha,
+        mul(float(0.8), mul(fadeIn, fadeOut)),
+      );
+    } else {
+      const twinkle = max(
+        float(0),
+        mul(
+          sin(add(mul(time, float(8)), mul(angle, float(5)))),
+          sin(add(mul(time, float(13)), mul(angle, float(3)))),
+        ),
+      );
+      const envelope = mul(
+        min(mul(t, float(4)), float(1)),
+        min(mul(sub(float(1), t), float(4)), float(1)),
+      );
+      material.opacityNode = mul(
+        texAlpha,
+        mul(float(0.85), mul(twinkle, envelope)),
+      );
+    }
+
+    return material;
+  }
+
+  private createRippleMaterial(
+    colorHex: number,
+    ringTex: THREE.DataTexture,
+  ): InstanceType<typeof MeshBasicNodeMaterial> {
+    const material = new MeshBasicNodeMaterial();
+    material.transparent = true;
+    material.blending = THREE.AdditiveBlending;
+    material.depthWrite = false;
+    material.side = THREE.DoubleSide;
+
+    const spotPos = attribute("spotPos", "vec3");
+    const rippleParams = attribute("rippleParams", "vec2");
+    const phaseOffset = rippleParams.x;
+    const rippleSpeed = rippleParams.y;
+
+    const phase = fract(
+      add(mul(time, mul(rippleSpeed, float(0.5))), phaseOffset),
+    );
+
+    const scale = add(float(0.15), mul(phase, float(1.3)));
+
+    const localXY = positionLocal.xy;
+    const worldPos = add(
+      vec3(spotPos.x, add(spotPos.y, float(0.1)), spotPos.z),
+      vec3(mul(localXY.x, scale), float(0), mul(localXY.y, scale)),
+    );
+    material.positionNode = worldPos;
+
+    const [r, g, b] = hexToVec3(colorHex);
+    material.colorNode = vec3(float(r), float(g), float(b));
+
+    const texAlpha = texture(ringTex, uv()).a;
+    const earlyFade = mul(div(phase, float(0.15)), float(0.55));
+    const lateFade = mul(
+      float(0.55),
+      pow(sub(float(1), div(sub(phase, float(0.15)), float(0.85))), float(1.5)),
+    );
+    const s = step(float(0.15), phase);
+    const rippleOpacity = mix(earlyFade, lateFade, s);
+
+    material.opacityNode = mul(texAlpha, rippleOpacity);
+
+    return material;
+  }
+
+  // ===========================================================================
+  // PUBLIC API
+  // ===========================================================================
+
+  registerSpot(config: {
+    entityId: string;
+    position: { x: number; y: number; z: number };
+    resourceId: string;
+  }): void {
+    if (this.activeSpots.has(config.entityId)) return;
+
+    const variant = getFishingSpotVariant(config.resourceId);
+    const pos = config.position;
+
+    const splashSlots = this.allocSlots(this.splashLayer, variant.splashCount);
+    for (const s of splashSlots) {
+      this.writeParticle(this.splashLayer, s, pos, {
+        age: Math.random() * 1.2,
+        lifetime: 0.6 + Math.random() * 0.6,
+        angle: Math.random() * Math.PI * 2,
+        radius: 0.05 + Math.random() * 0.3,
+        peakHeight: 0.12 + Math.random() * 0.2,
+        size: 0.055,
+        speed: 0.3 + Math.random() * 0.4,
+        direction: Math.random() > 0.5 ? 1 : -1,
+      });
+    }
+
+    const bubbleSlots = this.allocSlots(this.bubbleLayer, variant.bubbleCount);
+    for (const s of bubbleSlots) {
+      this.writeParticle(this.bubbleLayer, s, pos, {
+        age: Math.random() * 2.5,
+        lifetime: 1.2 + Math.random() * 1.3,
+        angle: Math.random() * Math.PI * 2,
+        radius: 0.04 + Math.random() * 0.2,
+        peakHeight: 0.3 + Math.random() * 0.25,
+        size: 0.09,
+        speed: 0.15 + Math.random() * 0.2,
+        direction: Math.random() > 0.5 ? 1 : -1,
+      });
+    }
+
+    const shimmerSlots = this.allocSlots(
+      this.shimmerLayer,
+      variant.shimmerCount,
+    );
+    for (const s of shimmerSlots) {
+      this.writeParticle(this.shimmerLayer, s, pos, {
+        age: Math.random() * 3.0,
+        lifetime: 1.5 + Math.random() * 1.5,
+        angle: Math.random() * Math.PI * 2,
+        radius: 0.15 + Math.random() * 0.45,
+        peakHeight: 0,
+        size: 0.055,
+        speed: 0.1 + Math.random() * 0.15,
+        direction: Math.random() > 0.5 ? 1 : -1,
+      });
+    }
+
+    const rippleSlots: number[] = [];
+    for (let i = 0; i < variant.rippleCount; i++) {
+      if (this.rippleLayer.freeSlots.length === 0) break;
+      const s = this.rippleLayer.freeSlots.pop()!;
+      rippleSlots.push(s);
+      const R = this.rippleLayer;
+      R.spotPosArr[s * 3] = pos.x;
+      R.spotPosArr[s * 3 + 1] = pos.y;
+      R.spotPosArr[s * 3 + 2] = pos.z;
+      R.rippleParamsArr[s * 2] = i / variant.rippleCount;
+      R.rippleParamsArr[s * 2 + 1] = variant.rippleSpeed;
+    }
+    if (rippleSlots.length > 0) {
+      this.rippleLayer.spotPosAttr.needsUpdate = true;
+      this.rippleLayer.rippleParamsAttr.needsUpdate = true;
+    }
+
+    this.activeSpots.set(config.entityId, {
+      entityId: config.entityId,
+      position: { ...pos },
+      variant,
+      splashSlots,
+      bubbleSlots,
+      shimmerSlots,
+      rippleSlots,
+      burstTimer:
+        variant.burstIntervalMin +
+        Math.random() * (variant.burstIntervalMax - variant.burstIntervalMin),
+    });
+
+    console.log(
+      `[WaterParticles] Registered ${config.entityId}: ` +
+        `${splashSlots.length}S+${bubbleSlots.length}B+${shimmerSlots.length}Sh+${rippleSlots.length}R ` +
+        `at (${pos.x.toFixed(1)},${pos.y.toFixed(1)},${pos.z.toFixed(1)})`,
+    );
+  }
+
+  unregisterSpot(entityId: string): void {
+    const spot = this.activeSpots.get(entityId);
+    if (!spot) return;
+
+    const clearParticle = (layer: ParticleLayer, slots: number[]) => {
+      for (const s of slots) {
+        layer.dynamicsArr[s * 4 + 1] = 0;
+        layer.freeSlots.push(s);
+      }
+      if (slots.length > 0) layer.dynamicsAttr.needsUpdate = true;
+    };
+    clearParticle(this.splashLayer, spot.splashSlots);
+    clearParticle(this.bubbleLayer, spot.bubbleSlots);
+    clearParticle(this.shimmerLayer, spot.shimmerSlots);
+
+    for (const s of spot.rippleSlots) {
+      this.rippleLayer.rippleParamsArr[s * 2 + 1] = 0;
+      this.rippleLayer.freeSlots.push(s);
+    }
+    if (spot.rippleSlots.length > 0) {
+      this.rippleLayer.rippleParamsAttr.needsUpdate = true;
+    }
+
+    this.activeSpots.delete(entityId);
+  }
+
+  moveSpot(
+    entityId: string,
+    newPos: { x: number; y: number; z: number },
+  ): void {
+    const spot = this.activeSpots.get(entityId);
+    if (!spot) return;
+
+    spot.position = { ...newPos };
+
+    const updateLayer = (layer: ParticleLayer, slots: number[]) => {
+      for (const s of slots) {
+        layer.spotPosArr[s * 3] = newPos.x;
+        layer.spotPosArr[s * 3 + 1] = newPos.y;
+        layer.spotPosArr[s * 3 + 2] = newPos.z;
+      }
+      if (slots.length > 0) layer.spotPosAttr.needsUpdate = true;
+    };
+    updateLayer(this.splashLayer, spot.splashSlots);
+    updateLayer(this.bubbleLayer, spot.bubbleSlots);
+    updateLayer(this.shimmerLayer, spot.shimmerSlots);
+
+    for (const s of spot.rippleSlots) {
+      this.rippleLayer.spotPosArr[s * 3] = newPos.x;
+      this.rippleLayer.spotPosArr[s * 3 + 1] = newPos.y;
+      this.rippleLayer.spotPosArr[s * 3 + 2] = newPos.z;
+    }
+    if (spot.rippleSlots.length > 0) {
+      this.rippleLayer.spotPosAttr.needsUpdate = true;
+    }
+  }
+
+  update(dt: number, camera: THREE.Camera): void {
+    if (this.activeSpots.size === 0) return;
+
+    const right = new THREE.Vector3();
+    const up = new THREE.Vector3();
+    const fwd = new THREE.Vector3();
+    camera.matrixWorld.extractBasis(right, up, fwd);
+    this.uCameraRight.value.copy(right);
+    this.uCameraUp.value.copy(up);
+
+    let splashALDirty = false;
+    let splashARDirty = false;
+    let splashDynDirty = false;
+    let bubbleALDirty = false;
+    let bubbleARDirty = false;
+    let bubbleDynDirty = false;
+    let shimmerALDirty = false;
+    let shimmerARDirty = false;
+
+    for (const spot of this.activeSpots.values()) {
+      for (const s of spot.splashSlots) {
+        const L = this.splashLayer;
+        const al = L.ageLifetimeArr;
+        al[s * 2] += dt;
+        if (al[s * 2] >= al[s * 2 + 1]) {
+          al[s * 2] -= al[s * 2 + 1];
+          al[s * 2 + 1] = 0.6 + Math.random() * 0.6;
+          L.angleRadiusArr[s * 2] = Math.random() * Math.PI * 2;
+          L.angleRadiusArr[s * 2 + 1] = 0.05 + Math.random() * 0.3;
+          L.dynamicsArr[s * 4] = 0.12 + Math.random() * 0.2;
+          splashARDirty = true;
+          splashDynDirty = true;
+        }
+        splashALDirty = true;
+      }
+
+      for (const s of spot.bubbleSlots) {
+        const L = this.bubbleLayer;
+        const al = L.ageLifetimeArr;
+        al[s * 2] += dt;
+        if (al[s * 2] >= al[s * 2 + 1]) {
+          al[s * 2] -= al[s * 2 + 1];
+          L.angleRadiusArr[s * 2] = Math.random() * Math.PI * 2;
+          L.angleRadiusArr[s * 2 + 1] = 0.04 + Math.random() * 0.2;
+          L.dynamicsArr[s * 4] = 0.3 + Math.random() * 0.25;
+          bubbleARDirty = true;
+          bubbleDynDirty = true;
+        }
+        bubbleALDirty = true;
+      }
+
+      for (const s of spot.shimmerSlots) {
+        const L = this.shimmerLayer;
+        const al = L.ageLifetimeArr;
+        al[s * 2] += dt;
+        if (al[s * 2] >= al[s * 2 + 1]) {
+          al[s * 2] -= al[s * 2 + 1];
+          L.angleRadiusArr[s * 2] = Math.random() * Math.PI * 2;
+          shimmerARDirty = true;
+        }
+        shimmerALDirty = true;
+      }
+
+      spot.burstTimer -= dt;
+      if (spot.burstTimer <= 0) {
+        const v = spot.variant;
+        spot.burstTimer =
+          v.burstIntervalMin +
+          Math.random() * (v.burstIntervalMax - v.burstIntervalMin);
+        this.fireBurst(spot);
+        splashALDirty = true;
+        splashARDirty = true;
+        splashDynDirty = true;
+      }
+    }
+
+    if (splashALDirty) this.splashLayer.ageLifetimeAttr.needsUpdate = true;
+    if (splashARDirty) this.splashLayer.angleRadiusAttr.needsUpdate = true;
+    if (splashDynDirty) this.splashLayer.dynamicsAttr.needsUpdate = true;
+    if (bubbleALDirty) this.bubbleLayer.ageLifetimeAttr.needsUpdate = true;
+    if (bubbleARDirty) this.bubbleLayer.angleRadiusAttr.needsUpdate = true;
+    if (bubbleDynDirty) this.bubbleLayer.dynamicsAttr.needsUpdate = true;
+    if (shimmerALDirty) this.shimmerLayer.ageLifetimeAttr.needsUpdate = true;
+    if (shimmerARDirty) this.shimmerLayer.angleRadiusAttr.needsUpdate = true;
+  }
+
+  dispose(): void {
+    const disposeMesh = (mesh: THREE.InstancedMesh) => {
+      this.scene.remove(mesh);
+      mesh.geometry.dispose();
+      if (Array.isArray(mesh.material)) {
+        mesh.material.forEach((m) => m.dispose());
+      } else {
+        mesh.material.dispose();
+      }
+    };
+
+    disposeMesh(this.splashLayer.mesh);
+    disposeMesh(this.bubbleLayer.mesh);
+    disposeMesh(this.shimmerLayer.mesh);
+    disposeMesh(this.rippleLayer.mesh);
+
+    this.glowTexture.dispose();
+    this.ringTexture.dispose();
+    this.activeSpots.clear();
+  }
+
+  // ===========================================================================
+  // PRIVATE HELPERS
+  // ===========================================================================
+
+  private allocSlots(layer: ParticleLayer, count: number): number[] {
+    const slots: number[] = [];
+    for (let i = 0; i < count; i++) {
+      if (layer.freeSlots.length === 0) break;
+      slots.push(layer.freeSlots.pop()!);
+    }
+    return slots;
+  }
+
+  private writeParticle(
+    layer: ParticleLayer,
+    slot: number,
+    pos: { x: number; y: number; z: number },
+    p: {
+      age: number;
+      lifetime: number;
+      angle: number;
+      radius: number;
+      peakHeight: number;
+      size: number;
+      speed: number;
+      direction: number;
+    },
+  ): void {
+    const s = slot;
+    layer.spotPosArr[s * 3] = pos.x;
+    layer.spotPosArr[s * 3 + 1] = pos.y;
+    layer.spotPosArr[s * 3 + 2] = pos.z;
+    layer.ageLifetimeArr[s * 2] = p.age;
+    layer.ageLifetimeArr[s * 2 + 1] = p.lifetime;
+    layer.angleRadiusArr[s * 2] = p.angle;
+    layer.angleRadiusArr[s * 2 + 1] = p.radius;
+    layer.dynamicsArr[s * 4] = p.peakHeight;
+    layer.dynamicsArr[s * 4 + 1] = p.size;
+    layer.dynamicsArr[s * 4 + 2] = p.speed;
+    layer.dynamicsArr[s * 4 + 3] = p.direction;
+
+    layer.spotPosAttr.needsUpdate = true;
+    layer.ageLifetimeAttr.needsUpdate = true;
+    layer.angleRadiusAttr.needsUpdate = true;
+    layer.dynamicsAttr.needsUpdate = true;
+  }
+
+  private fireBurst(spot: ActiveSpot): void {
+    const burstAngle = Math.random() * Math.PI * 2;
+    const burstR = 0.05 + Math.random() * 0.15;
+    const cx = Math.cos(burstAngle) * burstR;
+    const cz = Math.sin(burstAngle) * burstR;
+    let fired = 0;
+    const L = this.splashLayer;
+
+    for (const s of spot.splashSlots) {
+      if (fired >= spot.variant.burstSplashCount) break;
+      const t = L.ageLifetimeArr[s * 2] / L.ageLifetimeArr[s * 2 + 1];
+      if (t > 0.6) {
+        L.ageLifetimeArr[s * 2] = 0;
+        const spread = 0.06;
+        L.angleRadiusArr[s * 2] = Math.atan2(
+          cz + (Math.random() - 0.5) * spread,
+          cx + (Math.random() - 0.5) * spread,
+        );
+        L.angleRadiusArr[s * 2 + 1] =
+          Math.sqrt(cx * cx + cz * cz) + (Math.random() - 0.5) * 0.08;
+        L.dynamicsArr[s * 4] = 0.25 + Math.random() * 0.35;
+        L.ageLifetimeArr[s * 2 + 1] = 0.5 + Math.random() * 0.4;
+        fired++;
+      }
+    }
+  }
+}

--- a/packages/shared/src/entities/managers/particleManager/index.ts
+++ b/packages/shared/src/entities/managers/particleManager/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Particle Manager
+ * GPU-instanced particle systems managed by the central ParticleManager.
+ */
+
+export { ParticleManager } from "./ParticleManager";
+export type {
+  ParticleSpotConfig,
+  ParticleResourceEvent,
+} from "./ParticleManager";
+export { WaterParticleManager } from "./WaterParticleManager";
+export type { FishingSpotVariant } from "./WaterParticleManager";

--- a/packages/shared/src/entities/world/ResourceEntity.ts
+++ b/packages/shared/src/entities/world/ResourceEntity.ts
@@ -68,86 +68,22 @@ import {
   type TileCoord,
 } from "../../systems/shared/movement/TileSystem";
 import { FOOTPRINT_SIZES } from "../../types/game/resource-processing-types";
+import type { ParticleManager } from "../managers/particleManager";
 
 // Re-export types for external use
 export type { ResourceEntityConfig } from "../../types/entities";
-
-// Fishing spot particle layer types
-const FISHING_LAYER_SPLASH = 0;
-const FISHING_LAYER_BUBBLE = 1;
-const FISHING_LAYER_SHIMMER = 2;
-const FISHING_PARTICLE_SIZE = 0.055;
-const FISHING_BUBBLE_SIZE = 0.09;
-
-// Splash arc animation: y = peakHeight * PARABOLIC_SCALE * t * (1-t), peaks at t=0.5
-const SPLASH_PARABOLIC_SCALE = 4;
-// How fast splash particles pop in (higher = snappier)
-const SPLASH_FADE_IN_RATE = 12;
-// Bubble lateral wobble frequency multiplier
-const BUBBLE_WOBBLE_FREQ = 4.0;
-
-interface FishingParticleState {
-  types: Uint8Array;
-  ages: Float32Array;
-  lifetimes: Float32Array;
-  angles: Float32Array;
-  speeds: Float32Array;
-  radii: Float32Array;
-  directions: Int8Array;
-  peakHeights: Float32Array;
-  worldX: number;
-  worldY: number;
-  worldZ: number;
-  /** Countdown until next fish activity burst (seconds) */
-  burstTimer: number;
-  /** Min/max interval between bursts (seconds) */
-  burstIntervalMin: number;
-  burstIntervalMax: number;
-  /** Number of splash particles to fire per burst */
-  burstSplashCount: number;
-  /** Index range of splash particles [start, end) */
-  splashStart: number;
-  splashEnd: number;
-}
-
-interface FishingSpotVariant {
-  color: number;
-  rippleSpeed: number;
-  rippleCount: number;
-  splashCount: number;
-  bubbleCount: number;
-  shimmerCount: number;
-  splashColor: number;
-  bubbleColor: number;
-  shimmerColor: number;
-  burstIntervalMin: number;
-  burstIntervalMax: number;
-  burstSplashCount: number;
-}
 
 export class ResourceEntity extends InteractableEntity {
   public config: ResourceEntityConfig;
   private respawnTimer?: NodeJS.Timeout;
   /** Glow indicator mesh for fishing spot visibility from distance (client-only) */
   private glowMesh?: THREE.Mesh;
-  /** Ripple rings for animated fishing spot effect (client-only) */
-  private rippleRings?: THREE.Mesh[];
-  /** Billboard particle meshes for fishing spot effects (client-only, world-space) */
-  private particleMeshes: THREE.Mesh[] = [];
-  /** Per-particle animation state (typed arrays for zero-allocation updates) */
-  private particleState: FishingParticleState | null = null;
-  /** Ripple animation speed (stored from variant for clientUpdate use) */
-  private fishingRippleSpeed = 1.0;
-  /** Shared billboard geometry for fishing particles */
-  private static particleGeometry: THREE.CircleGeometry | null = null;
+  /** Whether this fishing spot has been registered with the centralized particle manager */
+  private _registeredWithParticleManager = false;
   /** Cache for DataTextures keyed by generation parameters to avoid duplicates */
   private static textureCache = new Map<string, THREE.DataTexture>();
-  /** Dispose shared static resources (geometry + texture cache). Call on world teardown. */
+  /** Dispose shared static resources (texture cache). Call on world teardown. */
   static disposeSharedResources(): void {
-    if (ResourceEntity.particleGeometry) {
-      ResourceEntity.particleGeometry.dispose();
-      ResourceEntity.particleGeometry = null;
-    }
     for (const tex of ResourceEntity.textureCache.values()) {
       tex.dispose();
     }
@@ -562,119 +498,49 @@ export class ResourceEntity extends InteractableEntity {
 
   /**
    * Create animated visual for fishing spots.
-   * Uses expanding ripple rings and a glowing indicator.
-   * Different fishing methods have distinct visual variations.
+   * Glow indicator stays on entity node for interaction detection.
+   * All particle/ripple effects handled by centralized ParticleManager → WaterParticleManager.
    */
   private createFishingSpotVisual(): void {
-    // Get variant-specific settings based on fishing type
-    const variant = this.getFishingSpotVariant();
-    this.fishingRippleSpeed = variant.rippleSpeed;
-
     // Create the glow indicator (interaction hitbox + distant visibility)
     this.createGlowIndicator();
 
-    // Create animated ripple rings (animated via clientUpdate)
-    this.createRippleRings(variant);
+    // Try to register with centralized particle manager (may not exist yet)
+    this.tryRegisterWithParticleManager();
 
-    // Create billboard particle effects (splash, bubble, shimmer)
-    this.createFishingSpotParticles(variant);
-
-    // Register for frame updates (ripples + particles)
+    // Register for frame updates (glow pulse + lazy particle registration)
     this.world.setHot(this, true);
   }
 
   /**
-   * Get visual variant settings based on fishing spot type.
-   * Net = calm/gentle, Bait = medium, Fly = more active.
+   * Attempt to register this fishing spot with the centralized particle manager.
+   * Called initially from createFishingSpotVisual, and retried from clientUpdate
+   * if the manager wasn't available yet (timing/lifecycle issue where entity init
+   * runs before ResourceSystem.start() creates the manager).
    */
-  private getFishingSpotVariant(): FishingSpotVariant {
-    const resourceId = this.config.resourceId || "";
+  public tryRegisterWithParticleManager(): boolean {
+    if (this._registeredWithParticleManager) return true;
 
-    if (resourceId.includes("net")) {
-      // Calm, gentle ripples (shallow water fishing)
-      return {
-        color: 0x88ccff,
-        rippleSpeed: 0.8,
-        rippleCount: 2,
-        splashCount: 4,
-        bubbleCount: 3,
-        shimmerCount: 3,
-        splashColor: 0xddeeff,
-        bubbleColor: 0x99ccee,
-        shimmerColor: 0xeef4ff,
-        burstIntervalMin: 5,
-        burstIntervalMax: 10,
-        burstSplashCount: 2,
-      };
-    } else if (resourceId.includes("fly")) {
-      // More active (river/moving water)
-      return {
-        color: 0xaaddff,
-        rippleSpeed: 1.5,
-        rippleCount: 2,
-        splashCount: 8,
-        bubbleCount: 5,
-        shimmerCount: 5,
-        splashColor: 0xeef5ff,
-        bubbleColor: 0xaaddee,
-        shimmerColor: 0xf5faff,
-        burstIntervalMin: 2,
-        burstIntervalMax: 5,
-        burstSplashCount: 4,
-      };
-    }
-    // Default: bait (medium activity)
-    return {
-      color: 0x66bbff,
-      rippleSpeed: 1.0,
-      rippleCount: 2,
-      splashCount: 5,
-      bubbleCount: 4,
-      shimmerCount: 4,
-      splashColor: 0xddeeff,
-      bubbleColor: 0x88ccee,
-      shimmerColor: 0xeef4ff,
-      burstIntervalMin: 3,
-      burstIntervalMax: 7,
-      burstSplashCount: 3,
-    };
+    const pm = this.getParticleManager();
+    if (!pm) return false;
+
+    const pos = this.getPosition();
+    pm.registerSpot({
+      entityId: this.id,
+      position: { x: pos.x, y: pos.y, z: pos.z },
+      resourceType: this.config.resourceType || "",
+      resourceId: this.config.resourceId || "",
+    });
+    this._registeredWithParticleManager = true;
+    return true;
   }
 
-  /**
-   * Create expanding ripple ring meshes for water effect.
-   */
-  private createRippleRings(variant: {
-    color: number;
-    rippleCount: number;
-  }): void {
-    this.rippleRings = [];
-
-    for (let i = 0; i < variant.rippleCount; i++) {
-      const geometry = new THREE.CircleGeometry(0.5, 24);
-      const tex = ResourceEntity.createRingTexture(
-        variant.color,
-        64,
-        0.65,
-        0.22,
-      );
-      const material = new THREE.MeshBasicMaterial({
-        map: tex,
-        transparent: true,
-        opacity: 0,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
-        side: THREE.DoubleSide,
-        fog: false,
-      });
-
-      const ring = new THREE.Mesh(geometry, material);
-      ring.rotation.x = -Math.PI / 2; // Horizontal
-      ring.position.y = 0.1; // Just above water surface
-      ring.name = `FishingSpotRipple_${i}`;
-
-      this.node.add(ring);
-      this.rippleRings.push(ring);
-    }
+  /** Access the centralized ParticleManager from the ResourceSystem. */
+  private getParticleManager(): ParticleManager | undefined {
+    const sys = this.world.getSystem("resource") as {
+      particleManager?: ParticleManager;
+    } | null;
+    return sys?.particleManager;
   }
 
   /**
@@ -720,422 +586,29 @@ export class ResourceEntity extends InteractableEntity {
   }
 
   /**
-   * Create a DataTexture with a soft Gaussian ring pattern.
-   * Used for natural-looking water ripples — transparent center, bright ring
-   * band at `ringRadius`, transparent edges with smooth falloff.
+   * Per-frame animation for fishing spot glow pulse.
+   * Particles and ripples are handled by the centralized ParticleManager → WaterParticleManager.
    */
-  private static createRingTexture(
-    colorHex: number,
-    size: number,
-    ringRadius: number,
-    ringWidth: number,
-  ): THREE.DataTexture {
-    const key = `ring:${colorHex}:${size}:${ringRadius}:${ringWidth}`;
-    const cached = ResourceEntity.textureCache.get(key);
-    if (cached) return cached;
+  protected clientUpdate(_deltaTime: number): void {
+    super.clientUpdate(_deltaTime);
 
-    const r = (colorHex >> 16) & 0xff;
-    const g = (colorHex >> 8) & 0xff;
-    const b = colorHex & 0xff;
-    const data = new Uint8Array(size * size * 4);
-    const half = size / 2;
-
-    for (let y = 0; y < size; y++) {
-      for (let x = 0; x < size; x++) {
-        const dx = (x + 0.5 - half) / half;
-        const dy = (y + 0.5 - half) / half;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-
-        // Gaussian falloff around the ring radius
-        const ringDist = Math.abs(dist - ringRadius) / ringWidth;
-        const strength = Math.exp(-ringDist * ringDist * 4);
-
-        // Soft fade at outer boundary
-        const edgeFade = Math.min(Math.max((1 - dist) * 5, 0), 1);
-
-        const alpha = strength * edgeFade;
-        const idx = (y * size + x) * 4;
-        data[idx] = Math.round(r * alpha);
-        data[idx + 1] = Math.round(g * alpha);
-        data[idx + 2] = Math.round(b * alpha);
-        data[idx + 3] = Math.round(255 * alpha);
-      }
-    }
-
-    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-    tex.magFilter = THREE.LinearFilter;
-    tex.minFilter = THREE.LinearFilter;
-    tex.needsUpdate = true;
-    ResourceEntity.textureCache.set(key, tex);
-    return tex;
-  }
-
-  /**
-   * Create an additive-blended glow material with color baked into the texture.
-   */
-  private static createFishingGlowMaterial(
-    colorHex: number,
-    sharpness: number,
-    initialOpacity: number,
-  ): THREE.MeshBasicMaterial {
-    const tex = ResourceEntity.createColoredGlowTexture(
-      colorHex,
-      64,
-      sharpness,
-    );
-
-    return new THREE.MeshBasicMaterial({
-      map: tex,
-      transparent: true,
-      opacity: initialOpacity,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-      depthTest: true,
-      side: THREE.DoubleSide,
-      fog: false,
-    });
-  }
-
-  /** Get or create shared unit CircleGeometry for billboard particles */
-  private static getFishingParticleGeometry(): THREE.CircleGeometry {
-    if (!ResourceEntity.particleGeometry) {
-      ResourceEntity.particleGeometry = new THREE.CircleGeometry(0.5, 16);
-    }
-    return ResourceEntity.particleGeometry;
-  }
-
-  /**
-   * Create billboard particle effects for a fishing spot.
-   * Three layers: splash droplets, bubbles, and surface shimmer.
-   */
-  private createFishingSpotParticles(variant: FishingSpotVariant): void {
-    const scene = this.world.stage?.scene;
-    if (!scene) return;
-
-    const pos = this.getPosition();
-    const worldX = pos.x;
-    const worldY = pos.y;
-    const worldZ = pos.z;
-
-    const total =
-      variant.splashCount + variant.bubbleCount + variant.shimmerCount;
-    const types = new Uint8Array(total);
-    const ages = new Float32Array(total);
-    const lifetimes = new Float32Array(total);
-    const angles = new Float32Array(total);
-    const speeds = new Float32Array(total);
-    const radii = new Float32Array(total);
-    const directions = new Int8Array(total);
-    const peakHeights = new Float32Array(total);
-
-    const geomRef = ResourceEntity.getFishingParticleGeometry();
-    let idx = 0;
-    const splashStart = 0;
-
-    const addParticle = (mat: THREE.MeshBasicMaterial): THREE.Mesh => {
-      const particle = new THREE.Mesh(geomRef, mat);
-      particle.renderOrder = 999;
-      particle.frustumCulled = false;
-      particle.layers.set(1);
-      scene.add(particle);
-      this.particleMeshes.push(particle);
-      return particle;
-    };
-
-    // --- SPLASH: water droplets popping up in parabolic arcs ---
-    for (let i = 0; i < variant.splashCount; i++, idx++) {
-      types[idx] = FISHING_LAYER_SPLASH;
-      lifetimes[idx] = 0.6 + Math.random() * 0.6;
-      ages[idx] = Math.random() * lifetimes[idx];
-      angles[idx] = Math.random() * Math.PI * 2;
-      speeds[idx] = 0.3 + Math.random() * 0.4;
-      radii[idx] = 0.05 + Math.random() * 0.3;
-      directions[idx] = Math.random() > 0.5 ? 1 : -1;
-      peakHeights[idx] = 0.12 + Math.random() * 0.2;
-
-      const mat = ResourceEntity.createFishingGlowMaterial(
-        variant.splashColor,
-        2.5,
-        0.8,
-      );
-      const particle = addParticle(mat);
-      particle.scale.set(
-        FISHING_PARTICLE_SIZE,
-        FISHING_PARTICLE_SIZE,
-        FISHING_PARTICLE_SIZE,
-      );
-    }
-    const splashEnd = idx;
-
-    // --- BUBBLE: gentle rise from below water surface ---
-    for (let i = 0; i < variant.bubbleCount; i++, idx++) {
-      types[idx] = FISHING_LAYER_BUBBLE;
-      lifetimes[idx] = 1.2 + Math.random() * 1.3;
-      ages[idx] = Math.random() * lifetimes[idx];
-      angles[idx] = Math.random() * Math.PI * 2;
-      speeds[idx] = 0.15 + Math.random() * 0.2;
-      radii[idx] = 0.04 + Math.random() * 0.2;
-      directions[idx] = Math.random() > 0.5 ? 1 : -1;
-      peakHeights[idx] = 0.3 + Math.random() * 0.25;
-
-      const mat = ResourceEntity.createFishingGlowMaterial(
-        variant.bubbleColor,
-        1.8,
-        0.6,
-      );
-      const particle = addParticle(mat);
-      particle.scale.set(
-        FISHING_BUBBLE_SIZE,
-        FISHING_BUBBLE_SIZE,
-        FISHING_BUBBLE_SIZE,
-      );
-    }
-
-    // --- SHIMMER: surface glints on the water plane ---
-    for (let i = 0; i < variant.shimmerCount; i++, idx++) {
-      types[idx] = FISHING_LAYER_SHIMMER;
-      lifetimes[idx] = 1.5 + Math.random() * 1.5;
-      ages[idx] = Math.random() * lifetimes[idx];
-      angles[idx] = Math.random() * Math.PI * 2;
-      speeds[idx] = 0.1 + Math.random() * 0.15;
-      radii[idx] = 0.15 + Math.random() * 0.45;
-      directions[idx] = Math.random() > 0.5 ? 1 : -1;
-      peakHeights[idx] = 0;
-
-      const mat = ResourceEntity.createFishingGlowMaterial(
-        variant.shimmerColor,
-        3.5,
-        0.7,
-      );
-      const particle = addParticle(mat);
-      particle.scale.set(
-        FISHING_PARTICLE_SIZE,
-        FISHING_PARTICLE_SIZE,
-        FISHING_PARTICLE_SIZE,
-      );
-    }
-
-    this.particleState = {
-      types,
-      ages,
-      lifetimes,
-      angles,
-      speeds,
-      radii,
-      directions,
-      peakHeights,
-      worldX,
-      worldY,
-      worldZ,
-      burstTimer:
-        variant.burstIntervalMin +
-        Math.random() * (variant.burstIntervalMax - variant.burstIntervalMin),
-      burstIntervalMin: variant.burstIntervalMin,
-      burstIntervalMax: variant.burstIntervalMax,
-      burstSplashCount: variant.burstSplashCount,
-      splashStart,
-      splashEnd,
-    };
-  }
-
-  /**
-   * Per-frame animation for fishing spot ripple rings and billboard particles.
-   */
-  protected clientUpdate(deltaTime: number): void {
-    super.clientUpdate(deltaTime);
-    const now = Date.now();
-
-    // Animate ripple rings with per-ring position jitter
-    if (this.rippleRings && this.rippleRings.length > 0) {
-      const rippleCount = this.rippleRings.length;
-      const cycleDuration = 2000 / this.fishingRippleSpeed;
-
-      for (let i = 0; i < rippleCount; i++) {
-        const ring = this.rippleRings[i];
-        if (!ring) continue;
-
-        const phase = (now / cycleDuration + i / rippleCount) % 1;
-
-        // Uniform scale for all rings — consistent expansion
-        const scale = 0.15 + phase * 1.3;
-        ring.scale.set(scale, scale, 1);
-
-        // Centered — no position jitter
-        ring.position.x = 0;
-        ring.position.z = 0;
-
-        // Smooth fade in/out — brighter peak for visibility
-        let opacity: number;
-        if (phase < 0.15) {
-          opacity = (phase / 0.15) * 0.55;
-        } else {
-          opacity = 0.55 * Math.pow(1 - (phase - 0.15) / 0.85, 1.5);
-        }
-        (ring.material as THREE.MeshBasicMaterial).opacity = opacity;
+    // Lazy registration: retry if particle manager wasn't ready during createFishingSpotVisual
+    if (
+      !this._registeredWithParticleManager &&
+      this.config.resourceType === "fishing_spot"
+    ) {
+      if (this.tryRegisterWithParticleManager()) {
+        console.log(`[FishingSpot] Late registration succeeded for ${this.id}`);
       }
     }
 
     // Organic glow pulse — two frequencies layered for natural breathing
     if (this.glowMesh) {
+      const now = Date.now();
       const slow = Math.sin(now * 0.0015) * 0.04;
       const fast = Math.sin(now * 0.004 + 1.3) * 0.02;
       const pulse = 0.18 + slow + fast;
       (this.glowMesh.material as THREE.MeshBasicMaterial).opacity = pulse;
-    }
-
-    // Animate fishing spot particles
-    if (!this.particleState || this.particleMeshes.length === 0) return;
-
-    const state = this.particleState;
-    const {
-      types,
-      ages,
-      lifetimes,
-      angles,
-      speeds,
-      radii,
-      directions,
-      peakHeights,
-      worldX,
-      worldY,
-      worldZ,
-    } = state;
-    const count = ages.length;
-    const cam = this.world.camera;
-    const camQuat = cam?.quaternion;
-
-    // --- Fish activity burst system ---
-    state.burstTimer -= deltaTime;
-    if (state.burstTimer <= 0) {
-      // Reset timer for next burst
-      state.burstTimer =
-        state.burstIntervalMin +
-        Math.random() * (state.burstIntervalMax - state.burstIntervalMin);
-
-      // Fire a cluster of splash particles simultaneously from a random point
-      const burstAngle = Math.random() * Math.PI * 2;
-      const burstR = 0.05 + Math.random() * 0.15;
-      const burstCenterX = Math.cos(burstAngle) * burstR;
-      const burstCenterZ = Math.sin(burstAngle) * burstR;
-      let fired = 0;
-
-      for (
-        let i = state.splashStart;
-        i < state.splashEnd && fired < state.burstSplashCount;
-        i++
-      ) {
-        // Pick splash particles that are past 60% of their life (nearly done)
-        if (ages[i] / lifetimes[i] > 0.6) {
-          ages[i] = 0;
-          // Cluster around burst center with slight spread
-          const spread = 0.06;
-          angles[i] = Math.atan2(
-            burstCenterZ + (Math.random() - 0.5) * spread,
-            burstCenterX + (Math.random() - 0.5) * spread,
-          );
-          radii[i] =
-            Math.sqrt(
-              burstCenterX * burstCenterX + burstCenterZ * burstCenterZ,
-            ) +
-            (Math.random() - 0.5) * 0.08;
-          // Burst splashes are taller
-          peakHeights[i] = 0.25 + Math.random() * 0.35;
-          lifetimes[i] = 0.5 + Math.random() * 0.4;
-          fired++;
-        }
-      }
-    }
-
-    for (let i = 0; i < count; i++) {
-      ages[i] += deltaTime;
-      const particle = this.particleMeshes[i];
-      const mat = particle.material as THREE.MeshBasicMaterial;
-      const layer = types[i];
-
-      // Billboard: face the camera
-      if (camQuat) {
-        particle.quaternion.copy(camQuat);
-      }
-
-      // Respawn when lifetime expires
-      if (ages[i] >= lifetimes[i]) {
-        ages[i] -= lifetimes[i];
-        angles[i] = Math.random() * Math.PI * 2;
-        if (layer === FISHING_LAYER_SPLASH) {
-          radii[i] = 0.05 + Math.random() * 0.3;
-          peakHeights[i] = 0.12 + Math.random() * 0.2;
-          lifetimes[i] = 0.6 + Math.random() * 0.6;
-        } else if (layer === FISHING_LAYER_BUBBLE) {
-          radii[i] = 0.04 + Math.random() * 0.2;
-          peakHeights[i] = 0.3 + Math.random() * 0.25;
-        }
-      }
-
-      const t = ages[i] / lifetimes[i];
-
-      if (layer === FISHING_LAYER_SPLASH) {
-        const arcY = peakHeights[i] * SPLASH_PARABOLIC_SCALE * t * (1 - t);
-        const offsetX = Math.cos(angles[i]) * radii[i];
-        const offsetZ = Math.sin(angles[i]) * radii[i];
-        particle.position.set(
-          worldX + offsetX,
-          worldY + 0.08 + arcY,
-          worldZ + offsetZ,
-        );
-        particle.scale.set(
-          FISHING_PARTICLE_SIZE,
-          FISHING_PARTICLE_SIZE,
-          FISHING_PARTICLE_SIZE,
-        );
-        // Snappy pop-in, smooth fade as it arcs down
-        const fadeIn = Math.min(t * SPLASH_FADE_IN_RATE, 1);
-        const fadeOut = Math.pow(1 - t, 1.2);
-        mat.opacity = 0.9 * fadeIn * fadeOut;
-      } else if (layer === FISHING_LAYER_BUBBLE) {
-        // Rise gently with wobbly lateral drift
-        const riseY = t * peakHeights[i];
-        const wobbleFreq = directions[i] * BUBBLE_WOBBLE_FREQ;
-        const drift = Math.sin(angles[i] + t * wobbleFreq) * radii[i];
-        const driftZ = Math.cos(angles[i] + t * 2.5) * radii[i] * 0.6;
-        particle.position.set(
-          worldX + drift,
-          worldY + 0.03 + riseY,
-          worldZ + driftZ,
-        );
-        particle.scale.set(
-          FISHING_BUBBLE_SIZE,
-          FISHING_BUBBLE_SIZE,
-          FISHING_BUBBLE_SIZE,
-        );
-        const fadeIn = Math.min(t * 6, 1);
-        const fadeOut = Math.pow(1 - t, 1.2);
-        mat.opacity = 0.8 * fadeIn * fadeOut;
-      } else {
-        // Shimmer: sparkle on water surface with fast twinkle
-        const wanderX =
-          Math.cos(angles[i] + t * speeds[i] * directions[i] * 6) * radii[i];
-        const wanderZ =
-          Math.sin(angles[i] + t * speeds[i] * directions[i] * 6) * radii[i];
-        particle.position.set(
-          worldX + wanderX,
-          worldY + 0.06,
-          worldZ + wanderZ,
-        );
-        particle.scale.set(
-          FISHING_PARTICLE_SIZE,
-          FISHING_PARTICLE_SIZE,
-          FISHING_PARTICLE_SIZE,
-        );
-        // Fast twinkle using global time for continuous sparkle
-        const twinkle = Math.max(
-          0,
-          Math.sin(now * 0.008 + angles[i] * 5) *
-            Math.sin(now * 0.013 + angles[i] * 3),
-        );
-        // Lifetime fade envelope
-        const envelope = Math.min(t * 4, 1) * Math.min((1 - t) * 4, 1);
-        mat.opacity = 0.85 * twinkle * envelope;
-      }
     }
   }
 
@@ -1185,31 +658,19 @@ export class ResourceEntity extends InteractableEntity {
       this.respawnTimer = undefined;
     }
 
-    // Unregister from frame updates (fishing spots use setHot for animation)
-    if (this.rippleRings || this.particleMeshes.length > 0) {
+    // Clean up fishing spot resources
+    if (this.config.resourceType === "fishing_spot") {
+      // Unregister from centralized particle manager
+      if (this._registeredWithParticleManager) {
+        const pm = this.getParticleManager();
+        if (pm) {
+          pm.unregisterSpot(this.id, this.config.resourceType || "");
+        }
+        this._registeredWithParticleManager = false;
+      }
+
+      // Unregister from frame updates (glow pulse)
       this.world.setHot(this, false);
-    }
-
-    // Clean up fishing spot particles (world-space billboard meshes)
-    // Note: textures are not disposed here — they are shared via textureCache
-    if (this.particleMeshes.length > 0) {
-      const scene = this.world.stage?.scene;
-      for (const mesh of this.particleMeshes) {
-        if (scene) scene.remove(mesh);
-        (mesh.material as THREE.Material).dispose();
-      }
-      this.particleMeshes = [];
-      this.particleState = null;
-    }
-
-    // Clean up ripple rings (fishing spots, node-local)
-    if (this.rippleRings) {
-      for (const ring of this.rippleRings) {
-        ring.geometry.dispose();
-        (ring.material as THREE.Material).dispose();
-        this.node.remove(ring);
-      }
-      this.rippleRings = undefined;
     }
 
     // Clean up glow mesh (fishing spots, node-local)

--- a/packages/shared/src/systems/shared/entities/ResourceSystem.ts
+++ b/packages/shared/src/systems/shared/entities/ResourceSystem.ts
@@ -3,6 +3,7 @@ import { TerrainSystem } from "..";
 import { uuid } from "../../../utils";
 import type { World } from "../../../types";
 import { ResourceEntity } from "../../../entities/world/ResourceEntity";
+import { ParticleManager } from "../../../entities/managers/particleManager";
 import { EventType } from "../../../types/events";
 import { Resource, ResourceDrop } from "../../../types/core/core";
 import { PlayerID, ResourceID } from "../../../types/core/identifiers";
@@ -113,6 +114,9 @@ interface ResourceEntityMethods {
  * @see resources.json for resource definitions
  */
 export class ResourceSystem extends SystemBase {
+  /** Centralized particle manager routing events to specialised sub-managers (client only) */
+  public particleManager?: ParticleManager;
+
   private resources = new Map<ResourceID, Resource>();
 
   // Tick-based gathering sessions (OSRS-accurate timing)
@@ -580,6 +584,48 @@ export class ResourceSystem extends SystemBase {
           }
         }
       }, GATHERING_CONSTANTS.RATE_LIMIT_CLEANUP_INTERVAL_MS);
+    }
+
+    // CLIENT: Create centralized particle hub for all particle effects
+    if (!this.world.isServer) {
+      const scene = this.world.stage?.scene;
+      if (scene) {
+        this.particleManager = new ParticleManager(scene as any);
+
+        // Retroactively register any fishing spot entities created before this system started
+        const existingEntities =
+          this.world.entities?.getByType?.("resource") || [];
+        for (const entity of existingEntities) {
+          if (
+            entity instanceof ResourceEntity &&
+            entity.config?.resourceType === "fishing_spot"
+          ) {
+            entity.tryRegisterWithParticleManager();
+          }
+        }
+      }
+
+      // Listen for resource events and route them through the particle hub
+      this.subscribe(
+        EventType.RESOURCE_SPAWNED,
+        (data: {
+          id?: string;
+          type?: string;
+          position?: { x: number; y: number; z: number };
+        }) => {
+          this.particleManager?.handleResourceEvent(data);
+        },
+      );
+    }
+  }
+
+  /** Per-frame update: drives all particle managers on the client. */
+  update(dt: number): void {
+    if (this.particleManager) {
+      const camera = this.world.camera;
+      if (camera) {
+        this.particleManager.update(dt, camera);
+      }
     }
   }
 
@@ -2950,7 +2996,13 @@ export class ResourceSystem extends SystemBase {
     // SECURITY: Clear rate limit tracking
     this.gatherRateLimits.clear();
 
-    // Dispose shared GPU resources (cached textures, geometry) used by fishing spot visuals
+    // Dispose centralized particle manager (client only)
+    if (this.particleManager) {
+      this.particleManager.dispose();
+      this.particleManager = undefined;
+    }
+
+    // Dispose shared GPU resources (cached textures) used by fishing spot glow
     ResourceEntity.disposeSharedResources();
 
     // Call parent cleanup (automatically clears all tracked timers, intervals, and listeners)


### PR DESCRIPTION
## Summary

- Previously each fishing spot created 10-21 individual `THREE.Mesh` objects (splash, bubble, shimmer particles + ripple rings), resulting in ~150 draw calls and heavy per-frame CPU animation (trig, quaternion copies, opacity writes). This caused FPS to drop to **65-70** on my machine.
- Refactored all fishing spot particle/ripple rendering into a centralized `ParticleManager` architecture using **4 GPU InstancedMeshes** driven by TSL NodeMaterials with `InstancedBufferAttribute`s. ~150 draw calls reduced to 4, ~450 lines of per-entity CPU animation code removed.
- After the refactor, FPS runs at **120** on my machine.

## Architecture

- **`WaterParticleManager`** — handles splash, bubble, shimmer, ripple layers via InstancedMesh + TSL shaders (billboard, parabolic arcs, wobble, twinkle, ring expansion all computed on GPU)
- **`ParticleManager`** — central router that dispatches events to the correct sub-manager based on resource type, extensible for future particle types (fire, magic, dust, etc.)
- **`ResourceSystem`** — creates `ParticleManager` on client, forwards resource events via `handleResourceEvent()`
- **`ResourceEntity`** — delegates to `ParticleManager` hub API, retains only the lightweight glow mesh for interaction detection

## Screenshot

before:


https://github.com/user-attachments/assets/47e5a849-fd61-4fbc-b9bc-0eab2dbf1b64

after:


https://github.com/user-attachments/assets/cec6585f-4c6b-4fc2-80c8-830c21b4e3fd

