### PR TITLE
fix: OSRS-accurate combat pathfinding with BFS, multi-dest, and LoS

### DIFF
--- a/packages/server/src/systems/ServerNetwork/PendingAttackManager.ts
+++ b/packages/server/src/systems/ServerNetwork/PendingAttackManager.ts
@@ -21,6 +21,8 @@ import {
   worldToTileInto,
   tilesWithinMeleeRange,
   tilesWithinRange,
+  hasLineOfSight,
+  CollisionMask,
   EventType,
   AttackType,
 } from "@hyperscape/shared";
@@ -209,7 +211,7 @@ export class PendingAttackManager {
       // OSRS-accurate range check:
       // - Melee range 1: Cardinal only (N/S/E/W)
       // - Melee range 2+: Allows diagonal (Chebyshev distance)
-      // - Ranged/Magic: Always use Chebyshev distance
+      // - Ranged/Magic: Chebyshev distance + Line of Sight
       const inRange =
         pending.attackType === AttackType.MELEE
           ? tilesWithinMeleeRange(
@@ -221,7 +223,7 @@ export class PendingAttackManager {
               this._playerTile,
               this._targetTile,
               pending.attackRange,
-            );
+            ) && this.tileHasLineOfSight(this._playerTile, this._targetTile);
 
       if (inRange) {
         // Stop remaining walk path — player has arrived at combat position.
@@ -306,6 +308,7 @@ export class PendingAttackManager {
     worldToTileInto(targetPos.x, targetPos.z, this._targetTile);
 
     // OSRS-accurate range check based on attack type
+    // Ranged/Magic additionally require Line of Sight
     const inRange =
       pending.attackType === AttackType.MELEE
         ? tilesWithinMeleeRange(
@@ -317,7 +320,7 @@ export class PendingAttackManager {
             this._playerTile,
             this._targetTile,
             pending.attackRange,
-          );
+          ) && this.tileHasLineOfSight(this._playerTile, this._targetTile);
 
     if (inRange) {
       // Stop remaining walk path — player has arrived at combat position.
@@ -367,6 +370,16 @@ export class PendingAttackManager {
    */
   onPlayerDisconnect(playerId: string): void {
     this.pendingAttacks.delete(playerId);
+  }
+
+  /**
+   * Check line of sight between two tiles for ranged/magic combat.
+   * Uses BLOCKS_RANGED collision mask (BLOCK_LOS | BLOCKED).
+   */
+  private tileHasLineOfSight(from: TileCoord, to: TileCoord): boolean {
+    return hasLineOfSight(from, to, (x, z) =>
+      this.world.collision.hasFlags(x, z, CollisionMask.BLOCKS_RANGED),
+    );
   }
 
   /**

--- a/packages/server/src/systems/ServerNetwork/tile-movement.ts
+++ b/packages/server/src/systems/ServerNetwork/tile-movement.ts
@@ -29,10 +29,12 @@ import {
   tilesEqual,
   tilesWithinMeleeRange,
   tilesWithinRange,
-  getBestMeleeTile,
-  getBestCombatRangeTile,
   createTileMovementState,
   BFSPathfinder,
+  // Combat pathfinding: LoS and valid tile generation
+  hasLineOfSight,
+  getValidRangedTiles,
+  getValidMeleeTiles,
   // Collision system
   CollisionMask,
 } from "@hyperscape/shared";
@@ -1127,72 +1129,70 @@ export class TileMovementManager {
     // Convert target to tile (zero allocation)
     worldToTileInto(targetPosition.x, targetPosition.z, this._targetTile);
 
-    // Determine destination tile based on combat or non-combat movement
-    let destinationTile: TileCoord;
+    let path: TileCoord[];
 
     if (attackRange > 0) {
-      // COMBAT MOVEMENT: Use appropriate positioning based on attack type
-      if (attackType === AttackType.RANGED || attackType === AttackType.MAGIC) {
-        // RANGED/MAGIC: Use Chebyshev distance - stop when within attack range
+      // COMBAT MOVEMENT: Multi-destination BFS to ANY valid combat tile
+
+      // Check if already in valid position
+      const alreadyInRange =
+        attackType === AttackType.MELEE
+          ? tilesWithinMeleeRange(
+              state.currentTile,
+              this._targetTile,
+              attackRange,
+            )
+          : tilesWithinRange(state.currentTile, this._targetTile, attackRange);
+
+      if (alreadyInRange) {
+        // For ranged/magic: also verify LoS before considering "in position"
         if (
-          tilesWithinRange(state.currentTile, this._targetTile, attackRange)
+          attackType === AttackType.MELEE ||
+          this.tileHasLineOfSight(state.currentTile, this._targetTile)
         ) {
-          return; // Already in position, no movement needed
+          return; // Already in valid combat position
         }
-
-        // Find best tile within attack range
-        const combatTile = getBestCombatRangeTile(
-          this._targetTile,
-          state.currentTile,
-          attackRange,
-          (tile) => this.isTileWalkable(tile),
-        );
-
-        if (!combatTile) {
-          return; // No valid combat position found
-        }
-
-        destinationTile = combatTile;
-      } else {
-        // MELEE: Use OSRS-accurate melee positioning (cardinal-only for range 1)
-        if (
-          tilesWithinMeleeRange(
-            state.currentTile,
-            this._targetTile,
-            attackRange,
-          )
-        ) {
-          return; // Already in position, no movement needed
-        }
-
-        // Find best melee tile (cardinal-only for range 1, diagonal allowed for range 2+)
-        const meleeTile = getBestMeleeTile(
-          this._targetTile,
-          state.currentTile,
-          attackRange,
-          (tile) => this.isTileWalkable(tile),
-        );
-
-        if (!meleeTile) {
-          return; // No valid melee position found
-        }
-
-        destinationTile = meleeTile;
       }
+
+      // Generate ALL valid destination tiles
+      let validTiles: TileCoord[];
+      if (attackType === AttackType.RANGED || attackType === AttackType.MAGIC) {
+        validTiles = getValidRangedTiles(
+          this._targetTile,
+          attackRange,
+          (tile) => this.isTileWalkable(tile),
+          (x, z) =>
+            this.world.collision.hasFlags(x, z, CollisionMask.BLOCKS_RANGED),
+        );
+      } else {
+        validTiles = getValidMeleeTiles(this._targetTile, attackRange, (tile) =>
+          this.isTileWalkable(tile),
+        );
+      }
+
+      if (validTiles.length === 0) {
+        return; // No valid combat position found
+      }
+
+      // Multi-destination BFS: finds shortest path to ANY valid tile
+      path = this.pathfinder.findPathToAny(
+        state.currentTile,
+        validTiles,
+        (tile) => this.isTileWalkable(tile),
+      );
     } else {
       // NON-COMBAT MOVEMENT: Go directly to target tile
       if (tilesEqual(this._targetTile, state.currentTile)) {
         return; // Already at target
       }
-      destinationTile = this._targetTile;
-    }
 
-    // Calculate BFS path to the destination tile (NOT to target, then truncate!)
-    const path = this.pathfinder.findPath(
-      state.currentTile,
-      destinationTile,
-      (tile) => this.isTileWalkable(tile),
-    );
+      // Calculate BFS path to the target tile
+      path = this.pathfinder.findPath(
+        state.currentTile,
+        this._targetTile,
+        (tile) => this.isTileWalkable(tile),
+      );
+    }
 
     if (path.length === 0) {
       return; // No path found
@@ -1257,5 +1257,15 @@ export class TileMovementManager {
       moveSeq: state.moveSeq,
       emote: state.isRunning ? "run" : "walk",
     });
+  }
+
+  /**
+   * Check line of sight between two tiles for ranged/magic combat.
+   * Uses BLOCKS_RANGED collision mask (BLOCK_LOS | BLOCKED).
+   */
+  private tileHasLineOfSight(from: TileCoord, to: TileCoord): boolean {
+    return hasLineOfSight(from, to, (x, z) =>
+      this.world.collision.hasFlags(x, z, CollisionMask.BLOCKS_RANGED),
+    );
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -993,6 +993,10 @@ export {
   parseTileKey,
   clampTile,
   createTileMovementState,
+  // Combat pathfinding: LoS and valid tile generation
+  hasLineOfSight,
+  getValidRangedTiles,
+  getValidMeleeTiles,
 } from "./systems/shared/movement/TileSystem";
 export type {
   TileCoord,

--- a/packages/shared/src/systems/shared/movement/BFSPathfinder.ts
+++ b/packages/shared/src/systems/shared/movement/BFSPathfinder.ts
@@ -1,16 +1,14 @@
 /**
- * BFS Pathfinder with OSRS-style Naive Diagonal Pathing
+ * BFS Pathfinder — OSRS "Smartpathing"
  *
- * OSRS has two pathing modes:
- * 1. Click-to-move: Uses BFS with specific neighbor order
- * 2. Follow mode: "naively paths diagonally to the end tile and then straight"
+ * OSRS player movement uses BFS ("smartpathing") as the primary algorithm.
+ * Naive/dumb diagonal pathing is ONLY used by NPC chase movement (see ChasePathfinding.ts).
  *
- * The naive diagonal approach feels more intuitive - you walk toward your
- * destination diagonally first, then straight for the remaining distance.
- *
- * This implementation:
- * 1. First tries naive diagonal path (fast, intuitive, no obstacles)
- * 2. Falls back to BFS if obstacles block the naive path
+ * Key features:
+ * - BFS with OSRS neighbor order (W,E,S,N,SW,SE,NW,NE)
+ * - findPathToAny(): Multi-destination BFS for combat — terminates at the first
+ *   valid combat tile reached, naturally finding the shortest path.
+ * - findNaivePath(): Exposed for NPC chase systems only, never called from findPath().
  *
  * @see https://oldschool.runescape.wiki/w/Pathfinding
  */
@@ -40,9 +38,8 @@ export type WalkabilityChecker = (
  */
 export class BFSPathfinder {
   /**
-   * Find a path from start to end
-   * Uses naive diagonal pathing first (OSRS follow-mode style),
-   * falls back to BFS if obstacles are encountered
+   * Find a path from start to end using BFS (OSRS "smartpathing").
+   * BFS is the primary pathfinder for all player movement.
    */
   findPath(
     start: TileCoord,
@@ -64,25 +61,95 @@ export class BFSPathfinder {
       end = nearestWalkable;
     }
 
-    // First, try naive diagonal path (fast and intuitive)
-    const naivePath = this.findNaiveDiagonalPath(start, end, isWalkable);
-    if (naivePath.length > 0) {
-      return naivePath;
-    }
-
-    // Naive path blocked - use BFS to find path around obstacles
+    // BFS is the primary pathfinder (OSRS "smartpathing")
     return this.findBFSPath(start, end, isWalkable);
   }
 
   /**
-   * OSRS-style naive diagonal pathing
-   * "naively paths diagonally to the end tile and then straight if there's no diagonals left"
+   * Multi-destination BFS: find shortest path from start to ANY destination tile.
    *
-   * This creates the intuitive path where you walk toward your target:
-   * - First, move diagonally (both X and Z changing) toward target
-   * - Then, move straight (only X or Z) for the remaining distance
+   * OSRS combat pathfinding feeds all valid interaction tiles into the pathfinder
+   * and terminates as soon as any is reached. This naturally finds the shortest
+   * path to the closest valid combat tile.
+   *
+   * @param start - Starting tile
+   * @param destinations - Array of valid destination tiles (e.g. all tiles in attack range with LoS)
+   * @param isWalkable - Walkability checker
+   * @returns Shortest path to the nearest reachable destination, or [] if none reachable
    */
-  private findNaiveDiagonalPath(
+  findPathToAny(
+    start: TileCoord,
+    destinations: TileCoord[],
+    isWalkable: WalkabilityChecker,
+  ): TileCoord[] {
+    if (destinations.length === 0) return [];
+
+    // Check if already at any destination
+    for (const dest of destinations) {
+      if (tilesEqual(start, dest)) return [];
+    }
+
+    // Build destination lookup set for O(1) checks
+    const destSet = new Set<string>();
+    for (const dest of destinations) {
+      destSet.add(tileKey(dest));
+    }
+
+    // Standard BFS from start, terminate at first destination hit
+    const pooledData = bfsPool.acquire();
+    const { visited, parent, queue } = pooledData;
+
+    try {
+      queue.push(start);
+      visited.add(tileKey(start));
+
+      const minX = start.x - PATHFIND_RADIUS;
+      const maxX = start.x + PATHFIND_RADIUS;
+      const minZ = start.z - PATHFIND_RADIUS;
+      const maxZ = start.z + PATHFIND_RADIUS;
+      let front = 0;
+
+      while (front < queue.length) {
+        const current = queue[front++];
+
+        // Check if we reached ANY destination
+        if (destSet.has(tileKey(current))) {
+          return this.reconstructPath(start, current, parent);
+        }
+
+        // Expand neighbors in OSRS order
+        for (const dir of TILE_DIRECTIONS) {
+          const nx = current.x + dir.x;
+          const nz = current.z + dir.z;
+          if (nx < minX || nx > maxX || nz < minZ || nz > maxZ) continue;
+
+          const neighborKey = `${nx},${nz}`;
+          if (visited.has(neighborKey)) continue;
+
+          const neighbor: TileCoord = { x: nx, z: nz };
+          if (!this.canMoveTo(current, neighbor, isWalkable)) continue;
+
+          visited.add(neighborKey);
+          parent.set(neighborKey, current);
+          queue.push(neighbor);
+        }
+      }
+
+      // No destination reachable — partial path to closest destination
+      return this.findPartialPathToAny(start, destinations, visited, parent);
+    } finally {
+      bfsPool.release(pooledData);
+    }
+  }
+
+  /**
+   * Naive diagonal pathing — "dumb pathfinding" for NPC chase systems.
+   * Moves diagonally toward target first, then cardinally.
+   * This is NOT used for player movement (players use BFS).
+   *
+   * Exposed publicly for ChasePathfinding and NPC follow systems.
+   */
+  findNaivePath(
     start: TileCoord,
     end: TileCoord,
     isWalkable: WalkabilityChecker,
@@ -90,47 +157,37 @@ export class BFSPathfinder {
     const path: TileCoord[] = [];
     let current = { ...start };
 
-    // Maximum iterations to prevent infinite loops
     const maxIterations = 500;
     let iterations = 0;
 
     while (!tilesEqual(current, end) && iterations < maxIterations) {
       iterations++;
 
-      // Calculate direction to target
       const dx = Math.sign(end.x - current.x);
       const dz = Math.sign(end.z - current.z);
 
-      // Try to find the next tile to move to
       let nextTile: TileCoord | null = null;
 
       if (dx !== 0 && dz !== 0) {
-        // Need to move in both X and Z - try diagonal first
         const diagonal: TileCoord = { x: current.x + dx, z: current.z + dz };
 
         if (this.canMoveTo(current, diagonal, isWalkable)) {
           nextTile = diagonal;
         } else {
-          // Diagonal blocked - try cardinal directions
-          // Prefer the axis with more distance remaining
           const xDist = Math.abs(end.x - current.x);
           const zDist = Math.abs(end.z - current.z);
 
           if (xDist >= zDist) {
-            // Try X first, then Z
             const cardinalX: TileCoord = { x: current.x + dx, z: current.z };
             const cardinalZ: TileCoord = { x: current.x, z: current.z + dz };
-
             if (this.canMoveTo(current, cardinalX, isWalkable)) {
               nextTile = cardinalX;
             } else if (this.canMoveTo(current, cardinalZ, isWalkable)) {
               nextTile = cardinalZ;
             }
           } else {
-            // Try Z first, then X
             const cardinalZ: TileCoord = { x: current.x, z: current.z + dz };
             const cardinalX: TileCoord = { x: current.x + dx, z: current.z };
-
             if (this.canMoveTo(current, cardinalZ, isWalkable)) {
               nextTile = cardinalZ;
             } else if (this.canMoveTo(current, cardinalX, isWalkable)) {
@@ -139,28 +196,24 @@ export class BFSPathfinder {
           }
         }
       } else if (dx !== 0) {
-        // Only need to move in X
         const cardinalX: TileCoord = { x: current.x + dx, z: current.z };
         if (this.canMoveTo(current, cardinalX, isWalkable)) {
           nextTile = cardinalX;
         }
       } else if (dz !== 0) {
-        // Only need to move in Z
         const cardinalZ: TileCoord = { x: current.x, z: current.z + dz };
         if (this.canMoveTo(current, cardinalZ, isWalkable)) {
           nextTile = cardinalZ;
         }
       }
 
-      // If we couldn't find a valid next tile, naive path is blocked
       if (!nextTile) {
-        return []; // Signal to use BFS instead
+        return [];
       }
 
       path.push(nextTile);
       current = nextTile;
 
-      // Safety limit on path length
       if (path.length > 200) {
         return path;
       }
@@ -170,7 +223,7 @@ export class BFSPathfinder {
   }
 
   /**
-   * BFS pathfinding - used when naive diagonal path is blocked by obstacles
+   * BFS pathfinding — primary pathfinder for player movement.
    *
    * Uses object pool to minimize allocations in this hot path.
    */
@@ -246,10 +299,10 @@ export class BFSPathfinder {
   }
 
   /**
-   * Check if movement from one tile to another is valid
-   * Handles diagonal corner clipping prevention
+   * Check if movement from one tile to another is valid.
+   * Handles diagonal corner clipping prevention.
    */
-  private canMoveTo(
+  canMoveTo(
     from: TileCoord,
     to: TileCoord,
     isWalkable: WalkabilityChecker,
@@ -358,6 +411,43 @@ export class BFSPathfinder {
 
       if (distance < closestDistance) {
         closestDistance = distance;
+        closestTile = tile;
+      }
+    }
+
+    if (!closestTile || tilesEqual(closestTile, start)) {
+      return [];
+    }
+
+    return this.reconstructPath(start, closestTile, parent);
+  }
+
+  /**
+   * Find a partial path when no destination is reachable (multi-destination variant).
+   * Returns path to the visited tile closest to any destination.
+   */
+  private findPartialPathToAny(
+    start: TileCoord,
+    destinations: TileCoord[],
+    visited: Set<string>,
+    parent: Map<string, TileCoord>,
+  ): TileCoord[] {
+    let closestTile: TileCoord | null = null;
+    let closestDistance = Infinity;
+
+    for (const key of visited) {
+      const [x, z] = key.split(",").map(Number);
+      const tile: TileCoord = { x, z };
+
+      // Find minimum Manhattan distance to any destination
+      let minDist = Infinity;
+      for (const dest of destinations) {
+        const distance = Math.abs(tile.x - dest.x) + Math.abs(tile.z - dest.z);
+        if (distance < minDist) minDist = distance;
+      }
+
+      if (minDist < closestDistance) {
+        closestDistance = minDist;
         closestTile = tile;
       }
     }

--- a/packages/shared/src/systems/shared/movement/TileSystem.ts
+++ b/packages/shared/src/systems/shared/movement/TileSystem.ts
@@ -713,6 +713,133 @@ export function getBestStepOutTile(
   return null;
 }
 
+// ============================================================================
+// LINE OF SIGHT & COMBAT TILE GENERATION
+// ============================================================================
+
+/**
+ * OSRS-accurate Line of Sight check for ranged/magic combat.
+ * Traces a line between two tiles using Bresenham's algorithm and checks
+ * for BLOCKS_RANGED obstacles on intermediate tiles.
+ *
+ * @param from - Attacker tile
+ * @param to - Target tile
+ * @param hasBlockingFlags - Function to check if a tile blocks LoS (e.g. BLOCKS_RANGED)
+ * @returns true if there is a clear line of sight
+ */
+export function hasLineOfSight(
+  from: TileCoord,
+  to: TileCoord,
+  hasBlockingFlags: (x: number, z: number) => boolean,
+): boolean {
+  let x0 = from.x;
+  let z0 = from.z;
+  const x1 = to.x;
+  const z1 = to.z;
+  const dx = Math.abs(x1 - x0);
+  const dz = Math.abs(z1 - z0);
+  const sx = x0 < x1 ? 1 : -1;
+  const sz = z0 < z1 ? 1 : -1;
+  let err = dx - dz;
+
+  while (true) {
+    // Skip start and end tiles (attacker and target positions)
+    if ((x0 !== from.x || z0 !== from.z) && (x0 !== x1 || z0 !== z1)) {
+      if (hasBlockingFlags(x0, z0)) return false;
+    }
+    if (x0 === x1 && z0 === z1) break;
+    const e2 = 2 * err;
+    if (e2 > -dz) {
+      err -= dz;
+      x0 += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      z0 += sz;
+    }
+  }
+  return true;
+}
+
+/**
+ * Generate all valid tiles for ranged/magic combat within Chebyshev range that
+ * also have line of sight to the target.
+ *
+ * Used by movePlayerToward() to build the destination set for findPathToAny().
+ *
+ * @param target - Target's tile position
+ * @param combatRange - Maximum combat range in tiles
+ * @param isWalkable - Terrain walkability check
+ * @param hasBlockingFlags - LoS blocking check (e.g. BLOCKS_RANGED)
+ * @returns Array of valid combat tiles
+ */
+export function getValidRangedTiles(
+  target: TileCoord,
+  combatRange: number,
+  isWalkable: (tile: TileCoord) => boolean,
+  hasBlockingFlags: (x: number, z: number) => boolean,
+): TileCoord[] {
+  const effectiveRange = Math.max(1, Math.floor(combatRange));
+  const tiles: TileCoord[] = [];
+
+  for (let dx = -effectiveRange; dx <= effectiveRange; dx++) {
+    for (let dz = -effectiveRange; dz <= effectiveRange; dz++) {
+      const dist = Math.max(Math.abs(dx), Math.abs(dz));
+      if (dist < 1 || dist > effectiveRange) continue;
+
+      const tile: TileCoord = { x: target.x + dx, z: target.z + dz };
+      if (!isWalkable(tile)) continue;
+      if (!hasLineOfSight(tile, target, hasBlockingFlags)) continue;
+
+      tiles.push(tile);
+    }
+  }
+  return tiles;
+}
+
+/**
+ * Generate all valid tiles for melee combat.
+ * Range 1 (standard): cardinal only (N/S/E/W) — OSRS melee behavior.
+ * Range 2+ (halberd): all Chebyshev tiles within range.
+ *
+ * @param target - Target's tile position
+ * @param meleeRange - Weapon's melee range
+ * @param isWalkable - Terrain walkability check
+ * @returns Array of valid melee combat tiles
+ */
+export function getValidMeleeTiles(
+  target: TileCoord,
+  meleeRange: number,
+  isWalkable: (tile: TileCoord) => boolean,
+): TileCoord[] {
+  const effectiveRange = Math.max(1, Math.floor(meleeRange));
+  const tiles: TileCoord[] = [];
+
+  if (effectiveRange === COMBAT_CONSTANTS.MELEE_RANGE_STANDARD) {
+    // Range 1: cardinal only (OSRS melee behavior)
+    const cardinals = [
+      { x: target.x - 1, z: target.z },
+      { x: target.x + 1, z: target.z },
+      { x: target.x, z: target.z - 1 },
+      { x: target.x, z: target.z + 1 },
+    ];
+    for (const tile of cardinals) {
+      if (isWalkable(tile)) tiles.push(tile);
+    }
+  } else {
+    // Range 2+: Chebyshev distance
+    for (let dx = -effectiveRange; dx <= effectiveRange; dx++) {
+      for (let dz = -effectiveRange; dz <= effectiveRange; dz++) {
+        const dist = Math.max(Math.abs(dx), Math.abs(dz));
+        if (dist < 1 || dist > effectiveRange) continue;
+        const tile: TileCoord = { x: target.x + dx, z: target.z + dz };
+        if (isWalkable(tile)) tiles.push(tile);
+      }
+    }
+  }
+  return tiles;
+}
+
 /**
  * Check if a direction is diagonal
  */


### PR DESCRIPTION
## Summary
- **BFS as primary pathfinder**: Player movement now uses BFS ("smartpathing") instead of naive diagonal-first. Eliminates the visible diagonal zigzag when walking to attack targets.
- **Multi-destination combat BFS**: Instead of pre-picking one "best" combat tile then pathfinding to it, generates all valid attack tiles and uses `findPathToAny()` to find the shortest path to any of them. Naturally selects the closest reachable position.
- **Line of Sight for ranged/magic**: Ranged and magic attacks now verify LoS via Bresenham line trace against `BLOCKS_RANGED` collision flags. Prevents attacking through walls when in Chebyshev range.

## Files changed
- `BFSPathfinder.ts` — BFS primary, added `findPathToAny()`, renamed naive path to `findNaivePath()` (public, for NPC chase only)
- `TileSystem.ts` — Added `hasLineOfSight()`, `getValidRangedTiles()`, `getValidMeleeTiles()`
- `tile-movement.ts` — Combat movement uses multi-dest BFS + LoS check
- `PendingAttackManager.ts` — Ranged/magic range checks now require LoS
- `index.ts` — New exports

## What's NOT changed
- NPC chase pathfinding (`ChasePathfinding.ts`) — still uses naive/dumb pathing (OSRS-accurate for safespotting)
- Movement speed (2x OSRS) — intentional design choice
- Tick processing order — already correct

## Test plan
- [x] `tsc --noEmit` passes for shared and server packages (0 new errors)
- [x] All 608 combat tests pass (1 pre-existing unrelated failure)
- [ ] Manual: ranged attack in duel arena — player walks optimal BFS path, not diagonal-first
- [ ] Manual: melee attack — player BFS paths to cardinal-adjacent tile
- [ ] Manual: ranged attack with wall between — player paths around wall to find LoS tile
- [ ] Manual: NPC chase — mobs still use naive diagonal pathing (safespotting works)
- [ ] Manual: click-to-move — optimal BFS path, no diagonal-first