### PR TITLE
fix: mob position desync and stuck combat rotation on client

### DIFF
--- a/packages/server/src/systems/ServerNetwork/mob-tile-movement.ts
+++ b/packages/server/src/systems/ServerNetwork/mob-tile-movement.ts
@@ -462,18 +462,19 @@ export class MobTileMovementManager {
     state.hasDestination = false;
     state.isChasing = false;
 
-    // Broadcast idle state
-    const entity = this.world.entities.get(mobId);
-    if (entity) {
-      this.sendFn("entityModified", {
-        id: mobId,
-        changes: {
-          p: [entity.position.x, entity.position.y, entity.position.z],
-          v: [0, 0, 0],
-          e: "idle",
-        },
-      });
-    }
+    // Send tileMovementEnd so client TileInterpolator stops interpolating
+    // along the old path and snaps to current position.
+    // Previously sent entityModified which was stripped by PacketHandlers
+    // for tile-controlled entities, leaving TileInterpolator out of sync.
+    const worldPos = tileToWorld(state.currentTile);
+    this.sendFn("tileMovementEnd", {
+      id: mobId,
+      tile: state.currentTile,
+      worldPos: [worldPos.x, worldPos.y, worldPos.z],
+      moveSeq: state.moveSeq,
+      isMob: true,
+      emote: "idle",
+    });
   }
 
   /**
@@ -920,33 +921,21 @@ export class MobTileMovementManager {
       if (state.pathIndex >= state.path.length) {
         state.hasDestination = false;
 
-        // Broadcast movement end
+        // Broadcast movement end - include idle emote for non-chasing mobs
+        // so the client transitions to idle via the tile movement channel.
+        // When chasing (in combat), omit emote - CombatSystem controls animation.
         this.sendFn("tileMovementEnd", {
           id: mobId,
           tile: state.currentTile,
           worldPos: [worldPos.x, worldPos.y, worldPos.z],
           moveSeq: state.moveSeq,
           isMob: true,
+          emote: state.isChasing ? undefined : "idle",
         });
 
         // Clear path without creating new array
         state.path.length = 0;
         state.pathIndex = 0;
-
-        // ONLY broadcast idle state if NOT chasing a target
-        // When chasing (in combat), the AI state machine and CombatSystem
-        // control the animation - they will set combat/idle appropriately.
-        // Sending "idle" here would override the combat animation!
-        if (!state.isChasing) {
-          this.sendFn("entityModified", {
-            id: mobId,
-            changes: {
-              p: [worldPos.x, worldPos.y, worldPos.z],
-              v: [0, 0, 0],
-              e: "idle",
-            },
-          });
-        }
       }
     }
   }

--- a/packages/shared/src/systems/client/DamageSplatSystem.ts
+++ b/packages/shared/src/systems/client/DamageSplatSystem.ts
@@ -91,8 +91,10 @@ export class DamageSplatSystem extends System {
       return;
     }
 
-    // Use provided position or entity position
-    const targetPos = position || target.position;
+    // Prefer entity's visual position (updated by TileInterpolator) over
+    // server-provided position (tile center, potentially stale). This ensures
+    // damage splats appear where the entity visually is on the client.
+    const targetPos = target.position || position;
     if (!targetPos) {
       return;
     }

--- a/packages/shared/src/systems/client/TileInterpolator.ts
+++ b/packages/shared/src/systems/client/TileInterpolator.ts
@@ -293,9 +293,13 @@ export class TileInterpolator {
       state.isRunning = running;
       state.isMoving = true;
       state.emote = emote ?? (running ? "run" : "walk");
-      // NOTE: Don't clear inCombatRotation here - server manages combat rotation state
-      // If we clear it, player will face movement direction until next attack tick
-      // Server will stop sending combat rotation when combat ends
+      // Clear combat rotation on new movement start so movement direction takes over.
+      // For entities still in active combat, MobEntity.clientUpdate() handles combat
+      // rotation locally (checks aiState), and server re-sends setCombatRotation
+      // within 1 tick for remote players. Without this clear, the flag stays true
+      // forever (clearCombatRotation is never called), preventing mobs from rotating
+      // toward their movement direction after combat ends.
+      state.inCombatRotation = false;
       state.serverConfirmedTile = { ...serverConfirmed };
       state.lastServerTick = 0;
       state.catchUpMultiplier = 1.0;

--- a/packages/shared/src/systems/client/network/PacketHandlers.ts
+++ b/packages/shared/src/systems/client/network/PacketHandlers.ts
@@ -705,15 +705,22 @@ export class PacketHandlers {
         const changesTyped = changes as Record<string, unknown>;
         const { p, q, ...restChanges } = changesTyped;
 
-        if (q && Array.isArray(q) && q.length === 4) {
-          const applied = ctx.tileInterpolator.setCombatRotation(
+        // Only route q to setCombatRotation for player entities.
+        // Mobs handle combat rotation locally in MobEntity.clientUpdate()
+        // using aiState + targetPlayerId. The generic q from entityModified
+        // (server dirty sync) is just the mob's current rotation, not
+        // combat-specific, and incorrectly triggers permanent inCombatRotation.
+        if (
+          q &&
+          Array.isArray(q) &&
+          q.length === 4 &&
+          entity.type === "player"
+        ) {
+          ctx.tileInterpolator.setCombatRotation(
             id,
             q as number[],
             entity.position,
           );
-          if (!applied) {
-            // Entity is moving - combat rotation ignored (OSRS-accurate)
-          }
         }
 
         entity.modify(restChanges);


### PR DESCRIPTION
- Clear inCombatRotation flag on movement start in TileInterpolator (was never cleared, causing mobs to keep combat-facing after combat ended)
- Only route entityModified q to setCombatRotation for players, not mobs (mobs handle combat rotation locally in MobEntity.clientUpdate)
- Prefer entity visual position over server position in DamageSplatSystem so damage splats appear where the mob visually is
- Replace redundant entityModified with emote on tileMovementEnd packet
- Fix cancelMovement to send tileMovementEnd instead of entityModified so client TileInterpolator properly stops interpolating the old path