### PR TITLE
feat: add quest-state-aware icons on minimap for quest giver NPCs

### DIFF
--- a/packages/client/src/game/hud/Minimap.tsx
+++ b/packages/client/src/game/hud/Minimap.tsx
@@ -11,8 +11,8 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import { useThemeStore } from "@/ui";
-import { Entity, THREE, createRenderer } from "@hyperscape/shared";
+import { useThemeStore, useQuestSelectionStore } from "@/ui";
+import { Entity, EventType, THREE, createRenderer } from "@hyperscape/shared";
 import type { UniversalRenderer } from "@hyperscape/shared";
 import type { ClientWorld } from "../../types";
 import { ThreeResourceManager } from "../../lib/ThreeResourceManager";
@@ -315,9 +315,25 @@ function drawMinimapIcon(
       ctx.stroke();
       break;
 
-    // --- Quest NPC: cyan question mark ---
+    // --- Quest NPC (available): blue circle with white "!" ---
+    case "quest_available":
     case "quest":
-      ctx.fillStyle = "#00bbdd";
+      ctx.fillStyle = "#2196F3";
+      ctx.beginPath();
+      ctx.arc(cx, cy, 6, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "#000000";
+      ctx.stroke();
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 10px sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("!", cx + 0.5, cy + 1);
+      break;
+
+    // --- Quest NPC (in progress): blue circle with white "?" ---
+    case "quest_in_progress":
+      ctx.fillStyle = "#2196F3";
       ctx.beginPath();
       ctx.arc(cx, cy, 6, 0, Math.PI * 2);
       ctx.fill();
@@ -407,6 +423,81 @@ export function Minimap({
   const entityPipsRefForRender = useRef<EntityPip[]>([]);
   const entityCacheRef = useRef<Map<string, EntityPip>>(new Map());
   const rendererInitializedRef = useRef<boolean>(false);
+
+  // Quest statuses for minimap quest icons (ref for access in entity loop)
+  const questStatusesRef = useRef<Map<string, string>>(new Map());
+  const setQuestStatuses = useQuestSelectionStore((s) => s.setQuestStatuses);
+
+  // Fetch quest statuses from server for minimap quest icons
+  useEffect(() => {
+    /** Server quest status type */
+    type ServerQuestStatus =
+      | "not_started"
+      | "in_progress"
+      | "ready_to_complete"
+      | "completed";
+    type ClientQuestState = "available" | "active" | "completed";
+
+    const mapStatus = (status: ServerQuestStatus): ClientQuestState => {
+      switch (status) {
+        case "not_started":
+          return "available";
+        case "in_progress":
+        case "ready_to_complete":
+          return "active";
+        case "completed":
+          return "completed";
+        default:
+          return "available";
+      }
+    };
+
+    const fetchQuestList = () => {
+      world.network?.send?.("getQuestList", {});
+    };
+
+    const onQuestList = (data: unknown) => {
+      if (typeof data !== "object" || data === null) return;
+      const payload = data as {
+        quests?: Array<{ id: string; status: ServerQuestStatus }>;
+      };
+      if (!Array.isArray(payload.quests)) return;
+
+      const mapped = payload.quests.map((q) => ({
+        id: q.id,
+        state: mapStatus(q.status),
+      }));
+
+      // Update ref for synchronous access in entity loop
+      const map = new Map<string, string>();
+      for (const q of mapped) {
+        map.set(q.id, q.state);
+      }
+      questStatusesRef.current = map;
+
+      // Update store for external consumers
+      setQuestStatuses(mapped);
+    };
+
+    const onQuestEvent = () => {
+      fetchQuestList();
+    };
+
+    world.network?.on("questList", onQuestList);
+    world.on(EventType.QUEST_STARTED, onQuestEvent);
+    world.on(EventType.QUEST_PROGRESSED, onQuestEvent);
+    world.on(EventType.QUEST_COMPLETED, onQuestEvent);
+
+    // Initial fetch
+    fetchQuestList();
+
+    return () => {
+      world.network?.off("questList", onQuestList);
+      world.off(EventType.QUEST_STARTED, onQuestEvent);
+      world.off(EventType.QUEST_PROGRESSED, onQuestEvent);
+      world.off(EventType.QUEST_COMPLETED, onQuestEvent);
+    };
+  }, [world, setQuestStatuses]);
 
   // Collapsed state for collapsible minimap
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
@@ -828,16 +919,45 @@ export function Minimap({
               // Detect NPC service type for minimap icons
               const npcConfig = (
                 entity as unknown as {
-                  config?: { services?: { types?: string[] } };
+                  config?: {
+                    services?: string[];
+                    questIds?: string[];
+                  };
                 }
               ).config;
-              const serviceTypes = npcConfig?.services?.types;
+              const serviceTypes = npcConfig?.services;
               if (serviceTypes?.includes("bank")) {
                 subType = "bank";
               } else if (serviceTypes?.includes("shop")) {
                 subType = "shop";
-              } else if (serviceTypes?.includes("quest")) {
-                subType = "quest";
+              }
+              // Quest icon with state awareness (overrides shop for quest+shop NPCs)
+              if (serviceTypes?.includes("quest")) {
+                const questIds = npcConfig?.questIds;
+                const statuses = questStatusesRef.current;
+                if (questIds && questIds.length > 0 && statuses.size > 0) {
+                  let hasAvailable = false;
+                  let hasActive = false;
+                  let allCompleted = true;
+                  for (const qid of questIds) {
+                    const state = statuses.get(qid);
+                    if (state === "available") hasAvailable = true;
+                    else if (state === "active") hasActive = true;
+                    if (state !== "completed") allCompleted = false;
+                  }
+                  if (hasAvailable) {
+                    subType = "quest_available";
+                  } else if (hasActive) {
+                    subType = "quest_in_progress";
+                  } else if (!allCompleted) {
+                    // No status data yet, show generic quest icon
+                    subType = "quest_available";
+                  }
+                  // If all completed, don't override subType (keep bank/shop or nothing)
+                } else {
+                  // No quest status data loaded yet, show generic quest icon
+                  subType = "quest_available";
+                }
               }
               break;
             }

--- a/packages/client/src/ui/stores/questStore.ts
+++ b/packages/client/src/ui/stores/questStore.ts
@@ -3,10 +3,12 @@
  *
  * Manages the currently selected quest for the quest detail panel.
  * Used to communicate between QuestsPanel (list) and QuestDetailPanel (detail view).
+ *
+ * Also tracks quest statuses for minimap quest icons (available/active/completed).
  */
 
 import { create } from "zustand";
-import type { Quest } from "@/game/systems/quest";
+import type { Quest, QuestState } from "@/game/systems/quest";
 
 /** Quest selection store state and actions */
 export interface QuestSelectionState {
@@ -16,6 +18,10 @@ export interface QuestSelectionState {
   setSelectedQuest: (quest: Quest | null) => void;
   /** Clear the selected quest */
   clearSelectedQuest: () => void;
+  /** Quest status map: questId → QuestState ("available" | "active" | "completed") */
+  questStatuses: Map<string, QuestState>;
+  /** Update quest statuses from server quest list */
+  setQuestStatuses: (quests: Array<{ id: string; state: QuestState }>) => void;
 }
 
 /**
@@ -28,4 +34,12 @@ export const useQuestSelectionStore = create<QuestSelectionState>((set) => ({
   selectedQuest: null,
   setSelectedQuest: (quest) => set({ selectedQuest: quest }),
   clearSelectedQuest: () => set({ selectedQuest: null }),
+  questStatuses: new Map(),
+  setQuestStatuses: (quests) => {
+    const map = new Map<string, QuestState>();
+    for (const q of quests) {
+      map.set(q.id, q.state);
+    }
+    set({ questStatuses: map });
+  },
 }));

--- a/packages/shared/src/entities/npc/NPCEntity.ts
+++ b/packages/shared/src/entities/npc/NPCEntity.ts
@@ -116,6 +116,7 @@ export class NPCEntity extends Entity {
       ...config,
       dialogueLines: config.dialogueLines || ["Hello there!"],
       services: config.services || [],
+      questIds: config.questIds,
     };
 
     // NPCs don't have health bars - they're not combatants
@@ -662,6 +663,7 @@ export class NPCEntity extends Entity {
       npcType: this.config.npcType,
       npcId: this.config.npcId,
       services: this.config.services,
+      questIds: this.config.questIds,
     };
   }
 
@@ -674,6 +676,7 @@ export class NPCEntity extends Entity {
       npcType: this.config.npcType,
       npcId: this.config.npcId,
       services: this.config.services,
+      questIds: this.config.questIds,
     };
   }
 

--- a/packages/shared/src/systems/shared/entities/Entities.ts
+++ b/packages/shared/src/systems/shared/entities/Entities.ts
@@ -570,6 +570,7 @@ export class Entities extends SystemBase implements IEntities {
       // NOT data.id (entity instance ID like "npc_bank_clerk_123")
       const npcId = networkData.npcId || data.id;
       const services = networkData.services || [];
+      const questIds = (networkData as { questIds?: string[] }).questIds;
       // CRITICAL: Use model from network data for NPC model loading
       const modelPath = (networkData as { model?: string }).model || null;
 
@@ -600,6 +601,7 @@ export class Entities extends SystemBase implements IEntities {
         npcId: npcId,
         dialogueLines: ["Hello there!"],
         services: services,
+        questIds: questIds,
         inventory: [],
         skillsOffered: [],
         questsAvailable: [],

--- a/packages/shared/src/systems/shared/entities/MobNPCSpawnerSystem.ts
+++ b/packages/shared/src/systems/shared/entities/MobNPCSpawnerSystem.ts
@@ -131,6 +131,9 @@ export class MobNPCSpawnerSystem extends SystemBase {
           npcManifestData.appearance?.modelPath ||
           "asset://models/human/human_rigged.glb";
         const npcServices = npcManifestData.services?.types || [];
+        const npcQuestIds = npcManifestData.services?.questIds as
+          | string[]
+          | undefined;
         const npcDescription = npcManifestData.description || npc.id;
         const npcName = npcManifestData.name || npc.id;
 
@@ -152,6 +155,7 @@ export class MobNPCSpawnerSystem extends SystemBase {
           npcId: npc.id, // Manifest ID for dialogue lookup
           dialogueLines: [],
           services: npcServices, // From npcs.json
+          questIds: npcQuestIds, // Quest IDs from npcs.json
           inventory: [],
           skillsOffered: [],
           questsAvailable: [],

--- a/packages/shared/src/types/entities/entities.ts
+++ b/packages/shared/src/types/entities/entities.ts
@@ -275,6 +275,7 @@ export interface NPCEntityConfig extends EntityConfig<NPCEntityProperties> {
   npcId: string;
   dialogueLines: string[];
   services: string[];
+  questIds?: string[];
   inventory: Array<{
     itemId: string;
     quantity: number;


### PR DESCRIPTION
Add questIds field to NPCEntityConfig and pass it through the spawn → network → client pipeline so the minimap can identify quest giver NPCs. Fix broken NPC service detection cast in Minimap (services is string[], not { types: string[] }), which also fixes bank/shop icon detection. Minimap now fetches quest statuses from the server and shows blue "!" for available quests and blue "?" for in-progress quests. Icons disappear when all of an NPC's quests are completed.