### PR TITLE
feat: melee weapon overhaul — shortsword rename, 2h emotes, batch wea…

### DIFF
--- a/packages/asset-forge/server/models.ts
+++ b/packages/asset-forge/server/models.ts
@@ -142,6 +142,22 @@ export const AssetUpdate = t.Object({
   type: t.Optional(t.String()),
   tier: t.Optional(t.Number()),
   category: t.Optional(t.String()),
+  metadata: t.Optional(t.Record(t.String(), t.Any())),
+});
+
+export const BatchApplyFittingRequest = t.Object({
+  config: t.Record(t.String(), t.Any()),
+  assetIds: t.Array(t.String({ minLength: 1 }), { minItems: 1 }),
+});
+
+export const BatchApplyFittingResponse = t.Object({
+  success: t.Boolean(),
+  updated: t.Number(),
+});
+
+export const SaveAlignedResponse = t.Object({
+  success: t.Boolean(),
+  path: t.String(),
 });
 
 export const DeleteAssetQuery = t.Object({

--- a/packages/asset-forge/server/routes/assets.ts
+++ b/packages/asset-forge/server/routes/assets.ts
@@ -306,6 +306,145 @@ export const createAssetRoutes = (
           },
         )
 
+        // Batch apply fitting configuration to multiple assets
+        .post(
+          "/batch-apply-fitting",
+          async ({ body, set }) => {
+            const { config, assetIds } = body;
+
+            console.log(
+              `[Batch Fitting] Applying config to ${assetIds.length} assets`,
+            );
+
+            let updated = 0;
+
+            for (const assetId of assetIds) {
+              try {
+                const assetDir = path.join(rootDir, "gdd-assets", assetId);
+                const metadataPath = path.join(assetDir, "metadata.json");
+
+                // Security check
+                const normalizedPath = path.normalize(metadataPath);
+                if (
+                  !normalizedPath.startsWith(path.join(rootDir, "gdd-assets"))
+                ) {
+                  console.warn(
+                    `[Batch Fitting] Skipping ${assetId}: path traversal`,
+                  );
+                  continue;
+                }
+
+                const currentMetadata = JSON.parse(
+                  await fs.promises.readFile(metadataPath, "utf-8"),
+                );
+
+                const updatedMetadata = {
+                  ...currentMetadata,
+                  ...config,
+                  updatedAt: new Date().toISOString(),
+                };
+
+                await Bun.write(
+                  metadataPath,
+                  JSON.stringify(updatedMetadata, null, 2),
+                );
+
+                updated++;
+                console.log(`[Batch Fitting] Updated: ${assetId}`);
+              } catch (error) {
+                console.error(`[Batch Fitting] Failed for ${assetId}:`, error);
+              }
+            }
+
+            return { success: true, updated };
+          },
+          {
+            body: Models.BatchApplyFittingRequest,
+            response: Models.BatchApplyFittingResponse,
+            detail: {
+              tags: ["Assets"],
+              summary: "Batch apply fitting configuration",
+              description:
+                "Applies a fitting configuration (e.g., hyperscapeAttachment) to multiple asset metadata files.",
+            },
+          },
+        )
+
+        // Save aligned GLB for an asset
+        .post(
+          "/:id/save-aligned",
+          async ({ params: { id }, body, set }) => {
+            const formData = body as { file?: File };
+            const file = formData.file;
+
+            if (!file) {
+              set.status = 400;
+              return { success: false, path: "", error: "No file provided" };
+            }
+
+            console.log(
+              `[Save Aligned] Saving aligned GLB for asset: ${id} (${(file.size / 1024).toFixed(1)} KB)`,
+            );
+
+            const assetDir = path.join(rootDir, "gdd-assets", id);
+
+            // Security check
+            const normalizedPath = path.normalize(assetDir);
+            if (!normalizedPath.startsWith(path.join(rootDir, "gdd-assets"))) {
+              set.status = 403;
+              return { success: false, path: "", error: "Access denied" };
+            }
+
+            // Ensure directory exists
+            await fs.promises.mkdir(assetDir, { recursive: true });
+
+            // Save aligned GLB
+            const alignedPath = path.join(assetDir, `${id}-aligned.glb`);
+            await Bun.write(alignedPath, file);
+
+            // Update metadata.json with aligned model path
+            try {
+              const metadataPath = path.join(assetDir, "metadata.json");
+              const currentMetadata = JSON.parse(
+                await fs.promises.readFile(metadataPath, "utf-8"),
+              );
+
+              const updatedMetadata = {
+                ...currentMetadata,
+                alignedModelPath: `${id}-aligned.glb`,
+                alignedAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              };
+
+              await Bun.write(
+                metadataPath,
+                JSON.stringify(updatedMetadata, null, 2),
+              );
+            } catch (error) {
+              console.warn(
+                `[Save Aligned] Could not update metadata for ${id}:`,
+                error,
+              );
+            }
+
+            const relativePath = `gdd-assets/${id}/${id}-aligned.glb`;
+            console.log(`[Save Aligned] Saved: ${relativePath}`);
+
+            return { success: true, path: relativePath };
+          },
+          {
+            params: t.Object({
+              id: t.String({ minLength: 1 }),
+            }),
+            response: Models.SaveAlignedResponse,
+            detail: {
+              tags: ["Assets"],
+              summary: "Save aligned GLB model",
+              description: "Saves an aligned (fitted) GLB model for an asset.",
+            },
+          },
+        )
+
         // Upload VRM file
         .post(
           "/upload-vrm",

--- a/packages/asset-forge/src/components/Equipment/AssetSelectionPanel.tsx
+++ b/packages/asset-forge/src/components/Equipment/AssetSelectionPanel.tsx
@@ -1,6 +1,7 @@
 import {
   Search,
   ChevronRight,
+  ChevronDown,
   User,
   Sword,
   Shield,
@@ -59,29 +60,68 @@ export const AssetSelectionPanel: React.FC<AssetSelectionPanelProps> = ({
           a.name.toLowerCase().includes(searchTerm.toLowerCase()),
         );
 
-  // Group equipment by type
+  // Track collapsed subtype sections
+  const [collapsedSections, setCollapsedSections] = React.useState<Set<string>>(
+    new Set(),
+  );
+
+  const toggleSection = (section: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(section)) {
+        next.delete(section);
+      } else {
+        next.add(section);
+      }
+      return next;
+    });
+  };
+
+  // Group equipment by type, with weapons further grouped by subtype
   const groupedEquipment = React.useMemo(() => {
     if (assetTypeFilter !== "equipment") return {};
 
-    const groups: Record<string, Asset[]> = {
-      weapons: [],
-      tools: [],
-      shields: [],
-    };
+    const groups: Record<string, Asset[]> = {};
+    const tools: Asset[] = [];
+    const shields: Asset[] = [];
 
     filteredAssets.forEach((asset) => {
       const name = asset.name.toLowerCase();
       if (name.includes("shield") || asset.type === "shield") {
-        groups.shields.push(asset);
+        shields.push(asset);
       } else if (asset.type === "tool") {
-        groups.tools.push(asset);
+        tools.push(asset);
       } else {
-        groups.weapons.push(asset);
+        // Group weapons by subtype
+        const subtype = (asset.metadata?.subtype as string) || "other";
+        const groupKey = `weapon:${subtype}`;
+        if (!groups[groupKey]) {
+          groups[groupKey] = [];
+        }
+        groups[groupKey].push(asset);
       }
     });
 
+    // Add tools and shields as their own groups
+    if (tools.length > 0) groups["tools"] = tools;
+    if (shields.length > 0) groups["shields"] = shields;
+
     return groups;
   }, [assetTypeFilter, filteredAssets]);
+
+  // Format group label for display
+  const formatGroupLabel = (key: string): string => {
+    if (key === "tools") return "Tools";
+    if (key === "shields") return "Shields";
+    if (key.startsWith("weapon:")) {
+      const subtype = key.replace("weapon:", "");
+      if (subtype === "other") return "Other Weapons";
+      // Pluralize and capitalize
+      const label = subtype.replace(/_/g, " ");
+      return label.charAt(0).toUpperCase() + label.slice(1) + "s";
+    }
+    return key;
+  };
 
   // Get icon for asset type
   const getAssetIcon = (asset: Asset) => {
@@ -240,78 +280,89 @@ export const AssetSelectionPanel: React.FC<AssetSelectionPanelProps> = ({
               })}
             </div>
           ) : (
-            // Equipment list grouped by type
-            <div className="space-y-6">
+            // Equipment list grouped by type/subtype
+            <div className="space-y-4">
               {Object.entries(groupedEquipment).map(([group, groupAssets]) => {
                 if (groupAssets.length === 0) return null;
+                const isCollapsed = collapsedSections.has(group);
 
                 return (
                   <div key={group}>
-                    <h3 className="text-sm font-medium text-text-secondary mb-3 capitalize">
-                      {group} ({groupAssets.length})
-                    </h3>
-                    <div className="space-y-2">
-                      {groupAssets.map((asset) => {
-                        const Icon = getAssetIcon(asset);
-                        return (
-                          <button
-                            key={asset.id}
-                            onClick={() => onSelectEquipment(asset)}
-                            className={cn(
-                              "w-full p-4 rounded-xl border transition-all duration-200 text-left group",
-                              selectedEquipment?.id === asset.id
-                                ? "bg-primary/20 border-primary shadow-md shadow-primary/20"
-                                : "bg-bg-tertiary/20 border-white/10 hover:border-white/20 hover:bg-bg-tertiary/30",
-                            )}
-                          >
-                            <div className="flex items-center justify-between">
-                              <div className="flex items-center gap-3 flex-1">
-                                <div className="w-10 h-10 bg-bg-tertiary rounded flex items-center justify-center">
-                                  <Icon className="w-5 h-5 text-text-secondary" />
-                                </div>
-                                <div className="flex-1">
-                                  <p className="text-sm font-medium text-text-primary">
-                                    {asset.name}
-                                  </p>
-                                  <div className="flex items-center gap-2 mt-1">
-                                    <Badge
-                                      variant="secondary"
-                                      size="sm"
-                                      className="capitalize bg-bg-tertiary/50 text-text-secondary border border-white/10"
-                                    >
-                                      {asset.type}
-                                    </Badge>
-                                    {asset.modelFormat && (
+                    <button
+                      onClick={() => toggleSection(group)}
+                      className="flex items-center gap-2 w-full text-left text-sm font-medium text-text-secondary mb-2 hover:text-text-primary transition-colors"
+                    >
+                      {isCollapsed ? (
+                        <ChevronRight size={14} />
+                      ) : (
+                        <ChevronDown size={14} />
+                      )}
+                      {formatGroupLabel(group)} ({groupAssets.length})
+                    </button>
+                    {isCollapsed ? null : (
+                      <div className="space-y-2">
+                        {groupAssets.map((asset) => {
+                          const Icon = getAssetIcon(asset);
+                          return (
+                            <button
+                              key={asset.id}
+                              onClick={() => onSelectEquipment(asset)}
+                              className={cn(
+                                "w-full p-4 rounded-xl border transition-all duration-200 text-left group",
+                                selectedEquipment?.id === asset.id
+                                  ? "bg-primary/20 border-primary shadow-md shadow-primary/20"
+                                  : "bg-bg-tertiary/20 border-white/10 hover:border-white/20 hover:bg-bg-tertiary/30",
+                              )}
+                            >
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3 flex-1">
+                                  <div className="w-10 h-10 bg-bg-tertiary rounded flex items-center justify-center">
+                                    <Icon className="w-5 h-5 text-text-secondary" />
+                                  </div>
+                                  <div className="flex-1">
+                                    <p className="text-sm font-medium text-text-primary">
+                                      {asset.name}
+                                    </p>
+                                    <div className="flex items-center gap-2 mt-1">
                                       <Badge
-                                        variant="primary"
+                                        variant="secondary"
                                         size="sm"
-                                        className={
-                                          asset.modelFormat === "vrm"
-                                            ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
-                                            : "bg-primary/20 text-primary border border-primary/30"
-                                        }
+                                        className="capitalize bg-bg-tertiary/50 text-text-secondary border border-white/10"
                                       >
-                                        <Box size={10} className="mr-1" />
-                                        {asset.modelFormat.toUpperCase()}
+                                        {asset.type}
                                       </Badge>
-                                    )}
+                                      {asset.modelFormat && (
+                                        <Badge
+                                          variant="primary"
+                                          size="sm"
+                                          className={
+                                            asset.modelFormat === "vrm"
+                                              ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
+                                              : "bg-primary/20 text-primary border border-primary/30"
+                                          }
+                                        >
+                                          <Box size={10} className="mr-1" />
+                                          {asset.modelFormat.toUpperCase()}
+                                        </Badge>
+                                      )}
+                                    </div>
                                   </div>
                                 </div>
+                                <ChevronRight
+                                  size={18}
+                                  className={cn(
+                                    "text-text-tertiary transition-transform duration-200",
+                                    selectedEquipment?.id === asset.id
+                                      ? "translate-x-1 text-primary"
+                                      : "group-hover:translate-x-1",
+                                  )}
+                                />
                               </div>
-                              <ChevronRight
-                                size={18}
-                                className={cn(
-                                  "text-text-tertiary transition-transform duration-200",
-                                  selectedEquipment?.id === asset.id
-                                    ? "translate-x-1 text-primary"
-                                    : "group-hover:translate-x-1",
-                                )}
-                              />
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/packages/asset-forge/src/components/Equipment/BatchProgressOverlay.tsx
+++ b/packages/asset-forge/src/components/Equipment/BatchProgressOverlay.tsx
@@ -1,0 +1,233 @@
+import {
+  X,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Check,
+  SkipForward,
+} from "lucide-react";
+import React from "react";
+
+import { cn } from "../../styles";
+
+// Simple spinner overlay for quick batch operations (e.g. apply fitting)
+export interface BatchProgress {
+  current: number;
+  total: number;
+  currentAsset: string;
+  phase: "applying" | "exporting";
+}
+
+interface BatchProgressOverlayProps {
+  progress: BatchProgress;
+  onCancel: () => void;
+}
+
+export const BatchProgressOverlay: React.FC<BatchProgressOverlayProps> = ({
+  progress,
+  onCancel,
+}) => {
+  const percentage = Math.round((progress.current / progress.total) * 100);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-bg-primary border border-white/10 rounded-2xl shadow-2xl p-6 w-96 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-text-primary">
+            Applying Fitting Config
+          </h3>
+          <button
+            onClick={onCancel}
+            className="p-1.5 rounded-lg hover:bg-bg-tertiary/30 text-text-tertiary hover:text-text-primary transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
+          <Loader2 size={14} className="animate-spin text-primary" />
+          <span className="truncate">{progress.currentAsset}</span>
+        </div>
+
+        <div className="space-y-1">
+          <div className="w-full h-2 bg-bg-tertiary/30 rounded-full overflow-hidden">
+            <div
+              className="h-full rounded-full transition-all duration-300 bg-amber-500"
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-xs text-text-tertiary">
+            <span>
+              {progress.current} / {progress.total}
+            </span>
+            <span>{percentage}%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Review bar for stepping through weapons before export
+export interface BatchReviewState {
+  weapons: { id: string; name: string }[];
+  currentIndex: number;
+  exported: Set<string>;
+  isExporting: boolean;
+}
+
+interface BatchReviewBarProps {
+  review: BatchReviewState;
+  onPrev: () => void;
+  onNext: () => void;
+  onExportCurrent: () => void;
+  onExportAll: () => void;
+  onSkip: () => void;
+  onDone: () => void;
+}
+
+export const BatchReviewBar: React.FC<BatchReviewBarProps> = ({
+  review,
+  onPrev,
+  onNext,
+  onExportCurrent,
+  onExportAll,
+  onSkip,
+  onDone,
+}) => {
+  const current = review.weapons[review.currentIndex];
+  const isExported = current ? review.exported.has(current.id) : false;
+  const exportedCount = review.exported.size;
+  const total = review.weapons.length;
+  const allExported = exportedCount === total;
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 z-20 bg-bg-primary/90 backdrop-blur-md border-t border-white/10">
+      <div className="px-4 py-3 flex items-center gap-3">
+        {/* Navigation */}
+        <button
+          onClick={onPrev}
+          disabled={review.currentIndex === 0 || review.isExporting}
+          className={cn(
+            "p-2 rounded-lg border border-white/10 text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/30 transition-colors",
+            (review.currentIndex === 0 || review.isExporting) &&
+              "opacity-40 cursor-not-allowed",
+          )}
+        >
+          <ChevronLeft size={18} />
+        </button>
+
+        {/* Current weapon info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-tertiary font-mono">
+              {review.currentIndex + 1}/{total}
+            </span>
+            <span className="text-sm font-medium text-text-primary truncate">
+              {current?.name || "—"}
+            </span>
+            {isExported && (
+              <span className="flex items-center gap-1 text-xs text-emerald-400">
+                <Check size={12} />
+                exported
+              </span>
+            )}
+          </div>
+          {/* Progress dots */}
+          <div className="flex gap-1 mt-1.5">
+            {review.weapons.map((w, i) => (
+              <div
+                key={w.id}
+                className={cn(
+                  "h-1.5 rounded-full transition-all",
+                  i === review.currentIndex ? "w-4" : "w-1.5",
+                  review.exported.has(w.id)
+                    ? "bg-emerald-500"
+                    : i === review.currentIndex
+                      ? "bg-primary"
+                      : "bg-bg-tertiary/50",
+                )}
+              />
+            ))}
+          </div>
+        </div>
+
+        <button
+          onClick={onNext}
+          disabled={review.currentIndex === total - 1 || review.isExporting}
+          className={cn(
+            "p-2 rounded-lg border border-white/10 text-text-secondary hover:text-text-primary hover:bg-bg-tertiary/30 transition-colors",
+            (review.currentIndex === total - 1 || review.isExporting) &&
+              "opacity-40 cursor-not-allowed",
+          )}
+        >
+          <ChevronRight size={18} />
+        </button>
+
+        {/* Divider */}
+        <div className="w-px h-8 bg-white/10" />
+
+        {/* Actions */}
+        {review.isExporting ? (
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
+            <Loader2 size={14} className="animate-spin" />
+            Exporting...
+          </div>
+        ) : (
+          <>
+            <button
+              onClick={onSkip}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium text-text-tertiary hover:text-text-secondary hover:bg-bg-tertiary/20 transition-colors flex items-center gap-1.5"
+            >
+              <SkipForward size={12} />
+              Skip
+            </button>
+            <button
+              onClick={onExportCurrent}
+              disabled={isExported}
+              className={cn(
+                "px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-1.5 transition-all",
+                isExported
+                  ? "bg-emerald-500/10 text-emerald-400/50 cursor-not-allowed"
+                  : "bg-emerald-500/20 border border-emerald-500/30 text-emerald-300 hover:bg-emerald-500/30",
+              )}
+            >
+              <Download size={14} />
+              {isExported ? "Exported" : "Export"}
+            </button>
+            <button
+              onClick={allExported ? onDone : onExportAll}
+              className={cn(
+                "px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-1.5 transition-all",
+                allExported
+                  ? "bg-primary/80 text-white hover:bg-primary"
+                  : "bg-bg-secondary/50 border border-white/10 text-text-primary hover:bg-bg-secondary/70",
+              )}
+            >
+              {allExported ? (
+                <>
+                  <Check size={14} />
+                  Done
+                </>
+              ) : exportedCount > 0 ? (
+                `Export Remaining (${total - exportedCount})`
+              ) : (
+                `Export All (${total})`
+              )}
+            </button>
+          </>
+        )}
+
+        {/* Close */}
+        <button
+          onClick={onDone}
+          disabled={review.isExporting}
+          className="p-2 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary/30 transition-colors"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/asset-forge/src/components/Equipment/EquipmentViewer.tsx
+++ b/packages/asset-forge/src/components/Equipment/EquipmentViewer.tsx
@@ -34,6 +34,7 @@ interface EquipmentViewerProps {
   positionOffset?: { x: number; y: number; z: number }; // Manual position adjustment in meters
   isAnimating?: boolean; // Whether to play animations
   animationType?: "tpose" | "walking" | "running"; // Which animation to play
+  onEquipmentLoaded?: () => void; // Callback when equipment finishes loading and is positioned
 }
 
 export interface EquipmentViewerRef {
@@ -48,6 +49,10 @@ export interface EquipmentViewerRef {
   getAvatar?: () => THREE.Object3D | null;
   getEquipment?: () => THREE.Object3D | null;
   forceRender?: () => void;
+  /** Returns the computed target scale (before bone compensation) or null if no equipment loaded */
+  getEquipmentScale?: () => number | null;
+  /** Swap the visual mesh content without touching any transforms — for batch review */
+  swapEquipmentContent?: (newEquipmentUrl: string) => Promise<void>;
 }
 
 const BONE_MAPPING: Record<string, string[]> = {
@@ -117,6 +122,7 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
       positionOffset = { x: 0, y: 0, z: 0 },
       isAnimating = false,
       animationType = "tpose",
+      onEquipmentLoaded,
     } = props;
 
     const [isInitialized, setIsInitialized] = useState(false);
@@ -555,6 +561,83 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
       return scaleFactor;
     };
 
+    /**
+     * Compute the average vertex position (centroid) of all meshes.
+     * Unlike bbox center (which is the midpoint of min/max), the vertex
+     * centroid is biased toward areas with denser geometry — e.g. a dagger
+     * blade has more vertices than its handle, so the centroid is offset
+     * toward the blade. This asymmetry is used to detect 180° flips during
+     * batch weapon swap.
+     */
+    const computeVertexCentroid = (obj: THREE.Object3D): THREE.Vector3 => {
+      const centroid = new THREE.Vector3();
+      let totalVertices = 0;
+      obj.traverse((child) => {
+        if (
+          child instanceof THREE.Mesh &&
+          !(child instanceof THREE.SkinnedMesh)
+        ) {
+          const pos = child.geometry.getAttribute("position");
+          if (pos) {
+            for (let i = 0; i < pos.count; i++) {
+              centroid.x += pos.getX(i);
+              centroid.y += pos.getY(i);
+              centroid.z += pos.getZ(i);
+              totalVertices++;
+            }
+          }
+        }
+      });
+      if (totalVertices > 0) {
+        centroid.divideScalar(totalVertices);
+      }
+      return centroid;
+    };
+
+    /**
+     * Bake all intermediate node transforms into mesh geometry so that every
+     * mesh's vertex positions are in scene-root-local space and every node
+     * transform is identity.  This eliminates GLTF hierarchy differences
+     * between weapons — two weapons with identical raw geometry bounds will
+     * occupy the exact same visual space regardless of internal node structure.
+     */
+    const flattenSceneTransforms = (scene: THREE.Object3D): void => {
+      // Compute matrixWorld with the ORIGINAL transforms first — if the scene
+      // root has scale/rotation (common for Meshy AI GLTFs), those transforms
+      // must be baked into geometry before we reset them to identity.
+      scene.updateMatrixWorld(true);
+
+      // First pass: bake world transform into each mesh's geometry
+      scene.traverse((child) => {
+        if (
+          child instanceof THREE.Mesh &&
+          !(child instanceof THREE.SkinnedMesh)
+        ) {
+          child.geometry = child.geometry.clone();
+          child.geometry.applyMatrix4(child.matrixWorld);
+          child.position.set(0, 0, 0);
+          child.quaternion.identity();
+          child.scale.set(1, 1, 1);
+          child.updateMatrix();
+        }
+      });
+
+      // Second pass: reset scene root and all non-mesh intermediate nodes
+      scene.position.set(0, 0, 0);
+      scene.quaternion.identity();
+      scene.scale.set(1, 1, 1);
+      scene.traverse((child) => {
+        if (child !== scene && !(child instanceof THREE.Mesh)) {
+          child.position.set(0, 0, 0);
+          child.quaternion.identity();
+          child.scale.set(1, 1, 1);
+          child.updateMatrix();
+        }
+      });
+
+      scene.updateMatrixWorld(true);
+    };
+
     // Helper: default orientation based on weapon type
     const calculateWeaponOrientation = (
       _weapon: THREE.Object3D,
@@ -902,23 +985,73 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
               `🎯 Grip offset detected: (${gripOffset.x.toFixed(3)}, ${gripOffset.y.toFixed(3)}, ${gripOffset.z.toFixed(3)})`,
             );
 
-            // IMPORTANT: Reset scale on loaded equipment before normalizing
-            // This ensures we're working with the original size
-            loadedEquipment.scale.set(1, 1, 1);
-            loadedEquipment.traverse((child) => {
-              if (child instanceof THREE.Mesh) {
-                child.scale.set(1, 1, 1);
-              }
-            });
+            // Flatten ALL intermediate transforms into geometry so that
+            // two GLTFs with different internal hierarchies but identical raw
+            // geometry bounds produce the same visual result.
+            flattenSceneTransforms(loadedEquipment);
+
+            // Store original geometry bbox info for batch review corrections.
+            // Different weapons from Meshy AI have geometry at different origins
+            // and orientations — during swap we correct for these differences.
+            const origBox = new THREE.Box3().setFromObject(loadedEquipment);
+            const origCenter = new THREE.Vector3();
+            origBox.getCenter(origCenter);
+            const origSize = new THREE.Vector3();
+            origBox.getSize(origSize);
+            const origDims = [origSize.x, origSize.y, origSize.z];
+            const origLongestAxis = origDims.indexOf(Math.max(...origDims));
+
+            // Vertex centroid is biased toward denser geometry (blade > handle).
+            // Used during batch swap to detect 180° flips after axis alignment.
+            const origCentroid = computeVertexCentroid(loadedEquipment);
+            const origCentroidBias =
+              origCentroid.getComponent(origLongestAxis) -
+              origCenter.getComponent(origLongestAxis);
 
             equipment = createNormalizedWeapon(loadedEquipment, gripVector);
             equipment.userData.isNormalized = true;
-            console.log(`✅ Using normalized weapon with grip at origin`);
+            equipment.userData.originalBBoxCenter = origCenter;
+            equipment.userData.originalLongestAxis = origLongestAxis;
+            equipment.userData.originalCentroidBias = origCentroidBias;
+            // Persist the grip offset for reliable retrieval during batch swaps
+            equipment.userData.normalizedGripOffset = equipment.children[0]
+              ? equipment.children[0].position.clone()
+              : new THREE.Vector3();
+            console.log(
+              `✅ Using normalized weapon with grip at origin, bbox center: (${origCenter.x.toFixed(3)}, ${origCenter.y.toFixed(3)}, ${origCenter.z.toFixed(3)}), longestAxis: ${origLongestAxis}, centroidBias: ${origCentroidBias.toFixed(4)}`,
+            );
           } else {
+            flattenSceneTransforms(loadedEquipment);
+
+            // Store original geometry bbox info for batch review corrections
+            const origBoxNoGrip = new THREE.Box3().setFromObject(
+              loadedEquipment,
+            );
+            const origCenterNoGrip = new THREE.Vector3();
+            origBoxNoGrip.getCenter(origCenterNoGrip);
+            const origSizeNoGrip = new THREE.Vector3();
+            origBoxNoGrip.getSize(origSizeNoGrip);
+            const origDimsNoGrip = [
+              origSizeNoGrip.x,
+              origSizeNoGrip.y,
+              origSizeNoGrip.z,
+            ];
+            const origLongestAxisNoGrip = origDimsNoGrip.indexOf(
+              Math.max(...origDimsNoGrip),
+            );
+
+            const origCentroidNoGrip = computeVertexCentroid(loadedEquipment);
+            const origCentroidBiasNoGrip =
+              origCentroidNoGrip.getComponent(origLongestAxisNoGrip) -
+              origCenterNoGrip.getComponent(origLongestAxisNoGrip);
+
             equipment = loadedEquipment;
             equipment.userData.isNormalized = false;
+            equipment.userData.originalBBoxCenter = origCenterNoGrip;
+            equipment.userData.originalLongestAxis = origLongestAxisNoGrip;
+            equipment.userData.originalCentroidBias = origCentroidBiasNoGrip;
             console.log(
-              `✅ Using weapon as-is (no grip offset or already normalized)`,
+              `✅ Using weapon as-is (no grip offset), bbox center: (${origCenterNoGrip.x.toFixed(3)}, ${origCenterNoGrip.y.toFixed(3)}, ${origCenterNoGrip.z.toFixed(3)}), longestAxis: ${origLongestAxisNoGrip}, centroidBias: ${origCentroidBiasNoGrip.toFixed(4)}`,
             );
           }
 
@@ -965,6 +1098,9 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
             // No avatar loaded yet, just apply base scale
             equipment.scale.set(scaleOverride, scaleOverride, scaleOverride);
           }
+
+          // Notify parent that equipment is loaded and positioned
+          onEquipmentLoaded?.();
         } catch (error) {
           console.error("Failed to load equipment:", error);
         }
@@ -977,8 +1113,9 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
       equipmentUrl,
       weaponType,
       avatarHeight,
-      autoScale,
-      scaleOverride,
+      // NOTE: autoScale and scaleOverride intentionally omitted — changing them
+      // should NOT trigger a full equipment reload. The dedicated scale useEffect
+      // below handles scale prop changes without destroying/rebuilding the mesh.
       gripOffset?.x,
       gripOffset?.y,
       gripOffset?.z,
@@ -2015,6 +2152,256 @@ const EquipmentViewer = forwardRef<EquipmentViewerRef, EquipmentViewerProps>(
         if (rendererRef.current && sceneRef.current && cameraRef.current) {
           rendererRef.current.render(sceneRef.current, cameraRef.current);
         }
+      },
+
+      getEquipmentScale: () => {
+        return equipmentRef.current?.userData.targetScale ?? null;
+      },
+
+      swapEquipmentContent: async (newEquipmentUrl: string) => {
+        if (!equipmentRef.current || !avatarRef.current) return;
+
+        const oldEquip = equipmentRef.current;
+        const wrapper = oldEquip.parent;
+
+        // Capture normalization state from the original equipment before disposal.
+        // If the initial load used grip detection, we need to replicate the
+        // NormalizedWeapon structure for the new weapon so it appears at the
+        // same position (grip at origin).
+        const wasNormalized = oldEquip.userData.isNormalized === true;
+        const savedGripOffset = oldEquip.userData.normalizedGripOffset
+          ? (oldEquip.userData.normalizedGripOffset as THREE.Vector3).clone()
+          : null;
+        const savedBBoxCenter = oldEquip.userData.originalBBoxCenter
+          ? (oldEquip.userData.originalBBoxCenter as THREE.Vector3).clone()
+          : null;
+        const savedLongestAxis =
+          typeof oldEquip.userData.originalLongestAxis === "number"
+            ? (oldEquip.userData.originalLongestAxis as number)
+            : null;
+        const savedCentroidBias =
+          typeof oldEquip.userData.originalCentroidBias === "number"
+            ? (oldEquip.userData.originalCentroidBias as number)
+            : null;
+
+        console.log(
+          `🔄 Swap: wasNormalized=${wasNormalized}, savedGripOffset=${savedGripOffset ? `(${savedGripOffset.x.toFixed(3)}, ${savedGripOffset.y.toFixed(3)}, ${savedGripOffset.z.toFixed(3)})` : "none"}, savedBBoxCenter=${savedBBoxCenter ? `(${savedBBoxCenter.x.toFixed(3)}, ${savedBBoxCenter.y.toFixed(3)}, ${savedBBoxCenter.z.toFixed(3)})` : "none"}, savedLongestAxis=${savedLongestAxis}, savedCentroidBias=${savedCentroidBias?.toFixed(4) ?? "none"}`,
+        );
+
+        // Load new weapon GLB
+        const newGltf = await loader.current.loadAsync(newEquipmentUrl);
+        const newScene = newGltf.scene;
+
+        // Mirror loadEquipment: flatten ALL intermediate transforms into
+        // geometry so GLTF hierarchy differences are eliminated.
+        flattenSceneTransforms(newScene);
+
+        // Step 1: Axis alignment — some GLTFs have the blade oriented along
+        // a different axis after flattening (e.g. adamant along Y, bronze
+        // along Z). Rotate geometry so the longest axis matches the original.
+        if (savedLongestAxis !== null) {
+          const axisBox = new THREE.Box3().setFromObject(newScene);
+          const axisSize = new THREE.Vector3();
+          axisBox.getSize(axisSize);
+          const dims = [axisSize.x, axisSize.y, axisSize.z];
+          const newLongestAxis = dims.indexOf(Math.max(...dims));
+
+          if (newLongestAxis !== savedLongestAxis) {
+            // Build a rotation matrix that maps newLongestAxis → savedLongestAxis
+            const rotMatrix = new THREE.Matrix4();
+            if (newLongestAxis === 0 && savedLongestAxis === 1) {
+              rotMatrix.makeRotationZ(Math.PI / 2);
+            } else if (newLongestAxis === 0 && savedLongestAxis === 2) {
+              rotMatrix.makeRotationY(-Math.PI / 2);
+            } else if (newLongestAxis === 1 && savedLongestAxis === 0) {
+              rotMatrix.makeRotationZ(-Math.PI / 2);
+            } else if (newLongestAxis === 1 && savedLongestAxis === 2) {
+              rotMatrix.makeRotationX(Math.PI / 2);
+            } else if (newLongestAxis === 2 && savedLongestAxis === 0) {
+              rotMatrix.makeRotationY(Math.PI / 2);
+            } else if (newLongestAxis === 2 && savedLongestAxis === 1) {
+              rotMatrix.makeRotationX(-Math.PI / 2);
+            }
+
+            console.log(
+              `🔄 Swap: rotating geometry axis ${newLongestAxis} → ${savedLongestAxis} (dims: ${axisSize.x.toFixed(3)}, ${axisSize.y.toFixed(3)}, ${axisSize.z.toFixed(3)})`,
+            );
+            newScene.traverse((child) => {
+              if (
+                child instanceof THREE.Mesh &&
+                !(child instanceof THREE.SkinnedMesh)
+              ) {
+                child.geometry.applyMatrix4(rotMatrix);
+              }
+            });
+          }
+        }
+
+        // Step 1b: Flip detection — axis alignment resolves which axis is
+        // longest but has a 180° ambiguity (blade vs handle end).  Compare
+        // vertex-centroid bias along the longest axis: the centroid is pulled
+        // toward denser geometry (blade > handle).  If the bias sign differs
+        // from the original, the weapon is flipped and needs a 180° rotation.
+        if (savedLongestAxis !== null && savedCentroidBias !== null) {
+          const newCentroid = computeVertexCentroid(newScene);
+          const newBBox = new THREE.Box3().setFromObject(newScene);
+          const newBBoxCenter = new THREE.Vector3();
+          newBBox.getCenter(newBBoxCenter);
+          const newCentroidBias =
+            newCentroid.getComponent(savedLongestAxis) -
+            newBBoxCenter.getComponent(savedLongestAxis);
+
+          // If the signs differ (one positive, one negative) and both are
+          // non-negligible, the weapon is flipped 180°.
+          const biasThreshold = 0.001;
+          if (
+            Math.abs(savedCentroidBias) > biasThreshold &&
+            Math.abs(newCentroidBias) > biasThreshold &&
+            Math.sign(savedCentroidBias) !== Math.sign(newCentroidBias)
+          ) {
+            // 180° rotation around a perpendicular axis flips the weapon
+            const flipMatrix = new THREE.Matrix4();
+            if (savedLongestAxis === 0) {
+              flipMatrix.makeRotationY(Math.PI); // flip along X
+            } else if (savedLongestAxis === 1) {
+              flipMatrix.makeRotationX(Math.PI); // flip along Y
+            } else {
+              flipMatrix.makeRotationX(Math.PI); // flip along Z
+            }
+
+            console.log(
+              `🔄 Swap: flipping 180° along axis ${savedLongestAxis} (origBias: ${savedCentroidBias.toFixed(4)}, newBias: ${newCentroidBias.toFixed(4)})`,
+            );
+            newScene.traverse((child) => {
+              if (
+                child instanceof THREE.Mesh &&
+                !(child instanceof THREE.SkinnedMesh)
+              ) {
+                child.geometry.applyMatrix4(flipMatrix);
+              }
+            });
+          } else {
+            console.log(
+              `✅ Swap: no flip needed (origBias: ${savedCentroidBias.toFixed(4)}, newBias: ${newCentroidBias.toFixed(4)})`,
+            );
+          }
+        }
+
+        // Step 2: Position alignment — after axis alignment, shift the bbox
+        // center to match the original weapon so the grip offset is valid.
+        if (savedBBoxCenter) {
+          const newBox = new THREE.Box3().setFromObject(newScene);
+          const newCenter = new THREE.Vector3();
+          newBox.getCenter(newCenter);
+          const shift = savedBBoxCenter.clone().sub(newCenter);
+
+          if (shift.length() > 0.001) {
+            console.log(
+              `📐 Swap: shifting geometry by (${shift.x.toFixed(3)}, ${shift.y.toFixed(3)}, ${shift.z.toFixed(3)}) to match original bbox center`,
+            );
+            newScene.traverse((child) => {
+              if (
+                child instanceof THREE.Mesh &&
+                !(child instanceof THREE.SkinnedMesh)
+              ) {
+                child.geometry.translate(shift.x, shift.y, shift.z);
+              }
+            });
+          }
+        }
+
+        // Build the equipment object the same way loadEquipment does:
+        // - If the original was normalized (grip detected), wrap in a
+        //   NormalizedWeapon group using the same grip offset
+        // - Otherwise, use the flattened scene directly
+        let equipment: THREE.Object3D;
+        if (wasNormalized && savedGripOffset) {
+          const weaponGroup = new THREE.Group();
+          weaponGroup.name = "NormalizedWeapon";
+          weaponGroup.userData.isNormalized = true;
+
+          // Position the flattened+shifted scene at the saved grip offset
+          // (this is the -transformedGrip value from createNormalizedWeapon)
+          newScene.position.copy(savedGripOffset);
+          newScene.updateMatrix();
+          weaponGroup.add(newScene);
+
+          equipment = weaponGroup;
+          equipment.userData.isNormalized = true;
+          equipment.userData.normalizedGripOffset = savedGripOffset.clone();
+          equipment.userData.originalBBoxCenter = savedBBoxCenter
+            ? savedBBoxCenter.clone()
+            : null;
+          equipment.userData.originalLongestAxis = savedLongestAxis;
+          equipment.userData.originalCentroidBias = savedCentroidBias;
+          console.log(
+            `✅ Swap: created NormalizedWeapon with grip offset (${savedGripOffset.x.toFixed(3)}, ${savedGripOffset.y.toFixed(3)}, ${savedGripOffset.z.toFixed(3)})`,
+          );
+        } else {
+          equipment = newScene;
+          equipment.userData.isNormalized = false;
+          equipment.userData.originalBBoxCenter = savedBBoxCenter
+            ? savedBBoxCenter.clone()
+            : null;
+          equipment.userData.originalLongestAxis = savedLongestAxis;
+          equipment.userData.originalCentroidBias = savedCentroidBias;
+        }
+
+        // Measure scale on the STANDALONE equipment (not in bone hierarchy)
+        // before any parenting — mirrors how loadEquipment works.
+        const effectiveHeight =
+          avatarHeight || calculateAvatarHeight(avatarRef.current);
+        const autoScaleFactor = autoScale
+          ? calculateWeaponScale(
+              equipment,
+              avatarRef.current,
+              weaponType,
+              effectiveHeight,
+            )
+          : 1.0;
+        const newTargetScale = scaleOverride * autoScaleFactor;
+
+        // Remove old equipment from wrapper and dispose
+        if (wrapper) wrapper.remove(oldEquip);
+        oldEquip.traverse((c) => {
+          if (c instanceof THREE.Mesh) {
+            c.geometry?.dispose();
+            const mats = Array.isArray(c.material) ? c.material : [c.material];
+            mats.forEach((m: THREE.Material) => m.dispose());
+          }
+        });
+
+        // Set up equipment metadata
+        equipment.userData.isEquipment = true;
+        equipment.userData.targetScale = newTargetScale;
+
+        // Enable shadows
+        equipment.traverse((c) => {
+          if (c instanceof THREE.Mesh) {
+            c.castShadow = true;
+            c.receiveShadow = true;
+          }
+        });
+
+        // Add to existing wrapper (keeps same bone parent)
+        if (wrapper && wrapper.name === "EquipmentWrapper") {
+          wrapper.add(equipment);
+        }
+        equipmentRef.current = equipment;
+        shouldAttachEquipmentRef.current = true;
+
+        // Re-run attachment — handles position, rotation, and scale
+        // identically to how loadEquipment + attachEquipmentToAvatar works.
+        attachEquipmentToAvatar();
+
+        console.log(
+          "🔄 Swapped equipment:",
+          newEquipmentUrl,
+          "scale:",
+          newTargetScale.toFixed(3),
+          "normalized:",
+          wasNormalized,
+        );
       },
     }));
 

--- a/packages/asset-forge/src/components/Equipment/ExportOptionsPanel.tsx
+++ b/packages/asset-forge/src/components/Equipment/ExportOptionsPanel.tsx
@@ -1,4 +1,4 @@
-import { Download, Save } from "lucide-react";
+import { Download, Save, Copy, Layers } from "lucide-react";
 import React from "react";
 
 import { cn } from "../../styles";
@@ -10,6 +10,9 @@ interface ExportOptionsPanelProps {
   onSaveConfiguration: () => void;
   onExportAlignedModel: () => void;
   onExportEquippedAvatar: () => void;
+  assets?: Asset[];
+  onBatchApplyFitting?: () => void;
+  onBatchExportAligned?: () => void;
 }
 
 export const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
@@ -18,7 +21,32 @@ export const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
   onSaveConfiguration,
   onExportAlignedModel,
   onExportEquippedAvatar,
+  assets = [],
+  onBatchApplyFitting,
+  onBatchExportAligned,
 }) => {
+  // Count same-subtype weapons for batch operations
+  const selectedSubtype = selectedEquipment?.metadata?.subtype as
+    | string
+    | undefined;
+  const sameSubtypeCount = React.useMemo(() => {
+    if (!selectedEquipment || !selectedSubtype) return 0;
+    return assets.filter(
+      (a) =>
+        a.type === "weapon" &&
+        (a.metadata?.subtype as string) === selectedSubtype &&
+        a.id !== selectedEquipment.id &&
+        a.hasModel,
+    ).length;
+  }, [assets, selectedEquipment, selectedSubtype]);
+
+  const hasFitting = selectedEquipment && selectedAvatar;
+
+  const canBatch = hasFitting && sameSubtypeCount > 0;
+
+  const subtypeLabel = selectedSubtype
+    ? selectedSubtype.replace(/_/g, " ")
+    : "";
   return (
     <div className="bg-bg-primary/40 backdrop-blur-sm rounded-xl border border-white/10 overflow-hidden">
       <div className="p-4 border-b border-white/5">
@@ -82,6 +110,42 @@ export const ExportOptionsPanel: React.FC<ExportOptionsPanelProps> = ({
             <span>Export Avatar</span>
           </button>
         </div>
+
+        {/* Batch operations */}
+        {selectedSubtype && sameSubtypeCount > 0 && (
+          <div className="pt-3 border-t border-white/5 space-y-2">
+            <p className="text-xs text-text-tertiary">
+              Batch ({sameSubtypeCount} other {subtypeLabel}
+              {sameSubtypeCount !== 1 ? "s" : ""})
+            </p>
+            <button
+              onClick={onBatchApplyFitting}
+              disabled={!canBatch}
+              className={cn(
+                "w-full px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 flex items-center justify-center gap-2",
+                "bg-amber-500/20 border border-amber-500/30 text-amber-300",
+                "hover:bg-amber-500/30 hover:border-amber-500/40",
+                !canBatch && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              <Copy size={14} />
+              <span>Apply Fitting to All {subtypeLabel}s</span>
+            </button>
+            <button
+              onClick={onBatchExportAligned}
+              disabled={!canBatch}
+              className={cn(
+                "w-full px-3 py-2 rounded-lg text-sm font-medium transition-all duration-300 flex items-center justify-center gap-2",
+                "bg-emerald-500/20 border border-emerald-500/30 text-emerald-300",
+                "hover:bg-emerald-500/30 hover:border-emerald-500/40",
+                !canBatch && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              <Layers size={14} />
+              <span>Review & Export All {subtypeLabel}s</span>
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/asset-forge/src/components/Equipment/ViewportSection.tsx
+++ b/packages/asset-forge/src/components/Equipment/ViewportSection.tsx
@@ -34,6 +34,7 @@ interface ViewportSectionProps {
   setCurrentAnimation: (animation: "tpose" | "walking" | "running") => void;
   isAnimationPlaying: boolean;
   setIsAnimationPlaying: (playing: boolean) => void;
+  onEquipmentLoaded?: () => void;
 }
 
 export const ViewportSection: React.FC<ViewportSectionProps> = ({
@@ -53,6 +54,7 @@ export const ViewportSection: React.FC<ViewportSectionProps> = ({
   setCurrentAnimation,
   isAnimationPlaying,
   setIsAnimationPlaying,
+  onEquipmentLoaded,
 }) => {
   const getAvatarUrl = () => {
     if (!selectedAvatar) return undefined;
@@ -112,6 +114,7 @@ export const ViewportSection: React.FC<ViewportSectionProps> = ({
               positionOffset={manualPosition}
               isAnimating={isAnimationPlaying && currentAnimation !== "tpose"}
               animationType={currentAnimation}
+              onEquipmentLoaded={onEquipmentLoaded}
             />
 
             {/* Viewport Controls */}

--- a/packages/asset-forge/src/components/Equipment/index.ts
+++ b/packages/asset-forge/src/components/Equipment/index.ts
@@ -6,3 +6,5 @@ export { OrientationControls } from "./OrientationControls";
 export { PositionControls } from "./PositionControls";
 export { CreatureSizeControls } from "./CreatureSizeControls";
 export { ExportOptionsPanel } from "./ExportOptionsPanel";
+export { BatchProgressOverlay, BatchReviewBar } from "./BatchProgressOverlay";
+export type { BatchProgress, BatchReviewState } from "./BatchProgressOverlay";

--- a/packages/asset-forge/src/constants/equipment.ts
+++ b/packages/asset-forge/src/constants/equipment.ts
@@ -56,6 +56,10 @@ export const EQUIPMENT_TYPES = {
 // Weapon subtypes
 export const WEAPON_SUBTYPES = {
   sword: "sword",
+  shortsword: "shortsword",
+  longsword: "longsword",
+  scimitar: "scimitar",
+  "2h_sword": "2h_sword",
   axe: "axe",
   mace: "mace",
   spear: "spear",
@@ -76,6 +80,10 @@ export type WeaponSubtype =
 // Minimum weapon sizes to maintain visibility
 export const MIN_WEAPON_SIZES: Record<string, number> = {
   sword: 0.5,
+  shortsword: 0.35,
+  longsword: 0.5,
+  scimitar: 0.45,
+  "2h_sword": 0.8,
   dagger: 0.15,
   axe: 0.3,
   mace: 0.3,
@@ -90,6 +98,10 @@ export const MIN_WEAPON_SIZES: Record<string, number> = {
 // Maximum weapon sizes for game balance
 export const MAX_WEAPON_SIZES: Record<string, number> = {
   sword: 3.0,
+  shortsword: 2.0,
+  longsword: 3.0,
+  scimitar: 2.5,
+  "2h_sword": 4.5,
   dagger: 0.8,
   axe: 2.5,
   mace: 2.0,
@@ -105,6 +117,10 @@ export const MAX_WEAPON_SIZES: Record<string, number> = {
 // Values represent percentage of creature height
 export const BASE_WEAPON_PROPORTIONS: Record<string, number> = {
   sword: 0.65, // 65% of height
+  shortsword: 0.45, // 45% of height
+  longsword: 0.65, // 65% of height
+  scimitar: 0.55, // 55% of height
+  "2h_sword": 0.9, // 90% of height
   dagger: 0.25, // 25% of height
   axe: 0.5, // 50% of height
   mace: 0.45, // 45% of height

--- a/packages/asset-forge/src/pages/EquipmentPage.tsx
+++ b/packages/asset-forge/src/pages/EquipmentPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 
 import { Asset } from "../types";
 import { getAssetModelUrl, getFullUrl } from "../utils/api";
@@ -13,7 +13,10 @@ import {
   PositionControls,
   CreatureSizeControls,
   ExportOptionsPanel,
+  BatchProgressOverlay,
+  BatchReviewBar,
 } from "@/components/Equipment";
+import type { BatchProgress, BatchReviewState } from "@/components/Equipment";
 import { EquipmentViewerRef } from "@/components/Equipment/EquipmentViewer";
 import { useAssets } from "@/hooks";
 import { WeaponHandleDetector } from "@/services/processing/WeaponHandleDetector";
@@ -53,6 +56,15 @@ export const EquipmentPage: React.FC = () => {
     "tpose" | "walking" | "running"
   >("tpose");
   const [isAnimationPlaying, setIsAnimationPlaying] = useState(false);
+
+  // Batch operation state
+  const [batchProgress, setBatchProgress] = useState<BatchProgress | null>(
+    null,
+  );
+  const [batchReview, setBatchReview] = useState<BatchReviewState | null>(null);
+  const batchCancelRef = useRef(false);
+  // Preserve the equipment selected before entering review mode
+  const preReviewEquipmentRef = useRef<Asset | null>(null);
 
   const viewerRef = useRef<EquipmentViewerRef>(null);
   const handleDetector = useRef<WeaponHandleDetector | null>(null);
@@ -198,17 +210,288 @@ export const EquipmentPage: React.FC = () => {
     }
   };
 
+  // Called by EquipmentViewer when equipment finishes loading
+  const handleEquipmentLoaded = useCallback(() => {
+    // Currently unused but kept as a hook for future features
+  }, []);
+
+  // Get all same-subtype weapon assets (excluding selected)
+  const getSameSubtypeAssets = (): Asset[] => {
+    if (!selectedEquipment) return [];
+    const subtype = selectedEquipment.metadata?.subtype as string | undefined;
+    if (!subtype) return [];
+    return assets.filter(
+      (a) =>
+        a.type === "weapon" &&
+        (a.metadata?.subtype as string) === subtype &&
+        a.id !== selectedEquipment.id &&
+        a.hasModel,
+    );
+  };
+
+  const handleBatchApplyFitting = async () => {
+    if (!selectedEquipment || !selectedAvatar) return;
+
+    const sameSubtype = getSameSubtypeAssets();
+    if (sameSubtype.length === 0) {
+      notify.error("No other weapons of the same subtype found");
+      return;
+    }
+
+    const config = {
+      hyperscapeAttachment: {
+        vrmBoneName:
+          equipmentSlot === "Hand_R"
+            ? "rightHand"
+            : equipmentSlot === "Hand_L"
+              ? "leftHand"
+              : "rightHand",
+        position: manualPosition,
+        rotation: manualRotation,
+        scale: weaponScaleOverride,
+        gripPoint: handleDetectionResult?.gripPoint || { x: 0, y: 0, z: 0 },
+        avatarHeight,
+        weaponType: selectedEquipment.type || "weapon",
+        testedWithAvatar: selectedAvatar.id,
+        lastUpdated: new Date().toISOString(),
+      },
+    };
+
+    const assetIds = sameSubtype.map((a) => a.id);
+
+    setBatchProgress({
+      current: 0,
+      total: assetIds.length,
+      currentAsset: "Starting...",
+      phase: "applying",
+    });
+    batchCancelRef.current = false;
+
+    try {
+      const response = await fetch(
+        getFullUrl("/api/assets/batch-apply-fitting"),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ config, assetIds }),
+        },
+      );
+
+      if (!response.ok) throw new Error("Batch apply fitting failed");
+
+      const result = await response.json();
+      notify.success(`Fitting applied to ${result.updated} weapons`);
+    } catch (error) {
+      console.error("Batch apply fitting failed:", error);
+      notify.error("Failed to batch apply fitting");
+    } finally {
+      setBatchProgress(null);
+    }
+  };
+
+  // --- Batch Review Mode ---
+
+  const handleStartBatchReview = () => {
+    if (!selectedEquipment || !selectedAvatar) return;
+
+    const sameSubtype = getSameSubtypeAssets();
+    const allWeapons = [selectedEquipment, ...sameSubtype];
+
+    if (allWeapons.length <= 1) {
+      notify.error("No other weapons of the same subtype found");
+      return;
+    }
+
+    preReviewEquipmentRef.current = selectedEquipment;
+
+    setBatchReview({
+      weapons: allWeapons.map((w) => ({ id: w.id, name: w.name })),
+      currentIndex: 0,
+      exported: new Set(),
+      isExporting: false,
+    });
+  };
+
+  const handleReviewNavigate = async (index: number) => {
+    if (!batchReview || batchReview.isExporting) return;
+    if (index < 0 || index >= batchReview.weapons.length) return;
+
+    const weapon = batchReview.weapons[index];
+    const asset = assets.find((a) => a.id === weapon.id);
+    if (!asset) return;
+
+    setBatchReview((prev) => (prev ? { ...prev, currentIndex: index } : null));
+
+    // Swap only the visual mesh content — keeps all transforms locked
+    if (viewerRef.current?.swapEquipmentContent) {
+      const url = getAssetModelUrl(asset.id);
+      await viewerRef.current.swapEquipmentContent(url);
+    }
+  };
+
+  const handleReviewPrev = () => {
+    if (batchReview) handleReviewNavigate(batchReview.currentIndex - 1);
+  };
+
+  const handleReviewNext = () => {
+    if (batchReview) handleReviewNavigate(batchReview.currentIndex + 1);
+  };
+
+  const handleReviewSkip = () => {
+    if (!batchReview) return;
+    if (batchReview.currentIndex < batchReview.weapons.length - 1) {
+      handleReviewNavigate(batchReview.currentIndex + 1);
+    }
+  };
+
+  // Export a single weapon (the one currently shown in the viewer)
+  const exportCurrentWeapon = async (weaponOverride?: {
+    id: string;
+    name: string;
+  }): Promise<boolean> => {
+    if (!batchReview || !viewerRef.current) return false;
+
+    const weapon =
+      weaponOverride || batchReview.weapons[batchReview.currentIndex];
+
+    setBatchReview((prev) => (prev ? { ...prev, isExporting: true } : null));
+
+    try {
+      const alignedModel = await viewerRef.current.exportAlignedEquipment();
+      if (alignedModel.byteLength === 0) {
+        notify.error(`Empty export for ${weapon.name}`);
+        return false;
+      }
+
+      // Browser download
+      const blob = new Blob([alignedModel], { type: "model/gltf-binary" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${weapon.name}-aligned.glb`;
+      a.click();
+      URL.revokeObjectURL(url);
+
+      // Save to server
+      const formData = new FormData();
+      formData.append(
+        "file",
+        new Blob([alignedModel], { type: "model/gltf-binary" }),
+        `${weapon.id}-aligned.glb`,
+      );
+      await fetch(getFullUrl(`/api/assets/${weapon.id}/save-aligned`), {
+        method: "POST",
+        body: formData,
+      });
+
+      // Mark as exported
+      setBatchReview((prev) => {
+        if (!prev) return null;
+        const exported = new Set(prev.exported);
+        exported.add(weapon.id);
+        return { ...prev, exported };
+      });
+
+      return true;
+    } catch (error) {
+      console.error(`Failed to export ${weapon.name}:`, error);
+      notify.error(`Failed to export ${weapon.name}`);
+      return false;
+    } finally {
+      setBatchReview((prev) => (prev ? { ...prev, isExporting: false } : null));
+    }
+  };
+
+  const handleReviewExportCurrent = async () => {
+    const ok = await exportCurrentWeapon();
+    if (ok && batchReview) {
+      // Auto-advance to next un-exported weapon
+      const nextIndex = batchReview.weapons.findIndex(
+        (w, i) =>
+          i > batchReview.currentIndex && !batchReview.exported.has(w.id),
+      );
+      if (nextIndex !== -1) {
+        // Small delay so the user sees the green checkmark
+        setTimeout(() => handleReviewNavigate(nextIndex), 400);
+      }
+    }
+  };
+
+  const handleReviewExportAll = async () => {
+    if (!batchReview) return;
+
+    batchCancelRef.current = false;
+
+    // Snapshot the weapons list and track exported locally to avoid stale closure
+    const weapons = batchReview.weapons;
+    const localExported = new Set(batchReview.exported);
+
+    for (let i = 0; i < weapons.length; i++) {
+      if (batchCancelRef.current) break;
+
+      const weapon = weapons[i];
+
+      // Skip already exported
+      if (localExported.has(weapon.id)) continue;
+
+      // Swap visual content (no reload, transforms locked)
+      await handleReviewNavigate(i);
+      // Small settle time for GPU to process new mesh
+      await new Promise((r) => setTimeout(r, 200));
+
+      const ok = await exportCurrentWeapon(weapon);
+      if (!ok) {
+        notify.error(`Failed on ${weapon.name}, stopping.`);
+        break;
+      }
+
+      localExported.add(weapon.id);
+    }
+
+    if (localExported.size === weapons.length) {
+      notify.success(`All ${weapons.length} weapons exported!`);
+    }
+  };
+
+  const handleReviewDone = async () => {
+    if (batchReview?.isExporting) return;
+
+    const exportedCount = batchReview?.exported.size || 0;
+    const total = batchReview?.weapons.length || 0;
+
+    // Restore original weapon's visual content before clearing review state
+    if (
+      preReviewEquipmentRef.current &&
+      viewerRef.current?.swapEquipmentContent
+    ) {
+      const url = getAssetModelUrl(preReviewEquipmentRef.current.id);
+      await viewerRef.current.swapEquipmentContent(url);
+    }
+
+    preReviewEquipmentRef.current = null;
+    setBatchReview(null);
+
+    if (exportedCount > 0) {
+      notify.success(`Exported ${exportedCount}/${total} weapons`);
+    }
+  };
+
+  const handleBatchCancel = () => {
+    batchCancelRef.current = true;
+  };
+
   const handleReset = () => {
     setAvatarHeight(1.83);
     setCreatureCategory("medium");
     setWeaponScaleOverride(1.0);
   };
 
-  // Reset manual adjustments when equipment changes
+  // Reset manual adjustments when equipment changes (but not during batch review)
   useEffect(() => {
+    if (batchReview) return;
     setManualPosition({ x: 0, y: 0, z: 0 });
     setManualRotation({ x: 0, y: 0, z: 0 });
-  }, [selectedEquipment]);
+  }, [selectedEquipment, batchReview]);
 
   return (
     <div className="flex h-[calc(100vh-60px)] bg-gradient-to-br from-bg-primary to-bg-secondary p-4 gap-4">
@@ -223,24 +506,40 @@ export const EquipmentPage: React.FC = () => {
       />
 
       {/* Center - 3D Viewport */}
-      <ViewportSection
-        selectedAvatar={selectedAvatar}
-        selectedEquipment={selectedEquipment}
-        equipmentSlot={equipmentSlot}
-        showSkeleton={showSkeleton}
-        setShowSkeleton={setShowSkeleton}
-        viewerRef={viewerRef}
-        handleDetectionResult={handleDetectionResult}
-        avatarHeight={avatarHeight}
-        autoScaleWeapon={autoScaleWeapon}
-        weaponScaleOverride={weaponScaleOverride}
-        manualRotation={manualRotation}
-        manualPosition={manualPosition}
-        currentAnimation={currentAnimation}
-        setCurrentAnimation={setCurrentAnimation}
-        isAnimationPlaying={isAnimationPlaying}
-        setIsAnimationPlaying={setIsAnimationPlaying}
-      />
+      <div className="flex-1 flex flex-col relative">
+        <ViewportSection
+          selectedAvatar={selectedAvatar}
+          selectedEquipment={selectedEquipment}
+          equipmentSlot={equipmentSlot}
+          showSkeleton={showSkeleton}
+          setShowSkeleton={setShowSkeleton}
+          viewerRef={viewerRef}
+          handleDetectionResult={handleDetectionResult}
+          avatarHeight={avatarHeight}
+          autoScaleWeapon={autoScaleWeapon}
+          weaponScaleOverride={weaponScaleOverride}
+          manualRotation={manualRotation}
+          manualPosition={manualPosition}
+          currentAnimation={currentAnimation}
+          setCurrentAnimation={setCurrentAnimation}
+          isAnimationPlaying={isAnimationPlaying}
+          setIsAnimationPlaying={setIsAnimationPlaying}
+          onEquipmentLoaded={handleEquipmentLoaded}
+        />
+
+        {/* Batch Review Bar */}
+        {batchReview && (
+          <BatchReviewBar
+            review={batchReview}
+            onPrev={handleReviewPrev}
+            onNext={handleReviewNext}
+            onExportCurrent={handleReviewExportCurrent}
+            onExportAll={handleReviewExportAll}
+            onSkip={handleReviewSkip}
+            onDone={handleReviewDone}
+          />
+        )}
+      </div>
 
       {/* Right Panel - Controls */}
       <div className="card overflow-hidden w-96 flex flex-col bg-gradient-to-br from-bg-primary to-bg-secondary">
@@ -301,10 +600,21 @@ export const EquipmentPage: React.FC = () => {
               onSaveConfiguration={handleSaveConfiguration}
               onExportAlignedModel={handleExportAlignedModel}
               onExportEquippedAvatar={handleExportEquippedAvatar}
+              assets={assets}
+              onBatchApplyFitting={handleBatchApplyFitting}
+              onBatchExportAligned={handleStartBatchReview}
             />
           </div>
         </div>
       </div>
+
+      {/* Batch Progress Overlay (for apply fitting) */}
+      {batchProgress && (
+        <BatchProgressOverlay
+          progress={batchProgress}
+          onCancel={handleBatchCancel}
+        />
+      )}
     </div>
   );
 };

--- a/packages/client/src/game/panels/QuestCompletePanel.tsx
+++ b/packages/client/src/game/panels/QuestCompletePanel.tsx
@@ -29,7 +29,7 @@ interface QuestCompletePanelProps {
 // Item ID to display name mapping (basic)
 const ITEM_NAMES: Record<string, string> = {
   xp_lamp_1000: "XP Lamp (1000 XP)",
-  bronze_sword: "Bronze Sword",
+  bronze_shortsword: "Bronze Sword",
   coins: "Coins",
 };
 

--- a/packages/client/src/game/systems/__tests__/InventoryActionDispatcher.test.ts
+++ b/packages/client/src/game/systems/__tests__/InventoryActionDispatcher.test.ts
@@ -131,14 +131,14 @@ describe("InventoryActionDispatcher", () => {
     it("sends equipItem network message", () => {
       const result = dispatchInventoryAction("wield", {
         world: asWorld(mockWorld),
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         slot: 10,
       });
 
       expect(result.success).toBe(true);
       expect(mockWorld.network?.send).toHaveBeenCalledWith("equipItem", {
         playerId: "player1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         inventorySlot: 10,
       });
     });
@@ -210,13 +210,13 @@ describe("InventoryActionDispatcher", () => {
     it("defaults quantity to 1", () => {
       const result = dispatchInventoryAction("drop", {
         world: asWorld(mockWorld),
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         slot: 0,
       });
 
       expect(result.success).toBe(true);
       expect(mockWorld.network?.dropItem).toHaveBeenCalledWith(
-        "bronze_sword",
+        "bronze_shortsword",
         0,
         1,
       );
@@ -231,7 +231,7 @@ describe("InventoryActionDispatcher", () => {
     it("emits UI_TOAST and adds chat message", () => {
       const result = dispatchInventoryAction("examine", {
         world: asWorld(mockWorld),
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         slot: 0,
       });
 

--- a/packages/client/src/utils/itemUtils.ts
+++ b/packages/client/src/utils/itemUtils.ts
@@ -29,7 +29,7 @@ export function isNotedItem(itemId: string): boolean {
  * IMPORTANT: Order matters! More specific checks must come before general ones.
  * e.g., "pickaxe" before "axe", "hatchet" before "hat"
  *
- * @param itemId - The item's ID (e.g., "bronze_sword", "oak_logs")
+ * @param itemId - The item's ID (e.g., "bronze_shortsword", "oak_logs")
  * @returns Emoji icon representing the item type
  */
 export function getItemIcon(itemId: string): string {
@@ -101,7 +101,7 @@ export function getItemIcon(itemId: string): string {
 /**
  * Format itemId to display name (snake_case -> Title Case)
  *
- * @param itemId - The item's ID (e.g., "bronze_sword")
+ * @param itemId - The item's ID (e.g., "bronze_shortsword")
  * @returns Formatted display name (e.g., "Bronze Sword")
  */
 export function formatItemName(itemId: string): string {

--- a/packages/client/tests/factories/entities.ts
+++ b/packages/client/tests/factories/entities.ts
@@ -268,7 +268,7 @@ export const npcs = {
       name: "Shopkeeper",
       npcType: "shopkeeper",
       dialogue: ["Welcome to my shop!", "Take a look at my wares."],
-      shop: { items: ["bronze_sword", "bronze_shield", "health_potion"] },
+      shop: { items: ["bronze_shortsword", "bronze_shield", "health_potion"] },
       ...overrides,
     }),
 

--- a/packages/client/tests/factories/items.ts
+++ b/packages/client/tests/factories/items.ts
@@ -104,7 +104,7 @@ export function createEquipmentItem(
 export const equipmentItems = {
   bronzeSword: (): TestItem =>
     createEquipmentItem("weapon", {
-      itemId: "bronze_sword",
+      itemId: "bronze_shortsword",
       name: "Bronze Sword",
       stats: { attack: 5 },
       value: 50,

--- a/packages/client/tests/unit/BankPanel/BankPanel.test.tsx
+++ b/packages/client/tests/unit/BankPanel/BankPanel.test.tsx
@@ -39,7 +39,7 @@ function createMockItem(id: string, name: string, equipSlot?: string): Item {
 
 function createBankItem(overrides: Partial<BankItem> = {}): BankItem {
   return {
-    itemId: "bronze_sword",
+    itemId: "bronze_shortsword",
     quantity: 1,
     slot: 0,
     tabIndex: 0,
@@ -50,7 +50,7 @@ function createBankItem(overrides: Partial<BankItem> = {}): BankItem {
 function createBankItems(count: number, tabIndex = 0): BankItem[] {
   const items: BankItem[] = [];
   const itemIds = [
-    "bronze_sword",
+    "bronze_shortsword",
     "iron_helmet",
     "lobster",
     "oak_logs",
@@ -71,7 +71,7 @@ function createBankItems(count: number, tabIndex = 0): BankItem[] {
 function createInventoryItems() {
   // Only return actual items, not null slots
   return [
-    { slot: 0, itemId: "bronze_sword", quantity: 1 },
+    { slot: 0, itemId: "bronze_shortsword", quantity: 1 },
     { slot: 1, itemId: "lobster", quantity: 5 },
     { slot: 5, itemId: "oak_logs_noted", quantity: 100 },
   ];
@@ -87,7 +87,7 @@ function createEquipment(): PlayerEquipmentItems {
     cape: null,
     amulet: null,
     ring: null,
-    weapon: createMockItem("bronze_sword", "Bronze Sword", "weapon"),
+    weapon: createMockItem("bronze_shortsword", "Bronze Sword", "weapon"),
     shield: null,
     arrows: null,
   };
@@ -136,7 +136,7 @@ describe("BankPanel", () => {
       render(<BankPanel {...defaultProps} />);
 
       // Should see item icons
-      expect(screen.getAllByText("⚔️").length).toBeGreaterThan(0); // bronze_sword
+      expect(screen.getAllByText("⚔️").length).toBeGreaterThan(0); // bronze_shortsword
     });
 
     it("renders right panel with inventory", () => {
@@ -391,7 +391,7 @@ describe("BankPanel", () => {
     it("withdraws to equipment when in equipment mode and item is equipable", () => {
       const items = [
         createBankItem({
-          itemId: "iron_sword",
+          itemId: "iron_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,
@@ -402,7 +402,7 @@ describe("BankPanel", () => {
       // Switch to equipment mode
       fireEvent.click(screen.getByTitle("View Worn Equipment"));
 
-      // Click on equipable item (iron_sword matches "sword" pattern = equipable)
+      // Click on equipable item (iron_shortsword matches "sword" pattern = equipable)
       const itemSlots = screen.getAllByTitle(/Iron Sword.*Tab 0/i);
       if (itemSlots.length > 0) {
         fireEvent.click(itemSlots[0]);
@@ -499,7 +499,7 @@ describe("BankPanel", () => {
     it("renders placeholder items (qty=0) with greyed style", () => {
       const items = [
         createBankItem({
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 0,
           slot: 0,
           tabIndex: 0,
@@ -515,7 +515,7 @@ describe("BankPanel", () => {
     it("shows release placeholder option in context menu for qty=0 items", () => {
       const items = [
         createBankItem({
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 0,
           slot: 0,
           tabIndex: 0,

--- a/packages/client/tests/unit/BankPanel/components/BankFooter.test.tsx
+++ b/packages/client/tests/unit/BankPanel/components/BankFooter.test.tsx
@@ -17,7 +17,7 @@ describe("BankFooter", () => {
   const mockOnReleaseAllPlaceholders = vi.fn();
 
   const defaultItems: BankItem[] = [
-    { itemId: "bronze_sword", quantity: 10, slot: 0, tabIndex: 0 },
+    { itemId: "bronze_shortsword", quantity: 10, slot: 0, tabIndex: 0 },
     { itemId: "iron_helmet", quantity: 5, slot: 1, tabIndex: 0 },
     { itemId: "oak_logs", quantity: 0, slot: 2, tabIndex: 0 }, // placeholder
     { itemId: "lobster", quantity: 100, slot: 0, tabIndex: 1 },

--- a/packages/client/tests/unit/BankPanel/components/BankSlotItem.test.tsx
+++ b/packages/client/tests/unit/BankPanel/components/BankSlotItem.test.tsx
@@ -20,7 +20,7 @@ describe("BankSlotItem", () => {
   const mockOnContextMenu = vi.fn();
 
   const defaultItem: BankItem = {
-    itemId: "bronze_sword",
+    itemId: "bronze_shortsword",
     quantity: 10,
     slot: 0,
     tabIndex: 0,
@@ -294,7 +294,7 @@ describe("BankSlotItem", () => {
       const slot = screen.getByTitle("Bronze Sword x10 (Tab 2)");
       fireEvent.click(slot);
 
-      expect(mockOnClick).toHaveBeenCalledWith("bronze_sword", 2, 5);
+      expect(mockOnClick).toHaveBeenCalledWith("bronze_shortsword", 2, 5);
     });
 
     it("calls onContextMenu with item on right-click", () => {

--- a/packages/client/tests/unit/BankPanel/components/BankTabBar.test.tsx
+++ b/packages/client/tests/unit/BankPanel/components/BankTabBar.test.tsx
@@ -34,7 +34,7 @@ describe("BankTabBar", () => {
   };
 
   const defaultItems: BankItem[] = [
-    { itemId: "bronze_sword", quantity: 10, slot: 0, tabIndex: 0 },
+    { itemId: "bronze_shortsword", quantity: 10, slot: 0, tabIndex: 0 },
     { itemId: "iron_helmet", quantity: 5, slot: 1, tabIndex: 0 },
     { itemId: "oak_logs", quantity: 100, slot: 0, tabIndex: 1 },
   ];
@@ -151,13 +151,13 @@ describe("BankTabBar", () => {
     it("shows first real item icon for tab", () => {
       render(<BankTabBar {...defaultProps} />);
 
-      // Tab 0 should show bronze_sword icon (⚔️)
+      // Tab 0 should show bronze_shortsword icon (⚔️)
       expect(screen.getByText("⚔️")).toBeInTheDocument();
     });
 
     it("shows placeholder icon when tab only has placeholders", () => {
       const placeholderItems: BankItem[] = [
-        { itemId: "bronze_sword", quantity: 0, slot: 0, tabIndex: 0 },
+        { itemId: "bronze_shortsword", quantity: 0, slot: 0, tabIndex: 0 },
       ];
 
       render(<BankTabBar {...defaultProps} items={placeholderItems} />);
@@ -344,7 +344,7 @@ describe("BankTabBar", () => {
 
     it("shows 'empty' indicator for placeholder-only tabs", () => {
       const placeholderItems: BankItem[] = [
-        { itemId: "bronze_sword", quantity: 0, slot: 0, tabIndex: 0 },
+        { itemId: "bronze_shortsword", quantity: 0, slot: 0, tabIndex: 0 },
       ];
 
       render(<BankTabBar {...defaultProps} items={placeholderItems} />);

--- a/packages/client/tests/unit/BankPanel/components/RightPanel.test.tsx
+++ b/packages/client/tests/unit/BankPanel/components/RightPanel.test.tsx
@@ -36,7 +36,7 @@ describe("RightPanel", () => {
   const mockOnDepositAllEquipment = vi.fn();
 
   const defaultInventory: InventorySlotViewItem[] = [
-    { slot: 0, itemId: "bronze_sword", quantity: 1 },
+    { slot: 0, itemId: "bronze_shortsword", quantity: 1 },
     { slot: 1, itemId: "lobster", quantity: 5 },
     { slot: 5, itemId: "oak_logs_noted", quantity: 100 },
   ];
@@ -50,7 +50,7 @@ describe("RightPanel", () => {
     cape: null,
     amulet: null,
     ring: null,
-    weapon: createMockItem("bronze_sword", "Bronze Sword", "weapon"),
+    weapon: createMockItem("bronze_shortsword", "Bronze Sword", "weapon"),
     shield: null,
     arrows: null,
   };

--- a/packages/client/tests/unit/BankPanel/components/modals/ContextMenu.test.tsx
+++ b/packages/client/tests/unit/BankPanel/components/modals/ContextMenu.test.tsx
@@ -18,7 +18,7 @@ describe("ContextMenu", () => {
     visible: true,
     x: 100,
     y: 100,
-    itemId: "bronze_sword",
+    itemId: "bronze_shortsword",
     quantity: 50,
     type: "bank",
     tabIndex: 0,
@@ -183,7 +183,7 @@ describe("ContextMenu", () => {
     it("shows Equip at bottom when inventory tab open for equipable items", () => {
       render(<ContextMenu {...defaultProps} rightPanelMode="inventory" />);
 
-      // Equip should be present (bronze_sword is equipable)
+      // Equip should be present (bronze_shortsword is equipable)
       expect(screen.getByText("Equip")).toBeInTheDocument();
     });
 

--- a/packages/client/tests/unit/BankPanel/utils.test.ts
+++ b/packages/client/tests/unit/BankPanel/utils.test.ts
@@ -52,8 +52,8 @@ describe("isNotedItem", () => {
 describe("getItemIcon", () => {
   describe("weapons", () => {
     it("returns sword icon for sword items", () => {
-      expect(getItemIcon("bronze_sword")).toBe("⚔️");
-      expect(getItemIcon("iron_sword")).toBe("⚔️");
+      expect(getItemIcon("bronze_shortsword")).toBe("⚔️");
+      expect(getItemIcon("iron_shortsword")).toBe("⚔️");
       expect(getItemIcon("RUNE_SWORD")).toBe("⚔️");
     });
 
@@ -217,7 +217,7 @@ describe("getItemIcon", () => {
 
 describe("formatItemName", () => {
   it("converts snake_case to Title Case", () => {
-    expect(formatItemName("bronze_sword")).toBe("Bronze Sword");
+    expect(formatItemName("bronze_shortsword")).toBe("Bronze Sword");
     expect(formatItemName("iron_platebody")).toBe("Iron Platebody");
   });
 

--- a/packages/client/tests/unit/CombatPanel/CombatPanel.test.tsx
+++ b/packages/client/tests/unit/CombatPanel/CombatPanel.test.tsx
@@ -60,7 +60,7 @@ function createEquipment(
     amulet: null,
     ring: null,
     weapon: {
-      id: "bronze_sword",
+      id: "bronze_shortsword",
       name: "Bronze Sword",
       type: "melee_weapon",
       equipSlot: "weapon",

--- a/packages/client/tests/unit/InventoryPanel/InventoryPanel.test.tsx
+++ b/packages/client/tests/unit/InventoryPanel/InventoryPanel.test.tsx
@@ -32,7 +32,7 @@ function createInventoryItem(
   overrides: Partial<TestInventoryItem> = {},
 ): TestInventoryItem {
   return {
-    itemId: "bronze_sword",
+    itemId: "bronze_shortsword",
     quantity: 1,
     slot: 0,
     ...overrides,
@@ -42,7 +42,7 @@ function createInventoryItem(
 function createInventoryItems(count: number): TestInventoryItem[] {
   const items: TestInventoryItem[] = [];
   const itemIds = [
-    "bronze_sword",
+    "bronze_shortsword",
     "iron_helmet",
     "lobster",
     "oak_logs",

--- a/packages/plugin-hyperscape/src/providers/possibilitiesProvider.ts
+++ b/packages/plugin-hyperscape/src/providers/possibilitiesProvider.ts
@@ -106,7 +106,7 @@ const SMITHING_RECIPES: SmithingRecipe[] = [
     category: "weapons",
   },
   {
-    itemId: "bronze_sword",
+    itemId: "bronze_shortsword",
     itemName: "Bronze Sword",
     barType: "bronze_bar",
     barsRequired: 1,
@@ -139,7 +139,7 @@ const SMITHING_RECIPES: SmithingRecipe[] = [
     category: "weapons",
   },
   {
-    itemId: "iron_sword",
+    itemId: "iron_shortsword",
     itemName: "Iron Sword",
     barType: "iron_bar",
     barsRequired: 2,

--- a/packages/server/src/systems/DuelSystem/__tests__/DuelSystem.test.ts
+++ b/packages/server/src/systems/DuelSystem/__tests__/DuelSystem.test.ts
@@ -466,7 +466,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         1,
       );
 
@@ -474,21 +474,27 @@ describe("DuelSystem", () => {
 
       const session = duelSystem.getDuelSession(duelId)!;
       expect(session.challengerStakes).toHaveLength(1);
-      expect(session.challengerStakes[0].itemId).toBe("bronze_sword");
+      expect(session.challengerStakes[0].itemId).toBe("bronze_shortsword");
     });
 
     it("resets acceptance when stake added", () => {
       const session = duelSystem.getDuelSession(duelId)!;
       session.challengerAccepted = true;
 
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
 
       expect(session.challengerAccepted).toBe(false);
     });
 
     it("rejects duplicate inventory slot", () => {
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
-      const result = duelSystem.addStake(duelId, "player1", 0, "iron_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
+      const result = duelSystem.addStake(
+        duelId,
+        "player1",
+        0,
+        "iron_shortsword",
+        1,
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("already staked");
@@ -502,7 +508,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         1,
       );
 
@@ -533,7 +539,7 @@ describe("DuelSystem", () => {
       duelSystem.acceptRules(duelId, "player2");
 
       // Add a stake to remove
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
     });
 
     it("removes stake successfully", () => {
@@ -821,7 +827,7 @@ describe("DuelSystem", () => {
       // Add stakes
       duelSystem.acceptRules(duelId, "player1");
       duelSystem.acceptRules(duelId, "player2");
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
 
       duelSystem.cancelDuel(duelId, "player_cancelled");
 
@@ -1494,7 +1500,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         0,
       );
       expect(result.success).toBe(false);
@@ -1506,7 +1512,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         -5,
       );
       expect(result.success).toBe(false);
@@ -1518,7 +1524,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         1.5,
       );
       expect(result.success).toBe(false);
@@ -1530,7 +1536,7 @@ describe("DuelSystem", () => {
         duelId,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         NaN,
       );
       expect(result.success).toBe(false);
@@ -1538,21 +1544,21 @@ describe("DuelSystem", () => {
     });
 
     it("rejects NaN stakeIndex for removeStake", () => {
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
       const result = duelSystem.removeStake(duelId, "player1", NaN);
       expect(result.success).toBe(false);
       expect(result.error).toContain("Invalid stake index");
     });
 
     it("rejects float stakeIndex for removeStake", () => {
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
       const result = duelSystem.removeStake(duelId, "player1", 0.5);
       expect(result.success).toBe(false);
       expect(result.error).toContain("Invalid stake index");
     });
 
     it("rejects negative stakeIndex for removeStake", () => {
-      duelSystem.addStake(duelId, "player1", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 0, "bronze_shortsword", 1);
       const result = duelSystem.removeStake(duelId, "player1", -1);
       expect(result.success).toBe(false);
       expect(result.error).toContain("Invalid stake index");
@@ -1604,7 +1610,7 @@ describe("DuelSystem", () => {
     });
 
     it("returns staked slot numbers", () => {
-      duelSystem.addStake(duelId, "player1", 3, "bronze_sword", 1);
+      duelSystem.addStake(duelId, "player1", 3, "bronze_shortsword", 1);
       duelSystem.addStake(duelId, "player1", 7, "iron_ore", 5);
 
       const stakedSlots = duelSystem.getStakedSlots("player1");
@@ -1707,7 +1713,7 @@ describe("DuelSystem", () => {
         duelId2,
         "player1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         1,
       );
       expect(result.success).toBe(false);
@@ -1720,7 +1726,7 @@ describe("DuelSystem", () => {
       duelSystem.acceptRules(duelId2, "player3");
       duelSystem.acceptRules(duelId2, "player4");
 
-      duelSystem.addStake(duelId2, "player3", 0, "bronze_sword", 1);
+      duelSystem.addStake(duelId2, "player3", 0, "bronze_shortsword", 1);
 
       const result = duelSystem.removeStake(duelId2, "player1", 0);
       expect(result.success).toBe(false);

--- a/packages/server/tests/integration/bank/equipment.integration.test.ts
+++ b/packages/server/tests/integration/bank/equipment.integration.test.ts
@@ -84,7 +84,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: 0, slot: 0 },
+        { itemId: "bronze_shortsword", tabIndex: 0, slot: 0 },
         mockWorld as never,
       );
 
@@ -142,7 +142,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: -1, slot: 0 },
+        { itemId: "bronze_shortsword", tabIndex: -1, slot: 0 },
         mockWorld as never,
       );
 
@@ -162,7 +162,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: 0, slot: -1 },
+        { itemId: "bronze_shortsword", tabIndex: 0, slot: -1 },
         mockWorld as never,
       );
 
@@ -187,7 +187,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: 0, slot: 0 },
+        { itemId: "bronze_shortsword", tabIndex: 0, slot: 0 },
         worldWithoutEquipment as never,
       );
 
@@ -252,7 +252,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "rune_sword", tabIndex: 0, slot: 0 },
+        { itemId: "rune_shortsword", tabIndex: 0, slot: 0 },
         worldWithEquipment as never,
       );
 
@@ -285,7 +285,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: 0, slot: 0 },
+        { itemId: "bronze_shortsword", tabIndex: 0, slot: 0 },
         worldWithEquipment as never,
       );
 
@@ -315,7 +315,7 @@ describe("Bank Withdraw To Equipment Handler Integration", () => {
 
       await handleBankWithdrawToEquipment(
         mockSocket as never,
-        { itemId: "bronze_sword", tabIndex: 0, slot: 0 },
+        { itemId: "bronze_shortsword", tabIndex: 0, slot: 0 },
         worldWithEquipment as never,
       );
 
@@ -403,7 +403,7 @@ describe("Bank Deposit Equipment Handler Integration", () => {
         context: mockContext,
       });
       (executeSecureTransaction as Mock).mockResolvedValue({
-        depositedItemId: "bronze_sword",
+        depositedItemId: "bronze_shortsword",
       });
 
       const equipSystem = createMockEquipmentSystem();
@@ -429,7 +429,7 @@ describe("Bank Deposit Equipment Handler Integration", () => {
         context: mockContext,
       });
       (executeSecureTransaction as Mock).mockResolvedValue({
-        depositedItemId: "bronze_sword",
+        depositedItemId: "bronze_shortsword",
       });
 
       const equipSystem = createMockEquipmentSystem();
@@ -459,7 +459,7 @@ describe("Bank Deposit Equipment Handler Integration", () => {
         context: mockContext,
       });
       (executeSecureTransaction as Mock).mockResolvedValue({
-        depositedItemId: "bronze_sword",
+        depositedItemId: "bronze_shortsword",
       });
 
       const equipSystem = createMockEquipmentSystem();
@@ -573,7 +573,7 @@ describe("Bank Deposit All Equipment Handler Integration", () => {
 
       const equipSystem = createMockEquipmentSystem({
         getAllEquippedItems: vi.fn().mockReturnValue([
-          { slot: "weapon", itemId: "bronze_sword" },
+          { slot: "weapon", itemId: "bronze_shortsword" },
           { slot: "helmet", itemId: "bronze_helm" },
           { slot: "body", itemId: "bronze_platebody" },
         ]),
@@ -605,7 +605,7 @@ describe("Bank Deposit All Equipment Handler Integration", () => {
 
       const equipSystem = createMockEquipmentSystem({
         getAllEquippedItems: vi.fn().mockReturnValue([
-          { slot: "weapon", itemId: "bronze_sword" },
+          { slot: "weapon", itemId: "bronze_shortsword" },
           { slot: "shield", itemId: "wooden_shield" },
         ]),
       });
@@ -640,7 +640,7 @@ describe("Bank Deposit All Equipment Handler Integration", () => {
 
       const equipSystem = createMockEquipmentSystem({
         getAllEquippedItems: vi.fn().mockReturnValue([
-          { slot: "weapon", itemId: "bronze_sword" },
+          { slot: "weapon", itemId: "bronze_shortsword" },
           { slot: "shield", itemId: "wooden_shield" },
           { slot: "helmet", itemId: "bronze_helm" },
           { slot: "body", itemId: "bronze_platebody" },
@@ -677,7 +677,7 @@ describe("Bank Deposit All Equipment Handler Integration", () => {
       const equipSystem = createMockEquipmentSystem({
         getAllEquippedItems: vi
           .fn()
-          .mockReturnValue([{ slot: "weapon", itemId: "bronze_sword" }]),
+          .mockReturnValue([{ slot: "weapon", itemId: "bronze_shortsword" }]),
       });
 
       const worldWithEquipment = {

--- a/packages/server/tests/integration/bank/helpers.ts
+++ b/packages/server/tests/integration/bank/helpers.ts
@@ -229,7 +229,7 @@ export function createMockEquipmentSystem(
     }),
     unequipItemDirect: vi.fn().mockResolvedValue({
       success: true,
-      itemId: "bronze_sword",
+      itemId: "bronze_shortsword",
       quantity: 1,
     }),
     getAllEquippedItems: vi.fn().mockReturnValue([]),

--- a/packages/server/tests/integration/inventory-move.integration.test.ts
+++ b/packages/server/tests/integration/inventory-move.integration.test.ts
@@ -245,7 +245,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
   describe("Swapping items between two occupied slots", () => {
     it("swaps sword in slot 0 with shield in slot 5", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 0),
+        createMockItem("bronze_shortsword", 0),
         createMockItem("bronze_shield", 5),
       ]);
 
@@ -259,7 +259,9 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
       expect(result.success).toBe(true);
 
       // Verify items swapped positions
-      const sword = inventory.items.find((i) => i.itemId === "bronze_sword");
+      const sword = inventory.items.find(
+        (i) => i.itemId === "bronze_shortsword",
+      );
       const shield = inventory.items.find((i) => i.itemId === "bronze_shield");
 
       expect(sword?.slot).toBe(5);
@@ -268,7 +270,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
     it("swaps items in non-adjacent slots (slot 2 and slot 25)", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("iron_sword", 2),
+        createMockItem("iron_shortsword", 2),
         createMockItem("gold_ring", 25),
       ]);
 
@@ -281,7 +283,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
       expect(result.success).toBe(true);
 
-      const sword = inventory.items.find((i) => i.itemId === "iron_sword");
+      const sword = inventory.items.find((i) => i.itemId === "iron_shortsword");
       const ring = inventory.items.find((i) => i.itemId === "gold_ring");
 
       expect(sword?.slot).toBe(25);
@@ -290,7 +292,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
     it("emits INVENTORY_MOVE event on successful swap", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 0),
+        createMockItem("bronze_shortsword", 0),
         createMockItem("bronze_shield", 5),
       ]);
 
@@ -307,7 +309,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
   describe("Moving item to empty slot", () => {
     it("moves item from slot 0 to empty slot 10", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 0),
+        createMockItem("bronze_shortsword", 0),
       ]);
 
       const result = handleMoveItem(
@@ -319,13 +321,15 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
       expect(result.success).toBe(true);
 
-      const sword = inventory.items.find((i) => i.itemId === "bronze_sword");
+      const sword = inventory.items.find(
+        (i) => i.itemId === "bronze_shortsword",
+      );
       expect(sword?.slot).toBe(10);
     });
 
     it("moves item to last slot (27)", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 0),
+        createMockItem("bronze_shortsword", 0),
       ]);
 
       const result = handleMoveItem(
@@ -337,13 +341,15 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
       expect(result.success).toBe(true);
 
-      const sword = inventory.items.find((i) => i.itemId === "bronze_sword");
+      const sword = inventory.items.find(
+        (i) => i.itemId === "bronze_shortsword",
+      );
       expect(sword?.slot).toBe(27);
     });
 
     it("leaves source slot empty after move", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 0),
+        createMockItem("bronze_shortsword", 0),
       ]);
 
       handleMoveItem(socket, { fromSlot: 0, toSlot: 10 }, world, inventory);
@@ -357,7 +363,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
   describe("Same-slot move (no-op)", () => {
     it("rejects move from slot 5 to slot 5", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 5),
+        createMockItem("bronze_shortsword", 5),
       ]);
 
       const result = handleMoveItem(
@@ -373,7 +379,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
 
     it("does not modify inventory on same-slot move", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 5),
+        createMockItem("bronze_shortsword", 5),
       ]);
 
       const originalSlot = inventory.items[0].slot;
@@ -387,7 +393,7 @@ describe("Inventory Move Integration - OSRS-style SWAP", () => {
   describe("Empty source slot", () => {
     it("rejects move from empty slot", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 5), // Only item in slot 5
+        createMockItem("bronze_shortsword", 5), // Only item in slot 5
       ]);
 
       const result = handleMoveItem(
@@ -415,7 +421,7 @@ describe("Inventory Move Integration - Input Validation", () => {
     socket = createMockSocket(player);
     world = { emit: vi.fn(), getSystem: vi.fn() };
     inventory = createMockInventory(player.id, [
-      createMockItem("bronze_sword", 0),
+      createMockItem("bronze_shortsword", 0),
     ]);
   });
 
@@ -570,7 +576,7 @@ describe("Inventory Move Integration - Input Validation", () => {
 
     it("accepts fromSlot = 27", () => {
       inventory = createMockInventory(player.id, [
-        createMockItem("bronze_sword", 27),
+        createMockItem("bronze_shortsword", 27),
       ]);
 
       const result = handleMoveItem(
@@ -600,7 +606,7 @@ describe("Inventory Move Integration - Rate Limiting", () => {
 
   it("allows up to 10 moves per second", () => {
     inventory = createMockInventory(player.id, [
-      createMockItem("bronze_sword", 0),
+      createMockItem("bronze_shortsword", 0),
       createMockItem("bronze_shield", 1),
     ]);
 
@@ -620,7 +626,7 @@ describe("Inventory Move Integration - Rate Limiting", () => {
 
   it("blocks 11th move within same second", () => {
     inventory = createMockInventory(player.id, [
-      createMockItem("bronze_sword", 0),
+      createMockItem("bronze_shortsword", 0),
       createMockItem("bronze_shield", 1),
     ]);
 
@@ -651,10 +657,10 @@ describe("Inventory Move Integration - Rate Limiting", () => {
     const socket2 = createMockSocket(player2);
 
     const inventory1 = createMockInventory(player.id, [
-      createMockItem("bronze_sword", 0),
+      createMockItem("bronze_shortsword", 0),
     ]);
     const inventory2 = createMockInventory(player2.id, [
-      createMockItem("iron_sword", 0),
+      createMockItem("iron_shortsword", 0),
     ]);
 
     const result1 = handleMoveItem(

--- a/packages/server/tests/integration/quest/quest.integration.test.ts
+++ b/packages/server/tests/integration/quest/quest.integration.test.ts
@@ -78,7 +78,7 @@ const mockQuestDefinitions: Record<string, QuestDefinition> = {
       },
     ],
     onStart: {
-      items: [{ itemId: "bronze_sword", quantity: 1 }],
+      items: [{ itemId: "bronze_shortsword", quantity: 1 }],
     },
     rewards: {
       questPoints: 1,
@@ -446,7 +446,7 @@ describe("QuestSystem Integration Tests", () => {
       expect(itemEvent?.data).toMatchObject({
         playerId: "player-1",
         item: {
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
         },
       });

--- a/packages/server/tests/integration/security-smoke-test.ts
+++ b/packages/server/tests/integration/security-smoke-test.ts
@@ -67,7 +67,7 @@ test(
 
 // Input validation tests
 console.log("\n--- Input Validation ---");
-test("Valid item ID accepted", isValidItemId("bronze_sword"));
+test("Valid item ID accepted", isValidItemId("bronze_shortsword"));
 test("Empty item ID rejected", !isValidItemId(""));
 test("Null item ID rejected", !isValidItemId(null));
 test("Too long item ID rejected", !isValidItemId("a".repeat(65)));

--- a/packages/server/tests/integration/store-handler.integration.test.ts
+++ b/packages/server/tests/integration/store-handler.integration.test.ts
@@ -207,7 +207,7 @@ describe("Store Handler Integration - Rate Limiting", () => {
 describe("Store Handler Integration - Input Validation", () => {
   describe("isValidItemId", () => {
     it("accepts valid item IDs", () => {
-      expect(isValidItemId("bronze_sword")).toBe(true);
+      expect(isValidItemId("bronze_shortsword")).toBe(true);
       expect(isValidItemId("coins")).toBe(true);
       expect(isValidItemId("rune_platebody")).toBe(true);
     });

--- a/packages/server/tests/integration/trade/trade.integration.test.ts
+++ b/packages/server/tests/integration/trade/trade.integration.test.ts
@@ -300,7 +300,7 @@ describe("TradingSystem Integration Tests", () => {
         tradeId,
         "player-1",
         0, // inventory slot
-        "bronze_sword",
+        "bronze_shortsword",
         1,
       );
 
@@ -308,12 +308,20 @@ describe("TradingSystem Integration Tests", () => {
 
       const session = tradingSystem.getTradeSession(tradeId);
       expect(session?.initiator.offeredItems.length).toBe(1);
-      expect(session?.initiator.offeredItems[0].itemId).toBe("bronze_sword");
+      expect(session?.initiator.offeredItems[0].itemId).toBe(
+        "bronze_shortsword",
+      );
     });
 
     it("removes item from trade offer", () => {
       // Add item first
-      tradingSystem.addItemToTrade(tradeId, "player-1", 0, "bronze_sword", 1);
+      tradingSystem.addItemToTrade(
+        tradeId,
+        "player-1",
+        0,
+        "bronze_shortsword",
+        1,
+      );
 
       // Remove it
       const result = tradingSystem.removeItemFromTrade(
@@ -334,7 +342,13 @@ describe("TradingSystem Integration Tests", () => {
       tradingSystem.setAcceptance(tradeId, "player-2", true);
 
       // Add item (should reset acceptance)
-      tradingSystem.addItemToTrade(tradeId, "player-1", 0, "bronze_sword", 1);
+      tradingSystem.addItemToTrade(
+        tradeId,
+        "player-1",
+        0,
+        "bronze_shortsword",
+        1,
+      );
 
       const session = tradingSystem.getTradeSession(tradeId);
       expect(session?.initiator.accepted).toBe(false);
@@ -346,7 +360,7 @@ describe("TradingSystem Integration Tests", () => {
         "non-existent",
         "player-1",
         0,
-        "bronze_sword",
+        "bronze_shortsword",
         1,
       );
 
@@ -399,8 +413,20 @@ describe("TradingSystem Integration Tests", () => {
 
     it("completes trade with full two-screen flow", () => {
       // Add items
-      tradingSystem.addItemToTrade(tradeId, "player-1", 0, "bronze_sword", 1);
-      tradingSystem.addItemToTrade(tradeId, "player-2", 0, "iron_sword", 1);
+      tradingSystem.addItemToTrade(
+        tradeId,
+        "player-1",
+        0,
+        "bronze_shortsword",
+        1,
+      );
+      tradingSystem.addItemToTrade(
+        tradeId,
+        "player-2",
+        0,
+        "iron_shortsword",
+        1,
+      );
 
       // Both accept on offer screen
       tradingSystem.setAcceptance(tradeId, "player-1", true);
@@ -419,8 +445,8 @@ describe("TradingSystem Integration Tests", () => {
       expect(result.success).toBe(true);
       expect(result.initiatorReceives?.length).toBe(1);
       expect(result.recipientReceives?.length).toBe(1);
-      expect(result.initiatorReceives?.[0].itemId).toBe("iron_sword");
-      expect(result.recipientReceives?.[0].itemId).toBe("bronze_sword");
+      expect(result.initiatorReceives?.[0].itemId).toBe("iron_shortsword");
+      expect(result.recipientReceives?.[0].itemId).toBe("bronze_shortsword");
     });
 
     it("rejects completion when not in confirming status", () => {

--- a/packages/server/tests/unit/bank/core.test.ts
+++ b/packages/server/tests/unit/bank/core.test.ts
@@ -60,12 +60,12 @@ const MOCK_ITEMS: Record<string, ItemDefinition> = {
     tradeable: true,
     notedId: "logs_noted",
   },
-  bronze_sword: {
-    id: "bronze_sword",
+  bronze_shortsword: {
+    id: "bronze_shortsword",
     name: "Bronze sword",
     stackable: false,
     tradeable: true,
-    notedId: "bronze_sword_noted",
+    notedId: "bronze_shortsword_noted",
   },
   iron_ore: {
     id: "iron_ore",
@@ -90,12 +90,12 @@ const MOCK_ITEMS: Record<string, ItemDefinition> = {
     tradeable: true,
     baseId: "logs",
   },
-  bronze_sword_noted: {
-    id: "bronze_sword_noted",
+  bronze_shortsword_noted: {
+    id: "bronze_shortsword_noted",
     name: "Bronze sword (noted)",
     stackable: true,
     tradeable: true,
-    baseId: "bronze_sword",
+    baseId: "bronze_shortsword",
   },
   iron_ore_noted: {
     id: "iron_ore_noted",
@@ -759,7 +759,7 @@ describe("Bank Core Handlers", () => {
         manager.addBankItem("player-1", "logs", 100, 0);
         // Fill 26 slots, leaving 2 free
         for (let i = 0; i < 26; i++) {
-          manager.addInventoryItem("player-1", "bronze_sword", 1, i);
+          manager.addInventoryItem("player-1", "bronze_shortsword", 1, i);
         }
 
         const result = manager.withdrawItem("player-1", "logs", 10);
@@ -854,14 +854,14 @@ describe("Bank Core Handlers", () => {
         manager.setAlwaysPlaceholder("player-1", false);
         manager.addBankItem("player-1", "logs", 5, 0);
         manager.addBankItem("player-1", "iron_ore", 10, 1);
-        manager.addBankItem("player-1", "bronze_sword", 1, 2);
+        manager.addBankItem("player-1", "bronze_shortsword", 1, 2);
 
         // Withdraw all logs (slot 0)
         manager.withdrawItem("player-1", "logs", 5);
 
         // Remaining items should shift
         const ironOre = manager.getBankItem("player-1", "iron_ore");
-        const sword = manager.getBankItem("player-1", "bronze_sword");
+        const sword = manager.getBankItem("player-1", "bronze_shortsword");
         expect(ironOre?.slot).toBe(0); // Was 1, now 0
         expect(sword?.slot).toBe(1); // Was 2, now 1
       });
@@ -888,7 +888,7 @@ describe("Bank Core Handlers", () => {
         manager.addBankItem("player-1", "logs", 10, 0);
         // Fill all 28 slots
         for (let i = 0; i < MAX_INVENTORY_SLOTS; i++) {
-          manager.addInventoryItem("player-1", "bronze_sword", 1, i);
+          manager.addInventoryItem("player-1", "bronze_shortsword", 1, i);
         }
 
         const result = manager.withdrawItem("player-1", "logs", 1);
@@ -905,7 +905,7 @@ describe("Bank Core Handlers", () => {
         manager.addInventoryItem("player-1", "logs", 1, 0);
         manager.addInventoryItem("player-1", "logs", 1, 1);
         manager.addInventoryItem("player-1", "iron_ore", 1, 2);
-        manager.addInventoryItem("player-1", "bronze_sword", 1, 3);
+        manager.addInventoryItem("player-1", "bronze_shortsword", 1, 3);
 
         const result = manager.depositAll("player-1");
 
@@ -914,7 +914,7 @@ describe("Bank Core Handlers", () => {
         expect(manager.getInventory("player-1").length).toBe(0);
         expect(manager.getBankCount("player-1", "logs")).toBe(2);
         expect(manager.getBankCount("player-1", "iron_ore")).toBe(1);
-        expect(manager.getBankCount("player-1", "bronze_sword")).toBe(1);
+        expect(manager.getBankCount("player-1", "bronze_shortsword")).toBe(1);
       });
 
       it("stacks with existing bank items", () => {

--- a/packages/server/tests/unit/bank/equipment.test.ts
+++ b/packages/server/tests/unit/bank/equipment.test.ts
@@ -48,14 +48,14 @@ interface ItemDefinition {
 // ============================================================================
 
 const MOCK_ITEMS: Record<string, ItemDefinition> = {
-  bronze_sword: {
-    id: "bronze_sword",
+  bronze_shortsword: {
+    id: "bronze_shortsword",
     name: "Bronze sword",
     equipSlot: "weapon",
     levelRequirement: 1,
   },
-  iron_sword: {
-    id: "iron_sword",
+  iron_shortsword: {
+    id: "iron_shortsword",
     name: "Iron sword",
     equipSlot: "weapon",
     levelRequirement: 1,
@@ -482,7 +482,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
       const manager = new MockEquipmentBankManager([
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,
@@ -491,7 +491,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
       const result = manager.withdrawToEquipment(
         "player-1",
-        "bronze_sword",
+        "bronze_shortsword",
         0,
         0,
       );
@@ -500,21 +500,21 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
       expect(result.equippedSlot).toBe("weapon");
 
       const equipment = manager.getEquipment("player-1");
-      expect(equipment?.weapon).toBe("bronze_sword");
+      expect(equipment?.weapon).toBe("bronze_shortsword");
     });
 
     it("removes item from bank after equipping", () => {
       const manager = new MockEquipmentBankManager([
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,
         },
       ]);
 
-      manager.withdrawToEquipment("player-1", "bronze_sword", 0, 0);
+      manager.withdrawToEquipment("player-1", "bronze_shortsword", 0, 0);
 
       const bankState = manager.getBankState("player-1");
       expect(bankState.length).toBe(0);
@@ -643,12 +643,14 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
   describe("Displaced Items", () => {
     it("returns existing weapon to bank when equipping new weapon", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager(
         [
           {
             playerId: "player-1",
-            itemId: "iron_sword",
+            itemId: "iron_shortsword",
             quantity: 1,
             slot: 0,
             tabIndex: 0,
@@ -659,23 +661,23 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
       const result = manager.withdrawToEquipment(
         "player-1",
-        "iron_sword",
+        "iron_shortsword",
         0,
         0,
       );
 
       expect(result.success).toBe(true);
       expect(result.displacedItems).toHaveLength(1);
-      expect(result.displacedItems![0].itemId).toBe("bronze_sword");
+      expect(result.displacedItems![0].itemId).toBe("bronze_shortsword");
 
       // Old weapon should be in bank
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem).toBeDefined();
       expect(bankItem?.quantity).toBe(1);
 
       // New weapon should be equipped
       const equip = manager.getEquipment("player-1");
-      expect(equip?.weapon).toBe("iron_sword");
+      expect(equip?.weapon).toBe("iron_shortsword");
     });
 
     it("returns shield to bank when equipping 2h weapon", () => {
@@ -711,7 +713,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
     it("returns both weapon and shield when equipping 2h with both equipped", () => {
       const equipment = new Map([
-        ["player-1", { weapon: "bronze_sword", shield: "wooden_shield" }],
+        ["player-1", { weapon: "bronze_shortsword", shield: "wooden_shield" }],
       ]);
       const manager = new MockEquipmentBankManager(
         [
@@ -732,24 +734,26 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
       expect(result.displacedItems).toHaveLength(2);
 
       const displacedIds = result.displacedItems!.map((d) => d.itemId);
-      expect(displacedIds).toContain("bronze_sword");
+      expect(displacedIds).toContain("bronze_shortsword");
       expect(displacedIds).toContain("wooden_shield");
     });
 
     it("adds displaced item to existing bank stack", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager(
         [
           {
             playerId: "player-1",
-            itemId: "iron_sword",
+            itemId: "iron_shortsword",
             quantity: 1,
             slot: 0,
             tabIndex: 0,
           },
           {
             playerId: "player-1",
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 5,
             slot: 1,
             tabIndex: 0,
@@ -758,10 +762,10 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
         equipment,
       );
 
-      manager.withdrawToEquipment("player-1", "iron_sword", 0, 0);
+      manager.withdrawToEquipment("player-1", "iron_shortsword", 0, 0);
 
       // Bronze sword should have qty increased
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem?.quantity).toBe(6);
     });
   });
@@ -773,7 +777,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
         [
           {
             playerId: "player-1",
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 1,
             slot: 0,
             tabIndex: 0,
@@ -784,9 +788,9 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
         settings,
       );
 
-      manager.withdrawToEquipment("player-1", "bronze_sword", 0, 0);
+      manager.withdrawToEquipment("player-1", "bronze_shortsword", 0, 0);
 
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem).toBeDefined();
       expect(bankItem?.quantity).toBe(0); // Placeholder
     });
@@ -797,7 +801,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
         [
           {
             playerId: "player-1",
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 1,
             slot: 0,
             tabIndex: 0,
@@ -808,9 +812,9 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
         settings,
       );
 
-      manager.withdrawToEquipment("player-1", "bronze_sword", 0, 0);
+      manager.withdrawToEquipment("player-1", "bronze_shortsword", 0, 0);
 
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem).toBeUndefined();
     });
   });
@@ -820,7 +824,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
       const manager = new MockEquipmentBankManager([
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,
@@ -829,7 +833,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
       const result = manager.withdrawToEquipment(
         "player-1",
-        "iron_sword",
+        "iron_shortsword",
         0,
         0,
       );
@@ -842,7 +846,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
       const manager = new MockEquipmentBankManager([
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 0,
           slot: 0,
           tabIndex: 0,
@@ -851,7 +855,7 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 
       const result = manager.withdrawToEquipment(
         "player-1",
-        "bronze_sword",
+        "bronze_shortsword",
         0,
         0,
       );
@@ -886,16 +890,18 @@ describe("Bank Equipment - Withdraw to Equipment", () => {
 describe("Bank Equipment - Deposit from Equipment", () => {
   describe("Basic Deposit", () => {
     it("deposits equipped item to bank", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager([], equipment);
 
       const result = manager.depositEquipment("player-1", "weapon");
 
       expect(result.success).toBe(true);
-      expect(result.depositedItemId).toBe("bronze_sword");
+      expect(result.depositedItemId).toBe("bronze_shortsword");
 
       // Item should be in bank
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem).toBeDefined();
       expect(bankItem?.quantity).toBe(1);
 
@@ -906,7 +912,7 @@ describe("Bank Equipment - Deposit from Equipment", () => {
 
     it("clears equipment slot after deposit", () => {
       const equipment = new Map([
-        ["player-1", { weapon: "bronze_sword", shield: "wooden_shield" }],
+        ["player-1", { weapon: "bronze_shortsword", shield: "wooden_shield" }],
       ]);
       const manager = new MockEquipmentBankManager([], equipment);
 
@@ -918,12 +924,14 @@ describe("Bank Equipment - Deposit from Equipment", () => {
     });
 
     it("adds to existing bank stack if item exists", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager(
         [
           {
             playerId: "player-1",
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 5,
             slot: 0,
             tabIndex: 0,
@@ -934,12 +942,14 @@ describe("Bank Equipment - Deposit from Equipment", () => {
 
       manager.depositEquipment("player-1", "weapon");
 
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem?.quantity).toBe(6);
     });
 
     it("creates new bank slot if item doesn't exist", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager(
         [
           {
@@ -955,7 +965,7 @@ describe("Bank Equipment - Deposit from Equipment", () => {
 
       manager.depositEquipment("player-1", "weapon");
 
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem).toBeDefined();
       expect(bankItem?.slot).toBe(1); // Next available slot
     });
@@ -967,7 +977,7 @@ describe("Bank Equipment - Deposit from Equipment", () => {
         [
           "player-1",
           {
-            weapon: "bronze_sword",
+            weapon: "bronze_shortsword",
             shield: "wooden_shield",
             helmet: "bronze_helm",
             body: "bronze_platebody",
@@ -1016,7 +1026,9 @@ describe("Bank Equipment - Deposit from Equipment", () => {
     });
 
     it("returns error for invalid slot name", () => {
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager([], equipment);
 
       const result = manager.depositEquipment("player-1", "invalid_slot");
@@ -1047,7 +1059,7 @@ describe("Bank Equipment - Deposit All Equipment", () => {
         [
           "player-1",
           {
-            weapon: "bronze_sword",
+            weapon: "bronze_shortsword",
             shield: "wooden_shield",
             helmet: "bronze_helm",
           },
@@ -1067,7 +1079,9 @@ describe("Bank Equipment - Deposit All Equipment", () => {
       expect(equip?.helmet).toBeNull();
 
       // All items should be in bank
-      expect(manager.getBankItem("player-1", "bronze_sword")).toBeDefined();
+      expect(
+        manager.getBankItem("player-1", "bronze_shortsword"),
+      ).toBeDefined();
       expect(manager.getBankItem("player-1", "wooden_shield")).toBeDefined();
       expect(manager.getBankItem("player-1", "bronze_helm")).toBeDefined();
     });
@@ -1077,7 +1091,7 @@ describe("Bank Equipment - Deposit All Equipment", () => {
         [
           "player-1",
           {
-            weapon: "bronze_sword",
+            weapon: "bronze_shortsword",
             shield: "wooden_shield",
             helmet: "bronze_helm",
             body: "bronze_platebody",
@@ -1107,12 +1121,14 @@ describe("Bank Equipment - Deposit All Equipment", () => {
       // Two bronze swords equipped (hypothetically, weapon and spare)
       // Actually, same item can't be in multiple slots, but if depositing
       // an item that already exists in bank, it should stack
-      const equipment = new Map([["player-1", { weapon: "bronze_sword" }]]);
+      const equipment = new Map([
+        ["player-1", { weapon: "bronze_shortsword" }],
+      ]);
       const manager = new MockEquipmentBankManager(
         [
           {
             playerId: "player-1",
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 5,
             slot: 0,
             tabIndex: 0,
@@ -1123,7 +1139,7 @@ describe("Bank Equipment - Deposit All Equipment", () => {
 
       manager.depositAllEquipment("player-1");
 
-      const bankItem = manager.getBankItem("player-1", "bronze_sword");
+      const bankItem = manager.getBankItem("player-1", "bronze_shortsword");
       expect(bankItem?.quantity).toBe(6);
     });
   });
@@ -1150,7 +1166,7 @@ describe("Bank Equipment - Deposit All Equipment", () => {
 
     it("deposits only occupied slots", () => {
       const equipment = new Map([
-        ["player-1", { weapon: "bronze_sword", body: "bronze_platebody" }],
+        ["player-1", { weapon: "bronze_shortsword", body: "bronze_platebody" }],
       ]);
       const manager = new MockEquipmentBankManager([], equipment);
 
@@ -1166,8 +1182,8 @@ describe("Bank Equipment - Deposit All Equipment", () => {
   describe("Player Isolation", () => {
     it("only deposits equipment for specified player", () => {
       const equipment = new Map([
-        ["player-1", { weapon: "bronze_sword" }],
-        ["player-2", { weapon: "iron_sword" }],
+        ["player-1", { weapon: "bronze_shortsword" }],
+        ["player-2", { weapon: "iron_shortsword" }],
       ]);
       const manager = new MockEquipmentBankManager([], equipment);
 
@@ -1175,11 +1191,15 @@ describe("Bank Equipment - Deposit All Equipment", () => {
 
       // Player 1 should have deposited
       expect(manager.getEquipment("player-1")?.weapon).toBeNull();
-      expect(manager.getBankItem("player-1", "bronze_sword")).toBeDefined();
+      expect(
+        manager.getBankItem("player-1", "bronze_shortsword"),
+      ).toBeDefined();
 
       // Player 2 should be unchanged
-      expect(manager.getEquipment("player-2")?.weapon).toBe("iron_sword");
-      expect(manager.getBankItem("player-2", "iron_sword")).toBeUndefined();
+      expect(manager.getEquipment("player-2")?.weapon).toBe("iron_shortsword");
+      expect(
+        manager.getBankItem("player-2", "iron_shortsword"),
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/server/tests/unit/bank/tabs.test.ts
+++ b/packages/server/tests/unit/bank/tabs.test.ts
@@ -393,7 +393,7 @@ describe("Bank Tabs - Create Tab", () => {
       const manager = new MockBankTabManager([
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,
@@ -402,7 +402,7 @@ describe("Bank Tabs - Create Tab", () => {
 
       manager.createTab("player-1", 0, 0, 1);
 
-      expect(manager.getTabIcon("player-1", 1)).toBe("bronze_sword");
+      expect(manager.getTabIcon("player-1", 1)).toBe("bronze_shortsword");
     });
   });
 

--- a/packages/server/tests/unit/bank/utils.test.ts
+++ b/packages/server/tests/unit/bank/utils.test.ts
@@ -149,7 +149,7 @@ describe("Slot Compaction Algorithm", () => {
         },
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 3,
           tabIndex: 0,
@@ -163,7 +163,7 @@ describe("Slot Compaction Algorithm", () => {
       const ironOre = manager.getItemAtSlot("player-1", 0, 1);
       const sword = manager.getItemAtSlot("player-1", 0, 2);
       expect(ironOre?.itemId).toBe("iron_ore"); // Was at slot 2, now at 1
-      expect(sword?.itemId).toBe("bronze_sword"); // Was at slot 3, now at 2
+      expect(sword?.itemId).toBe("bronze_shortsword"); // Was at slot 3, now at 2
     });
 
     it("shifts items left when first slot is deleted", () => {
@@ -280,7 +280,7 @@ describe("Slot Compaction Algorithm", () => {
         },
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 3,
           tabIndex: 0,
@@ -321,7 +321,7 @@ describe("Slot Compaction Algorithm", () => {
         // Tab 1
         {
           playerId: "player-1",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 1,
@@ -371,7 +371,7 @@ describe("Slot Compaction Algorithm", () => {
         // Player 2
         {
           playerId: "player-2",
-          itemId: "bronze_sword",
+          itemId: "bronze_shortsword",
           quantity: 1,
           slot: 0,
           tabIndex: 0,

--- a/packages/server/tests/unit/services/InputValidation.test.ts
+++ b/packages/server/tests/unit/services/InputValidation.test.ts
@@ -33,7 +33,7 @@ import { INPUT_LIMITS } from "@hyperscape/shared";
 describe("InputValidation", () => {
   describe("isValidItemId", () => {
     it("accepts valid item IDs", () => {
-      expect(isValidItemId("bronze_sword")).toBe(true);
+      expect(isValidItemId("bronze_shortsword")).toBe(true);
       expect(isValidItemId("iron_pickaxe")).toBe(true);
       expect(isValidItemId("coins")).toBe(true);
       expect(isValidItemId("item123")).toBe(true);

--- a/packages/shared/src/constants/CombatConstants.ts
+++ b/packages/shared/src/constants/CombatConstants.ts
@@ -93,6 +93,8 @@ export const COMBAT_CONSTANTS = {
     HITSPLAT_DURATION_TICKS: 2,
     EMOTE_COMBAT: "combat",
     EMOTE_SWORD_SWING: "sword_swing",
+    EMOTE_2H_SLASH: "2h_slash",
+    EMOTE_2H_IDLE: "2h_idle",
     EMOTE_RANGED: "ranged",
     EMOTE_MAGIC: "magic",
     EMOTE_IDLE: "idle",

--- a/packages/shared/src/constants/GameConstants.ts
+++ b/packages/shared/src/constants/GameConstants.ts
@@ -208,9 +208,9 @@ export const ITEM_IDS = {
 // Mapping from numeric IDs to string item keys
 export const ITEM_ID_TO_KEY: Record<number, string> = {
   // Weapons
-  [ITEM_IDS.BRONZE_SWORD]: "bronze_sword",
-  [ITEM_IDS.STEEL_SWORD]: "steel_sword",
-  [ITEM_IDS.MITHRIL_SWORD]: "mithril_sword",
+  [ITEM_IDS.BRONZE_SWORD]: "bronze_shortsword",
+  [ITEM_IDS.STEEL_SWORD]: "steel_shortsword",
+  [ITEM_IDS.MITHRIL_SWORD]: "mithril_shortsword",
   [ITEM_IDS.WOOD_BOW]: "wood_bow",
   [ITEM_IDS.OAK_BOW]: "oak_bow",
   [ITEM_IDS.WILLOW_BOW]: "willow_bow",

--- a/packages/shared/src/constants/WeaponStyleConfig.ts
+++ b/packages/shared/src/constants/WeaponStyleConfig.ts
@@ -27,6 +27,17 @@ export const WEAPON_STYLE_CONFIG: Record<WeaponType, CombatStyleExtended[]> = {
   // Spears - full style selection (reach weapon)
   [WeaponType.SPEAR]: ["accurate", "aggressive", "defensive", "controlled"],
 
+  // Longswords - full style selection (slash weapon)
+  [WeaponType.LONGSWORD]: ["accurate", "aggressive", "defensive", "controlled"],
+
+  // Two-handed swords - full style selection (2H melee)
+  [WeaponType.TWO_HAND_SWORD]: [
+    "accurate",
+    "aggressive",
+    "defensive",
+    "controlled",
+  ],
+
   // Halberds - full style selection (2H reach weapon)
   [WeaponType.HALBERD]: ["accurate", "aggressive", "defensive", "controlled"],
 

--- a/packages/shared/src/data/__tests__/DataManager-items-directory.test.ts
+++ b/packages/shared/src/data/__tests__/DataManager-items-directory.test.ts
@@ -44,10 +44,10 @@ describe.skipIf(!manifestsAvailable)(
       it("loads items from all 5 category files", () => {
         // Check representative items from each category
         const weapons = [
-          "bronze_sword",
-          "iron_sword",
-          "steel_sword",
-          "mithril_sword",
+          "bronze_shortsword",
+          "iron_shortsword",
+          "steel_shortsword",
+          "mithril_shortsword",
         ];
         const tools = ["bronze_hatchet", "fishing_rod", "hammer", "tinderbox"];
         const resources = ["copper_ore", "bronze_bar", "logs", "raw_shrimp"];
@@ -67,8 +67,8 @@ describe.skipIf(!manifestsAvailable)(
 
       it("correctly categorizes items by type", () => {
         // Weapons
-        expect(ITEMS.get("bronze_sword")?.type).toBe("weapon");
-        expect(ITEMS.get("mithril_sword")?.type).toBe("weapon");
+        expect(ITEMS.get("bronze_shortsword")?.type).toBe("weapon");
+        expect(ITEMS.get("mithril_shortsword")?.type).toBe("weapon");
 
         // Tools
         expect(ITEMS.get("bronze_hatchet")?.type).toBe("tool");
@@ -90,7 +90,7 @@ describe.skipIf(!manifestsAvailable)(
 
     describe("item normalization", () => {
       it("applies TierDataProvider requirements to tiered weapons", () => {
-        const steelSword = ITEMS.get("steel_sword");
+        const steelSword = ITEMS.get("steel_shortsword");
         expect(steelSword).toBeDefined();
         // Steel weapons require attack level 5
         expect(steelSword?.requirements?.skills?.attack).toBe(5);
@@ -106,12 +106,12 @@ describe.skipIf(!manifestsAvailable)(
 
       it("generates noted variants for tradeable non-stackable items", () => {
         // Check that noted variants exist
-        expect(ITEMS.has("bronze_sword_noted")).toBe(true);
+        expect(ITEMS.has("bronze_shortsword_noted")).toBe(true);
         expect(ITEMS.has("logs_noted")).toBe(true);
         expect(ITEMS.has("shrimp_noted")).toBe(true);
 
         // Verify noted items have isNoted flag
-        expect(ITEMS.get("bronze_sword_noted")?.isNoted).toBe(true);
+        expect(ITEMS.get("bronze_shortsword_noted")?.isNoted).toBe(true);
       });
 
       it("does not generate noted variants for stackable items", () => {

--- a/packages/shared/src/data/__tests__/NoteGenerator.test.ts
+++ b/packages/shared/src/data/__tests__/NoteGenerator.test.ts
@@ -61,7 +61,7 @@ describe("NoteGenerator", () => {
   describe("shouldGenerateNote", () => {
     it("returns true for standard tradeable non-stackable item", () => {
       const item = createTestItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         name: "Bronze Sword",
         tradeable: true,
         stackable: false,
@@ -71,17 +71,17 @@ describe("NoteGenerator", () => {
 
     it("returns false for already noted items", () => {
       const item = createTestItem({
-        id: "bronze_sword_noted",
+        id: "bronze_shortsword_noted",
         isNoted: true,
-        baseItemId: "bronze_sword",
+        baseItemId: "bronze_shortsword",
       });
       expect(shouldGenerateNote(item)).toBe(false);
     });
 
     it("returns false for items that already have notedItemId", () => {
       const item = createTestItem({
-        id: "bronze_sword",
-        notedItemId: "bronze_sword_noted",
+        id: "bronze_shortsword",
+        notedItemId: "bronze_shortsword_noted",
       });
       expect(shouldGenerateNote(item)).toBe(false);
     });
@@ -123,7 +123,7 @@ describe("NoteGenerator", () => {
 
     it("returns true when tradeable is undefined (defaults to tradeable)", () => {
       const item = createTestItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         tradeable: undefined,
       });
       expect(shouldGenerateNote(item)).toBe(true);
@@ -132,14 +132,14 @@ describe("NoteGenerator", () => {
 
   describe("generateNotedItem", () => {
     it("creates noted item with correct ID", () => {
-      const baseItem = createTestItem({ id: "bronze_sword" });
+      const baseItem = createTestItem({ id: "bronze_shortsword" });
       const notedItem = generateNotedItem(baseItem);
-      expect(notedItem.id).toBe("bronze_sword_noted");
+      expect(notedItem.id).toBe("bronze_shortsword_noted");
     });
 
     it("creates noted item with correct name", () => {
       const baseItem = createTestItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         name: "Bronze Sword",
       });
       const notedItem = generateNotedItem(baseItem);
@@ -191,9 +191,9 @@ describe("NoteGenerator", () => {
     });
 
     it("sets baseItemId to reference the original", () => {
-      const baseItem = createTestItem({ id: "bronze_sword" });
+      const baseItem = createTestItem({ id: "bronze_shortsword" });
       const notedItem = generateNotedItem(baseItem);
-      expect(notedItem.baseItemId).toBe("bronze_sword");
+      expect(notedItem.baseItemId).toBe("bronze_shortsword");
     });
 
     it("sets noteable to false (notes cannot be noted again)", () => {
@@ -239,9 +239,9 @@ describe("NoteGenerator", () => {
     it("generates noted variants for eligible items", () => {
       const items = new Map<string, Item>();
       items.set(
-        "bronze_sword",
+        "bronze_shortsword",
         createTestItem({
-          id: "bronze_sword",
+          id: "bronze_shortsword",
           name: "Bronze Sword",
           stackable: false,
           tradeable: true,
@@ -250,25 +250,25 @@ describe("NoteGenerator", () => {
 
       const result = generateAllNotedItems(items);
 
-      expect(result.has("bronze_sword")).toBe(true);
-      expect(result.has("bronze_sword_noted")).toBe(true);
+      expect(result.has("bronze_shortsword")).toBe(true);
+      expect(result.has("bronze_shortsword_noted")).toBe(true);
     });
 
     it("cross-links base item to noted variant", () => {
       const items = new Map<string, Item>();
       items.set(
-        "bronze_sword",
+        "bronze_shortsword",
         createTestItem({
-          id: "bronze_sword",
+          id: "bronze_shortsword",
           stackable: false,
         }),
       );
 
       const result = generateAllNotedItems(items);
-      const baseItem = result.get("bronze_sword");
+      const baseItem = result.get("bronze_shortsword");
 
       expect(baseItem?.noteable).toBe(true);
-      expect(baseItem?.notedItemId).toBe("bronze_sword_noted");
+      expect(baseItem?.notedItemId).toBe("bronze_shortsword_noted");
     });
 
     it("does not generate notes for stackable items", () => {
@@ -306,9 +306,9 @@ describe("NoteGenerator", () => {
     it("handles multiple items correctly", () => {
       const items = new Map<string, Item>();
       items.set(
-        "bronze_sword",
+        "bronze_shortsword",
         createTestItem({
-          id: "bronze_sword",
+          id: "bronze_shortsword",
           stackable: false,
           tradeable: true,
         }),
@@ -333,22 +333,22 @@ describe("NoteGenerator", () => {
 
       // Should generate notes for sword and logs, but not arrows
       expect(result.size).toBe(5); // 3 base + 2 noted
-      expect(result.has("bronze_sword_noted")).toBe(true);
+      expect(result.has("bronze_shortsword_noted")).toBe(true);
       expect(result.has("logs_noted")).toBe(true);
       expect(result.has("arrows_noted")).toBe(false);
     });
 
     it("preserves original items in the result map", () => {
       const originalItem = createTestItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         name: "Bronze Sword",
         value: 100,
       });
       const items = new Map<string, Item>();
-      items.set("bronze_sword", originalItem);
+      items.set("bronze_shortsword", originalItem);
 
       const result = generateAllNotedItems(items);
-      const resultItem = result.get("bronze_sword");
+      const resultItem = result.get("bronze_shortsword");
 
       expect(resultItem?.name).toBe("Bronze Sword");
       expect(resultItem?.value).toBe(100);
@@ -356,26 +356,29 @@ describe("NoteGenerator", () => {
 
     it("returns same map reference updated with new items", () => {
       const items = new Map<string, Item>();
-      items.set("bronze_sword", createTestItem({ id: "bronze_sword" }));
+      items.set(
+        "bronze_shortsword",
+        createTestItem({ id: "bronze_shortsword" }),
+      );
 
       const result = generateAllNotedItems(items);
 
       // Result is a new map, not the same reference
       expect(result).not.toBe(items);
       // But base items are preserved
-      expect(result.get("bronze_sword")).toBeDefined();
+      expect(result.get("bronze_shortsword")).toBeDefined();
     });
   });
 
   describe("isNotedItemId", () => {
     it("returns true for item IDs ending with _noted", () => {
-      expect(isNotedItemId("bronze_sword_noted")).toBe(true);
+      expect(isNotedItemId("bronze_shortsword_noted")).toBe(true);
       expect(isNotedItemId("logs_noted")).toBe(true);
       expect(isNotedItemId("lobster_noted")).toBe(true);
     });
 
     it("returns false for base item IDs", () => {
-      expect(isNotedItemId("bronze_sword")).toBe(false);
+      expect(isNotedItemId("bronze_shortsword")).toBe(false);
       expect(isNotedItemId("logs")).toBe(false);
       expect(isNotedItemId("lobster")).toBe(false);
     });
@@ -396,12 +399,14 @@ describe("NoteGenerator", () => {
 
   describe("getBaseItemId", () => {
     it("removes _noted suffix from noted item IDs", () => {
-      expect(getBaseItemId("bronze_sword_noted")).toBe("bronze_sword");
+      expect(getBaseItemId("bronze_shortsword_noted")).toBe(
+        "bronze_shortsword",
+      );
       expect(getBaseItemId("logs_noted")).toBe("logs");
     });
 
     it("returns unchanged ID for base items", () => {
-      expect(getBaseItemId("bronze_sword")).toBe("bronze_sword");
+      expect(getBaseItemId("bronze_shortsword")).toBe("bronze_shortsword");
       expect(getBaseItemId("logs")).toBe("logs");
     });
 
@@ -418,12 +423,16 @@ describe("NoteGenerator", () => {
 
   describe("getNotedItemId", () => {
     it("adds _noted suffix to base item IDs", () => {
-      expect(getNotedItemId("bronze_sword")).toBe("bronze_sword_noted");
+      expect(getNotedItemId("bronze_shortsword")).toBe(
+        "bronze_shortsword_noted",
+      );
       expect(getNotedItemId("logs")).toBe("logs_noted");
     });
 
     it("returns unchanged ID for already noted items", () => {
-      expect(getNotedItemId("bronze_sword_noted")).toBe("bronze_sword_noted");
+      expect(getNotedItemId("bronze_shortsword_noted")).toBe(
+        "bronze_shortsword_noted",
+      );
     });
 
     it("handles empty string", () => {
@@ -433,12 +442,12 @@ describe("NoteGenerator", () => {
 
   describe("round-trip conversions", () => {
     it("getBaseItemId(getNotedItemId(id)) returns original for base items", () => {
-      const baseId = "bronze_sword";
+      const baseId = "bronze_shortsword";
       expect(getBaseItemId(getNotedItemId(baseId))).toBe(baseId);
     });
 
     it("getNotedItemId(getBaseItemId(id)) returns original for noted items", () => {
-      const notedId = "bronze_sword_noted";
+      const notedId = "bronze_shortsword_noted";
       expect(getNotedItemId(getBaseItemId(notedId))).toBe(notedId);
     });
   });
@@ -450,8 +459,8 @@ describe("NoteGenerator", () => {
     });
 
     it("handles case sensitivity (suffix is lowercase)", () => {
-      expect(isNotedItemId("bronze_sword_NOTED")).toBe(false);
-      expect(isNotedItemId("bronze_sword_Noted")).toBe(false);
+      expect(isNotedItemId("bronze_shortsword_NOTED")).toBe(false);
+      expect(isNotedItemId("bronze_shortsword_Noted")).toBe(false);
     });
   });
 });

--- a/packages/shared/src/data/__tests__/ProcessingDataProvider.test.ts
+++ b/packages/shared/src/data/__tests__/ProcessingDataProvider.test.ts
@@ -63,7 +63,7 @@ describe("ProcessingDataProvider", () => {
     });
 
     it("returns recipe data for valid bronze item (if data loaded)", () => {
-      const recipe = provider.getSmithingRecipe("bronze_sword");
+      const recipe = provider.getSmithingRecipe("bronze_shortsword");
       // Only validate if recipe exists (data might not be loaded)
       if (recipe) {
         expect(recipe.barType).toBe("bronze_bar");
@@ -73,7 +73,7 @@ describe("ProcessingDataProvider", () => {
       } else if (hasSmithingData) {
         // Data was supposed to be loaded but recipe not found
         throw new Error(
-          "bronze_sword recipe should exist when smithing data is loaded",
+          "bronze_shortsword recipe should exist when smithing data is loaded",
         );
       }
     });
@@ -305,7 +305,7 @@ describe("ProcessingDataProvider", () => {
     });
 
     it("returns false for non-bar items", () => {
-      expect(provider.isSmeltableBar("bronze_sword")).toBe(false);
+      expect(provider.isSmeltableBar("bronze_shortsword")).toBe(false);
       expect(provider.isSmeltableBar("fake_item")).toBe(false);
     });
   });
@@ -316,7 +316,7 @@ describe("ProcessingDataProvider", () => {
       if (!hasSmithingData) {
         return;
       }
-      expect(provider.isSmithableItem("bronze_sword")).toBe(true);
+      expect(provider.isSmithableItem("bronze_shortsword")).toBe(true);
     });
 
     it("returns false for bars (bars are smelted, not smithed)", () => {
@@ -639,7 +639,7 @@ describe("ProcessingDataProvider", () => {
     });
 
     it("returns false for non-tannable items", () => {
-      expect(provider.isTannableItem("bronze_sword")).toBe(false);
+      expect(provider.isTannableItem("bronze_shortsword")).toBe(false);
       expect(provider.isTannableItem("fake_item")).toBe(false);
     });
   });

--- a/packages/shared/src/data/playerEmotes.ts
+++ b/packages/shared/src/data/playerEmotes.ts
@@ -51,6 +51,12 @@ export const Emotes = {
   /** Sword swing attack animation (used when sword is equipped) - plays once per attack, no loop */
   SWORD_SWING: "asset://emotes/emote_sword_swing.glb?l=0",
 
+  /** Two-handed sword idle stance (used when 2h sword is equipped) */
+  TWO_HAND_IDLE: "asset://emotes/emote-2h-idle.glb",
+
+  /** Two-handed sword slash animation - plays once per attack, no loop */
+  TWO_HAND_SLASH: "asset://emotes/emote-2h-slash.glb?l=0",
+
   /** Ranged attack animation (used when bow is equipped) - plays once per attack, no loop */
   RANGE: "asset://emotes/emote-range.glb?l=0",
 
@@ -81,6 +87,8 @@ export const emoteUrls = [
   Emotes.TALK,
   Emotes.COMBAT,
   Emotes.SWORD_SWING,
+  Emotes.TWO_HAND_IDLE,
+  Emotes.TWO_HAND_SLASH,
   Emotes.RANGE,
   Emotes.SPELL_CAST,
   Emotes.CHOPPING,

--- a/packages/shared/src/entities/managers/MobVisualManager.ts
+++ b/packages/shared/src/entities/managers/MobVisualManager.ts
@@ -109,6 +109,8 @@ export class MobVisualManager {
     range: Emotes.RANGE,
     spell_cast: Emotes.SPELL_CAST,
     sword_swing: Emotes.SWORD_SWING,
+    "2h_idle": Emotes.TWO_HAND_IDLE,
+    "2h_slash": Emotes.TWO_HAND_SLASH,
     death: Emotes.DEATH,
   };
 
@@ -930,6 +932,7 @@ export class MobVisualManager {
     return (
       emoteUrl === Emotes.COMBAT ||
       emoteUrl === Emotes.SWORD_SWING ||
+      emoteUrl === Emotes.TWO_HAND_SLASH ||
       emoteUrl === Emotes.RANGE ||
       emoteUrl === Emotes.SPELL_CAST ||
       emoteUrl === Emotes.DEATH
@@ -945,6 +948,7 @@ export class MobVisualManager {
     return (
       emoteUrl === Emotes.COMBAT ||
       emoteUrl === Emotes.SWORD_SWING ||
+      emoteUrl === Emotes.TWO_HAND_SLASH ||
       emoteUrl === Emotes.RANGE ||
       emoteUrl === Emotes.SPELL_CAST
     );

--- a/packages/shared/src/entities/player/PlayerAvatarController.ts
+++ b/packages/shared/src/entities/player/PlayerAvatarController.ts
@@ -65,6 +65,8 @@ const EMOTE_MAP: Record<string, string> = {
   run: Emotes.RUN,
   combat: Emotes.COMBAT,
   sword_swing: Emotes.SWORD_SWING,
+  "2h_idle": Emotes.TWO_HAND_IDLE,
+  "2h_slash": Emotes.TWO_HAND_SLASH,
   range: Emotes.RANGE,
   spell_cast: Emotes.SPELL_CAST,
   chopping: Emotes.CHOPPING,

--- a/packages/shared/src/entities/player/PlayerRemote.ts
+++ b/packages/shared/src/entities/player/PlayerRemote.ts
@@ -673,6 +673,8 @@ export class PlayerRemote extends Entity implements HotReloadable {
             talk: Emotes.TALK,
             combat: Emotes.COMBAT,
             sword_swing: Emotes.SWORD_SWING,
+            "2h_idle": Emotes.TWO_HAND_IDLE,
+            "2h_slash": Emotes.TWO_HAND_SLASH,
             range: Emotes.RANGE,
             spell_cast: Emotes.SPELL_CAST,
             chopping: Emotes.CHOPPING,

--- a/packages/shared/src/entities/world/ItemEntity.ts
+++ b/packages/shared/src/entities/world/ItemEntity.ts
@@ -262,8 +262,8 @@ export class ItemEntity extends InteractableEntity {
     // Send correct item data: entityId is the entity in the world, itemId is the item definition
     this.world.emit(EventType.ITEM_PICKUP, {
       playerId: data.playerId,
-      itemId: this.config.itemId, // The actual item ID (e.g., "bronze_sword")
-      entityId: this.id, // The entity ID in the world (e.g., "gdd_bronze_sword_1")
+      itemId: this.config.itemId, // The actual item ID (e.g., "bronze_shortsword")
+      entityId: this.id, // The entity ID in the world (e.g., "gdd_bronze_shortsword_1")
       position: this.getPosition(),
     });
 

--- a/packages/shared/src/systems/client/EquipmentVisualSystem.ts
+++ b/packages/shared/src/systems/client/EquipmentVisualSystem.ts
@@ -312,7 +312,7 @@ export class EquipmentVisualSystem extends SystemBase {
         weaponUrl = itemData.modelPath.replace("asset://", `${assetsUrl}/`);
       } else {
         // Fallback to convention-based derivation
-        // itemId format: "{material}_{item}" e.g., "steel_sword"
+        // itemId format: "{material}_{item}" e.g., "steel_shortsword"
         // asset format: "{item}-{material}" e.g., "sword-steel"
         let assetId = itemId.replace(/_/g, "-");
 

--- a/packages/shared/src/systems/shared/character/EquipmentSystem.ts
+++ b/packages/shared/src/systems/shared/character/EquipmentSystem.ts
@@ -1074,7 +1074,7 @@ export class EquipmentSystem extends SystemBase {
       return;
     }
 
-    // Keep itemId as STRING (e.g., "bronze_sword", "steel_sword")
+    // Keep itemId as STRING (e.g., "bronze_shortsword", "steel_shortsword")
     equipmentSlot.itemId = itemData.id as string | number;
     equipmentSlot.item = itemData;
 
@@ -1161,7 +1161,7 @@ export class EquipmentSystem extends SystemBase {
 
   private getEquipmentSlot(itemData: Item): string | null {
     // BANK NOTE SYSTEM: Explicitly non-equipable items cannot be equipped
-    // This catches noted items (e.g., "bronze_sword_noted") which inherit
+    // This catches noted items (e.g., "bronze_shortsword_noted") which inherit
     // type from base but are marked equipable: false
     if (itemData.equipable === false) {
       return null;
@@ -1324,7 +1324,7 @@ export class EquipmentSystem extends SystemBase {
    *
    * @example
    * const data = equipmentSystem.getEquipmentData(playerId);
-   * // { weapon: { id: "bronze_sword", ... }, shield: null, ... }
+   * // { weapon: { id: "bronze_shortsword", ... }, shield: null, ... }
    */
   getEquipmentData(playerId: string): Record<string, unknown> {
     const equipment = this.playerEquipment.get(playerId);
@@ -1431,7 +1431,7 @@ export class EquipmentSystem extends SystemBase {
    * @returns Slot name (weapon, shield, etc.) or null if not equipable
    *
    * @example
-   * const slot = equipmentSystem.getEquipmentSlotForItem("bronze_sword");
+   * const slot = equipmentSystem.getEquipmentSlotForItem("bronze_shortsword");
    * // Returns: "weapon"
    */
   getEquipmentSlotForItem(itemId: string | number): string | null {
@@ -1471,7 +1471,7 @@ export class EquipmentSystem extends SystemBase {
    * @returns Result with success status and any displaced items
    *
    * @example
-   * const result = await equipmentSystem.equipItemDirect(playerId, "bronze_sword");
+   * const result = await equipmentSystem.equipItemDirect(playerId, "bronze_shortsword");
    * if (result.success) {
    *   // Item equipped, handle result.displacedItems if any
    * }

--- a/packages/shared/src/systems/shared/character/InventorySystem.ts
+++ b/packages/shared/src/systems/shared/character/InventorySystem.ts
@@ -292,7 +292,7 @@ export class InventorySystem extends SystemBase {
 
   private async addStarterEquipment(playerId: PlayerID): Promise<void> {
     const starterItems = [
-      { itemId: "bronze_sword", quantity: 1 },
+      { itemId: "bronze_shortsword", quantity: 1 },
       { itemId: "bronze_shield", quantity: 1 },
       { itemId: "bronze_helmet", quantity: 1 },
       { itemId: "bronze_body", quantity: 1 },

--- a/packages/shared/src/systems/shared/character/PlayerSystem.ts
+++ b/packages/shared/src/systems/shared/character/PlayerSystem.ts
@@ -113,7 +113,7 @@ export class PlayerSystem extends SystemBase {
     itemId: string;
     slot: string;
     autoEquip: boolean;
-  }> = [{ itemId: "bronze_sword", slot: "weapon", autoEquip: true }];
+  }> = [{ itemId: "bronze_shortsword", slot: "weapon", autoEquip: true }];
 
   // Attack style tracking (merged from AttackStyleSystem)
   private playerAttackStyles = new Map<string, PlayerAttackStyleState>();

--- a/packages/shared/src/systems/shared/character/__tests__/EquipmentPersistence.test.ts
+++ b/packages/shared/src/systems/shared/character/__tests__/EquipmentPersistence.test.ts
@@ -130,14 +130,14 @@ class MockEquipmentManager {
   }
 
   private registerDefaultItems(): void {
-    this.itemDatabase.set("bronze_sword", {
-      id: "bronze_sword",
+    this.itemDatabase.set("bronze_shortsword", {
+      id: "bronze_shortsword",
       name: "Bronze Sword",
       type: "weapon",
       bonuses: { attack: 4 },
     });
-    this.itemDatabase.set("iron_sword", {
-      id: "iron_sword",
+    this.itemDatabase.set("iron_shortsword", {
+      id: "iron_shortsword",
       name: "Iron Sword",
       type: "weapon",
       bonuses: { attack: 8 },
@@ -368,10 +368,12 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // === Session 1: Player logs in, equips item, logs out ===
       manager.initializePlayer(playerId);
-      manager.equipItem(playerId, "bronze_sword");
+      manager.equipItem(playerId, "bronze_shortsword");
 
       // Verify equipped
-      expect(manager.getEquipmentData(playerId).weapon).toBe("bronze_sword");
+      expect(manager.getEquipmentData(playerId).weapon).toBe(
+        "bronze_shortsword",
+      );
 
       // Save and logout
       await manager.saveToDatabase(playerId);
@@ -387,7 +389,9 @@ describe("Equipment Persistence (Issue #273)", () => {
       await manager.loadFromDatabase(playerId);
 
       // Verify equipment persisted
-      expect(manager.getEquipmentData(playerId).weapon).toBe("bronze_sword");
+      expect(manager.getEquipmentData(playerId).weapon).toBe(
+        "bronze_shortsword",
+      );
     });
 
     it("preserves multiple equipped items across sessions", async () => {
@@ -395,7 +399,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Session 1: Equip multiple items
       manager.initializePlayer(playerId);
-      manager.equipItem(playerId, "bronze_sword");
+      manager.equipItem(playerId, "bronze_shortsword");
       manager.equipItem(playerId, "bronze_shield");
       await manager.saveToDatabase(playerId);
       manager.cleanupPlayer(playerId);
@@ -405,7 +409,7 @@ describe("Equipment Persistence (Issue #273)", () => {
       await manager.loadFromDatabase(playerId);
 
       const equipment = manager.getEquipmentData(playerId);
-      expect(equipment.weapon).toBe("bronze_sword");
+      expect(equipment.weapon).toBe("bronze_shortsword");
       expect(equipment.shield).toBe("bronze_shield");
     });
 
@@ -428,7 +432,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Pre-populate database with equipped item
       await database.saveEquipment(playerId, {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -456,7 +460,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Now it's loaded (but client already received empty data)
       const equipmentAfterLoad = manager.getEquipmentData(playerId);
-      expect(equipmentAfterLoad.weapon).toBe("bronze_sword");
+      expect(equipmentAfterLoad.weapon).toBe("bronze_shortsword");
     });
 
     it("FIX VERIFIED: awaited load returns correct equipment", async () => {
@@ -464,7 +468,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Pre-populate database with equipped item
       await database.saveEquipment(playerId, {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -483,14 +487,14 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Equipment is immediately available
       const equipment = manager.getEquipmentData(playerId);
-      expect(equipment.weapon).toBe("bronze_sword");
+      expect(equipment.weapon).toBe("bronze_shortsword");
     });
 
     it("event ordering shows the race condition", async () => {
       const playerId = "player-1";
 
       await database.saveEquipment(playerId, {
-        weapon: "iron_sword",
+        weapon: "iron_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -532,8 +536,8 @@ describe("Equipment Persistence (Issue #273)", () => {
       // Setup multiple players with equipment
       manager.initializePlayer("player-1");
       manager.initializePlayer("player-2");
-      manager.equipItem("player-1", "bronze_sword");
-      manager.equipItem("player-2", "iron_sword");
+      manager.equipItem("player-1", "bronze_shortsword");
+      manager.equipItem("player-2", "iron_shortsword");
 
       // Graceful shutdown
       await manager.destroyAsync();
@@ -542,13 +546,13 @@ describe("Equipment Persistence (Issue #273)", () => {
       const p1Equipment = database.getStoredEquipmentSync("player-1");
       const p2Equipment = database.getStoredEquipmentSync("player-2");
 
-      expect(p1Equipment?.weapon).toBe("bronze_sword");
-      expect(p2Equipment?.weapon).toBe("iron_sword");
+      expect(p1Equipment?.weapon).toBe("bronze_shortsword");
+      expect(p2Equipment?.weapon).toBe("iron_shortsword");
     });
 
     it("DEMONSTRATES BUG: fire-and-forget destroy may lose data", async () => {
       manager.initializePlayer("player-1");
-      manager.equipItem("player-1", "bronze_sword");
+      manager.equipItem("player-1", "bronze_shortsword");
 
       // Non-graceful shutdown (fire and forget)
       manager.destroyFireAndForget();
@@ -564,7 +568,7 @@ describe("Equipment Persistence (Issue #273)", () => {
       // Wait a bit and check again
       await new Promise((resolve) => setTimeout(resolve, 50));
       const equipmentAfterWait = database.getStoredEquipmentSync("player-1");
-      expect(equipmentAfterWait?.weapon).toBe("bronze_sword");
+      expect(equipmentAfterWait?.weapon).toBe("bronze_shortsword");
     });
   });
 
@@ -573,20 +577,20 @@ describe("Equipment Persistence (Issue #273)", () => {
       const playerId = "player-1";
       manager.initializePlayer(playerId);
 
-      manager.equipItem(playerId, "bronze_sword");
+      manager.equipItem(playerId, "bronze_shortsword");
       await manager.saveToDatabase(playerId);
 
       // Verify in database
       const dbEquipment = database.getStoredEquipmentSync(playerId);
-      expect(dbEquipment?.weapon).toBe("bronze_sword");
+      expect(dbEquipment?.weapon).toBe("bronze_shortsword");
 
       // Equip different item
-      manager.equipItem(playerId, "iron_sword");
+      manager.equipItem(playerId, "iron_shortsword");
       await manager.saveToDatabase(playerId);
 
       // Verify update persisted
       const updatedEquipment = database.getStoredEquipmentSync(playerId);
-      expect(updatedEquipment?.weapon).toBe("iron_sword");
+      expect(updatedEquipment?.weapon).toBe("iron_shortsword");
     });
 
     it("multiple rapid equip changes are all saved", async () => {
@@ -594,10 +598,10 @@ describe("Equipment Persistence (Issue #273)", () => {
       manager.initializePlayer(playerId);
 
       // Rapid equip/unequip cycle
-      manager.equipItem(playerId, "bronze_sword");
+      manager.equipItem(playerId, "bronze_shortsword");
       await manager.saveToDatabase(playerId);
 
-      manager.equipItem(playerId, "iron_sword");
+      manager.equipItem(playerId, "iron_shortsword");
       await manager.saveToDatabase(playerId);
 
       manager.equipItem(playerId, "bronze_shield");
@@ -605,7 +609,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Final state should be persisted
       const equipment = database.getStoredEquipmentSync(playerId);
-      expect(equipment?.weapon).toBe("iron_sword");
+      expect(equipment?.weapon).toBe("iron_shortsword");
       expect(equipment?.shield).toBe("bronze_shield");
     });
   });
@@ -619,7 +623,7 @@ describe("Equipment Persistence (Issue #273)", () => {
 
       // Save equipment first
       manager.initializePlayer(playerId);
-      manager.equipItem(playerId, "bronze_sword");
+      manager.equipItem(playerId, "bronze_shortsword");
       await manager.saveToDatabase(playerId);
       manager.cleanupPlayer(playerId);
 
@@ -628,13 +632,15 @@ describe("Equipment Persistence (Issue #273)", () => {
       await manager.loadFromDatabase(playerId);
 
       // Should still load correctly
-      expect(manager.getEquipmentData(playerId).weapon).toBe("bronze_sword");
+      expect(manager.getEquipmentData(playerId).weapon).toBe(
+        "bronze_shortsword",
+      );
     });
 
     it("concurrent logins don't corrupt data", async () => {
       // Pre-populate
       await database.saveEquipment("player-1", {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -647,7 +653,7 @@ describe("Equipment Persistence (Issue #273)", () => {
         arrows: null,
       });
       await database.saveEquipment("player-2", {
-        weapon: "iron_sword",
+        weapon: "iron_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -671,8 +677,12 @@ describe("Equipment Persistence (Issue #273)", () => {
       ]);
 
       // Each player should have their own equipment
-      expect(manager.getEquipmentData("player-1").weapon).toBe("bronze_sword");
-      expect(manager.getEquipmentData("player-2").weapon).toBe("iron_sword");
+      expect(manager.getEquipmentData("player-1").weapon).toBe(
+        "bronze_shortsword",
+      );
+      expect(manager.getEquipmentData("player-2").weapon).toBe(
+        "iron_shortsword",
+      );
     });
   });
 });

--- a/packages/shared/src/systems/shared/character/__tests__/EquipmentSystem.test.ts
+++ b/packages/shared/src/systems/shared/character/__tests__/EquipmentSystem.test.ts
@@ -748,8 +748,8 @@ function createTestItems(): Map<string, Item> {
   const items = new Map<string, Item>();
 
   // Bronze tier (level 1)
-  items.set("bronze_sword", {
-    id: "bronze_sword",
+  items.set("bronze_shortsword", {
+    id: "bronze_shortsword",
     name: "Bronze Sword",
     type: "weapon",
     bonuses: { attack: 4, strength: 3 },
@@ -766,8 +766,8 @@ function createTestItems(): Map<string, Item> {
   });
 
   // Steel tier (level 10)
-  items.set("steel_sword", {
-    id: "steel_sword",
+  items.set("steel_shortsword", {
+    id: "steel_shortsword",
     name: "Steel Sword",
     type: "weapon",
     bonuses: { attack: 12, strength: 10 },
@@ -888,32 +888,32 @@ describe("EquipmentSystem", () => {
   describe("Level Requirements", () => {
     it("allows equipping items when level requirements met", () => {
       manager.setSkills("player-1", { attack: 10, defense: 1 });
-      manager.addToInventory("player-1", "steel_sword");
+      manager.addToInventory("player-1", "steel_shortsword");
 
-      const result = manager.tryEquipItem("player-1", "steel_sword");
+      const result = manager.tryEquipItem("player-1", "steel_shortsword");
 
       expect(result.success).toBe(true);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "steel_sword",
+        "steel_shortsword",
       );
     });
 
     it("blocks equipping items when level requirements not met", () => {
       manager.setSkills("player-1", { attack: 5, defense: 1 }); // Level 5, needs 10
-      manager.addToInventory("player-1", "steel_sword");
+      manager.addToInventory("player-1", "steel_shortsword");
 
-      const result = manager.tryEquipItem("player-1", "steel_sword");
+      const result = manager.tryEquipItem("player-1", "steel_shortsword");
 
       expect(result.success).toBe(false);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBeNull();
-      expect(manager.hasItem("player-1", "steel_sword")).toBe(true); // Still in inventory
+      expect(manager.hasItem("player-1", "steel_shortsword")).toBe(true); // Still in inventory
     });
 
     it("returns correct requirement message for blocked items", () => {
       manager.setSkills("player-1", { attack: 5, defense: 1 });
-      manager.addToInventory("player-1", "steel_sword");
+      manager.addToInventory("player-1", "steel_shortsword");
 
-      manager.tryEquipItem("player-1", "steel_sword");
+      manager.tryEquipItem("player-1", "steel_shortsword");
 
       const messages = manager.getMessages();
       expect(messages.some((m) => m.message.includes("level 10 Attack"))).toBe(
@@ -977,15 +977,15 @@ describe("EquipmentSystem", () => {
 
     it("allows 1h weapon + shield combination", () => {
       manager.setSkills("player-1", { attack: 1, defense: 1 });
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.addToInventory("player-1", "bronze_shield");
 
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       const result = manager.tryEquipItem("player-1", "bronze_shield");
 
       expect(result.success).toBe(true);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
       expect(manager.getEquipment("player-1")?.shield.itemId).toBe(
         "bronze_shield",
@@ -995,52 +995,52 @@ describe("EquipmentSystem", () => {
 
   describe("Equip/Unequip Flow", () => {
     it("moves item from inventory to equipment slot", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      expect(manager.hasItem("player-1", "bronze_sword")).toBe(true);
+      manager.addToInventory("player-1", "bronze_shortsword");
+      expect(manager.hasItem("player-1", "bronze_shortsword")).toBe(true);
 
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
-      expect(manager.hasItem("player-1", "bronze_sword")).toBe(false);
+      expect(manager.hasItem("player-1", "bronze_shortsword")).toBe(false);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
 
     it("moves item from equipment slot to inventory", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       const result = manager.unequipSlot("player-1", "weapon");
 
       expect(result.success).toBe(true);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBeNull();
-      expect(manager.hasItem("player-1", "bronze_sword")).toBe(true);
+      expect(manager.hasItem("player-1", "bronze_shortsword")).toBe(true);
     });
 
     it("swaps items when equipping to occupied slot", () => {
       manager.setSkills("player-1", { attack: 10, defense: 1 });
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.addToInventory("player-1", "steel_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.addToInventory("player-1", "steel_shortsword");
 
       // Equip bronze sword first
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
 
       // Equip steel sword (should swap)
-      manager.tryEquipItem("player-1", "steel_sword");
+      manager.tryEquipItem("player-1", "steel_shortsword");
 
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "steel_sword",
+        "steel_shortsword",
       );
-      expect(manager.hasItem("player-1", "bronze_sword")).toBe(true);
-      expect(manager.hasItem("player-1", "steel_sword")).toBe(false);
+      expect(manager.hasItem("player-1", "bronze_shortsword")).toBe(true);
+      expect(manager.hasItem("player-1", "steel_shortsword")).toBe(false);
     });
 
     it("fails gracefully when inventory full on unequip", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       // Fill inventory
       manager.fillInventory("player-1");
@@ -1050,7 +1050,7 @@ describe("EquipmentSystem", () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe("Inventory is full");
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
 
@@ -1124,11 +1124,11 @@ describe("EquipmentSystem", () => {
   describe("Stats Calculation", () => {
     it("sums bonuses from all equipped items", () => {
       manager.setSkills("player-1", { attack: 10, defense: 10 });
-      manager.addToInventory("player-1", "steel_sword"); // attack: 12, strength: 10
+      manager.addToInventory("player-1", "steel_shortsword"); // attack: 12, strength: 10
       manager.addToInventory("player-1", "steel_platebody"); // defense: 15
       manager.addToInventory("player-1", "bronze_arrows"); // ranged: 2
 
-      manager.tryEquipItem("player-1", "steel_sword");
+      manager.tryEquipItem("player-1", "steel_shortsword");
       manager.tryEquipItem("player-1", "steel_platebody");
       manager.tryEquipItem("player-1", "bronze_arrows");
 
@@ -1141,12 +1141,12 @@ describe("EquipmentSystem", () => {
     });
 
     it("recalculates on equip", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
 
       const statsBefore = manager.getTotalStats("player-1");
       expect(statsBefore.attack).toBe(0);
 
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       const statsAfter = manager.getTotalStats("player-1");
       expect(statsAfter.attack).toBe(4);
@@ -1154,8 +1154,8 @@ describe("EquipmentSystem", () => {
     });
 
     it("recalculates on unequip", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(manager.getTotalStats("player-1").attack).toBe(4);
 
@@ -1179,7 +1179,7 @@ describe("EquipmentSystem", () => {
 
     it("sums bonuses from all 11 slots including new accessory slots", () => {
       manager.setSkills("player-1", { attack: 10, defense: 10 });
-      manager.addToInventory("player-1", "steel_sword"); // attack: 12, strength: 10
+      manager.addToInventory("player-1", "steel_shortsword"); // attack: 12, strength: 10
       manager.addToInventory("player-1", "steel_platebody"); // defense: 15
       manager.addToInventory("player-1", "leather_boots"); // defense: 2
       manager.addToInventory("player-1", "leather_gloves"); // attack: 1, defense: 1
@@ -1188,7 +1188,7 @@ describe("EquipmentSystem", () => {
       manager.addToInventory("player-1", "berserker_ring"); // strength: 4
       manager.addToInventory("player-1", "bronze_arrows"); // ranged: 2
 
-      manager.tryEquipItem("player-1", "steel_sword");
+      manager.tryEquipItem("player-1", "steel_shortsword");
       manager.tryEquipItem("player-1", "steel_platebody");
       manager.tryEquipItem("player-1", "leather_boots");
       manager.tryEquipItem("player-1", "leather_gloves");
@@ -1208,20 +1208,20 @@ describe("EquipmentSystem", () => {
 
   describe("Persistence", () => {
     it("saves equipment to database on request", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       manager.saveEquipment("player-1");
 
       const saved = manager.getSavedEquipment();
       expect(saved.length).toBe(1);
-      expect(saved[0].slots.weapon).toBe("bronze_sword");
+      expect(saved[0].slots.weapon).toBe("bronze_shortsword");
     });
 
     it("loads equipment from database", () => {
       // Simulate loading from database
       manager.loadEquipment("player-1", {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -1235,7 +1235,7 @@ describe("EquipmentSystem", () => {
       });
 
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
       expect(manager.getEquipment("player-1")?.weapon.item?.name).toBe(
         "Bronze Sword",
@@ -1273,7 +1273,7 @@ describe("EquipmentSystem", () => {
 
     it("recalculates stats after loading", () => {
       manager.loadEquipment("player-1", {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: "bronze_shield",
         helmet: null,
         body: null,
@@ -1295,9 +1295,9 @@ describe("EquipmentSystem", () => {
 
   describe("Death Handling", () => {
     it("clears all equipment on death via clearEquipmentImmediate", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.addToInventory("player-1", "bronze_shield");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       manager.tryEquipItem("player-1", "bronze_shield");
 
       const clearedCount = manager.clearEquipmentImmediate("player-1");
@@ -1308,8 +1308,8 @@ describe("EquipmentSystem", () => {
     });
 
     it("persists empty equipment immediately on death", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       manager.clearEquipmentImmediate("player-1");
 
@@ -1319,8 +1319,8 @@ describe("EquipmentSystem", () => {
     });
 
     it("resets stats on death", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(manager.getTotalStats("player-1").attack).toBe(4);
 
@@ -1330,7 +1330,7 @@ describe("EquipmentSystem", () => {
     });
 
     it("clears all 11 equipment slots on death", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.addToInventory("player-1", "bronze_shield");
       manager.addToInventory("player-1", "basic_helmet");
       manager.addToInventory("player-1", "leather_boots");
@@ -1339,7 +1339,7 @@ describe("EquipmentSystem", () => {
       manager.addToInventory("player-1", "amulet_of_strength");
       manager.addToInventory("player-1", "berserker_ring");
       manager.addToInventory("player-1", "bronze_arrows");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       manager.tryEquipItem("player-1", "bronze_shield");
       manager.tryEquipItem("player-1", "basic_helmet");
       manager.tryEquipItem("player-1", "leather_boots");
@@ -1360,8 +1360,8 @@ describe("EquipmentSystem", () => {
     });
 
     it("can re-equip after respawn", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
 
       // Death clears equipment
       manager.clearEquipmentImmediate("player-1");
@@ -1369,7 +1369,7 @@ describe("EquipmentSystem", () => {
 
       // Simulate respawn - reload from database
       manager.loadEquipment("player-1", {
-        weapon: "bronze_sword",
+        weapon: "bronze_shortsword",
         shield: null,
         helmet: null,
         body: null,
@@ -1383,27 +1383,27 @@ describe("EquipmentSystem", () => {
       });
 
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
   });
 
   describe("Trade + Equip Guard", () => {
     it("blocks equip when player is in active trade", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.setInTrade("player-1", true);
 
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("You can't change equipment during a trade.");
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBeNull();
-      expect(manager.hasItem("player-1", "bronze_sword")).toBe(true);
+      expect(manager.hasItem("player-1", "bronze_shortsword")).toBe(true);
     });
 
     it("blocks unequip when player is in active trade", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       manager.setInTrade("player-1", true);
 
       const result = manager.unequipSlot("player-1", "weapon");
@@ -1411,37 +1411,37 @@ describe("EquipmentSystem", () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe("You can't change equipment during a trade.");
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
 
     it("allows equip after trade ends", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.setInTrade("player-1", true);
 
       // Blocked during trade
-      expect(manager.tryEquipItem("player-1", "bronze_sword").success).toBe(
-        false,
-      );
+      expect(
+        manager.tryEquipItem("player-1", "bronze_shortsword").success,
+      ).toBe(false);
 
       // Trade ends
       manager.setInTrade("player-1", false);
 
       // Now allowed
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
       expect(result.success).toBe(true);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
   });
 
   describe("Death + Equip Guard", () => {
     it("blocks equip when player is dying", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.setDeathState("player-1", "dying");
 
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("You can't change equipment while dead.");
@@ -1449,18 +1449,18 @@ describe("EquipmentSystem", () => {
     });
 
     it("blocks equip when player is dead", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.setDeathState("player-1", "dead");
 
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("You can't change equipment while dead.");
     });
 
     it("blocks unequip when player is dead", () => {
-      manager.addToInventory("player-1", "bronze_sword");
-      manager.tryEquipItem("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
+      manager.tryEquipItem("player-1", "bronze_shortsword");
       manager.setDeathState("player-1", "dead");
 
       const result = manager.unequipSlot("player-1", "weapon");
@@ -1468,34 +1468,37 @@ describe("EquipmentSystem", () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe("You can't change equipment while dead.");
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
 
     it("allows equip after respawn", () => {
-      manager.addToInventory("player-1", "bronze_sword");
+      manager.addToInventory("player-1", "bronze_shortsword");
       manager.setDeathState("player-1", "dead");
 
       // Blocked while dead
-      expect(manager.tryEquipItem("player-1", "bronze_sword").success).toBe(
-        false,
-      );
+      expect(
+        manager.tryEquipItem("player-1", "bronze_shortsword").success,
+      ).toBe(false);
 
       // Respawn
       manager.setDeathState("player-1", "alive");
 
       // Now allowed
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
       expect(result.success).toBe(true);
       expect(manager.getEquipment("player-1")?.weapon.itemId).toBe(
-        "bronze_sword",
+        "bronze_shortsword",
       );
     });
   });
 
   describe("Edge Cases", () => {
     it("handles player not initialized", () => {
-      const result = manager.tryEquipItem("unknown-player", "bronze_sword");
+      const result = manager.tryEquipItem(
+        "unknown-player",
+        "bronze_shortsword",
+      );
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("Player not found");
@@ -1511,7 +1514,7 @@ describe("EquipmentSystem", () => {
     });
 
     it("handles item not in inventory", () => {
-      const result = manager.tryEquipItem("player-1", "bronze_sword");
+      const result = manager.tryEquipItem("player-1", "bronze_shortsword");
 
       expect(result.success).toBe(false);
       expect(result.message).toBe("Item not in inventory");

--- a/packages/shared/src/systems/shared/character/__tests__/InventorySystem.moveItem.test.ts
+++ b/packages/shared/src/systems/shared/character/__tests__/InventorySystem.moveItem.test.ts
@@ -183,7 +183,7 @@ describe("InventorySystem.moveItem", () => {
 
   describe("Basic swap between two occupied slots", () => {
     it("swaps sword in slot 0 with shield in slot 5", () => {
-      manager.setupItem(0, "bronze_sword", 1);
+      manager.setupItem(0, "bronze_shortsword", 1);
       manager.setupItem(5, "bronze_shield", 1);
 
       manager.moveItem({
@@ -193,7 +193,7 @@ describe("InventorySystem.moveItem", () => {
       });
 
       expect(manager.getItem(0)?.itemId).toBe("bronze_shield");
-      expect(manager.getItem(5)?.itemId).toBe("bronze_sword");
+      expect(manager.getItem(5)?.itemId).toBe("bronze_shortsword");
       expect(manager.wasUpdateEmitted()).toBe(true);
       expect(manager.wasPersistScheduled()).toBe(true);
     });
@@ -231,7 +231,7 @@ describe("InventorySystem.moveItem", () => {
 
   describe("Move to empty slot", () => {
     it("moves item from slot 0 to empty slot 10", () => {
-      manager.setupItem(0, "bronze_sword", 1);
+      manager.setupItem(0, "bronze_shortsword", 1);
 
       manager.moveItem({
         playerId: "player-123",
@@ -240,7 +240,7 @@ describe("InventorySystem.moveItem", () => {
       });
 
       expect(manager.getItem(0)).toBeUndefined();
-      expect(manager.getItem(10)?.itemId).toBe("bronze_sword");
+      expect(manager.getItem(10)?.itemId).toBe("bronze_shortsword");
       expect(manager.wasUpdateEmitted()).toBe(true);
     });
 

--- a/packages/shared/src/systems/shared/character/__tests__/InventorySystem.pickup.test.ts
+++ b/packages/shared/src/systems/shared/character/__tests__/InventorySystem.pickup.test.ts
@@ -225,7 +225,10 @@ describe("InventorySystem Pickup", () => {
     it("rejects pickup when inventory is full", () => {
       const manager = new MockInventoryManager();
       manager.fillInventory(); // Fill all 28 slots
-      manager.setEntityData("item-1", { itemId: "bronze_sword", quantity: 1 });
+      manager.setEntityData("item-1", {
+        itemId: "bronze_shortsword",
+        quantity: 1,
+      });
 
       const result = manager.pickupItem("player-1", "item-1");
 

--- a/packages/shared/src/systems/shared/combat/CombatAnimationManager.ts
+++ b/packages/shared/src/systems/shared/combat/CombatAnimationManager.ts
@@ -167,7 +167,19 @@ export class CombatAnimationManager {
           // OSRS-accurate: Magic weapons WITHOUT autocast use melee bonk (crush)
           // Staffs default to punching/combat animation when no spell selected
           combatEmote = "combat";
-        } else if (weaponType === "sword") {
+        } else if (weaponType === "two_hand_sword") {
+          combatEmote = "2h_slash";
+        } else if (
+          weaponType === "sword" ||
+          weaponType === "dagger" ||
+          weaponType === "longsword" ||
+          weaponType === "scimitar" ||
+          weaponType === "axe" ||
+          weaponType === "mace" ||
+          weaponType === "spear" ||
+          weaponType === "halberd" ||
+          attackType === "melee"
+        ) {
           combatEmote = "sword_swing";
         } else if (
           weaponType === "bow" ||
@@ -268,12 +280,27 @@ export class CombatAnimationManager {
           `resetEmote for player ${entityId}, current emote: ${playerEntity.data?.e}`,
         );
 
+        // Determine idle emote based on equipped weapon (2h weapons use 2h_idle)
+        let idleEmote = "idle";
+        const equipmentSystem = this.world.getSystem("equipment");
+        if (isEquipmentSystem(equipmentSystem)) {
+          const equipment = equipmentSystem.getPlayerEquipment(entityId);
+          if (equipment?.weapon?.item) {
+            const weaponType =
+              equipment.weapon.item.weaponType?.toLowerCase?.() ??
+              equipment.weapon.item.weaponType;
+            if (weaponType === "two_hand_sword") {
+              idleEmote = "2h_idle";
+            }
+          }
+        }
+
         // Reset to idle string key
         if (playerEntity.emote !== undefined) {
-          playerEntity.emote = "idle";
+          playerEntity.emote = idleEmote;
         }
         if (playerEntity.data) {
-          playerEntity.data.e = "idle";
+          playerEntity.data.e = idleEmote;
         }
 
         // Send immediate network update
@@ -281,7 +308,7 @@ export class CombatAnimationManager {
         if (this.world.isServer && this.world.network?.send) {
           this.world.network.send("entityModified", {
             id: entityId,
-            e: "idle",
+            e: idleEmote,
           });
         }
 

--- a/packages/shared/src/systems/shared/combat/__tests__/AmmunitionService.test.ts
+++ b/packages/shared/src/systems/shared/combat/__tests__/AmmunitionService.test.ts
@@ -45,7 +45,7 @@ describe("AmmunitionService", () => {
   };
 
   const sword: Item = {
-    id: "bronze_sword",
+    id: "bronze_shortsword",
     name: "Bronze sword",
     type: "weapon",
     description: "A bronze sword",

--- a/packages/shared/src/systems/shared/combat/__tests__/CombatAnimationManager.test.ts
+++ b/packages/shared/src/systems/shared/combat/__tests__/CombatAnimationManager.test.ts
@@ -145,7 +145,7 @@ describe("CombatAnimationManager", () => {
 
       const equipmentSystem = {
         getPlayerEquipment: vi.fn().mockReturnValue({
-          weapon: { item: { weaponType: "SWORD", id: "bronze_sword" } },
+          weapon: { item: { weaponType: "SWORD", id: "bronze_shortsword" } },
         }),
       };
       mockWorld = createMockWorld({

--- a/packages/shared/src/systems/shared/combat/__tests__/CombatMeleeRange.integration.test.ts
+++ b/packages/shared/src/systems/shared/combat/__tests__/CombatMeleeRange.integration.test.ts
@@ -211,7 +211,7 @@ function createTestWorld(options: { currentTick?: number } = {}) {
             return {
               weapon: {
                 item: {
-                  id: range === 2 ? "dragon_halberd" : "bronze_sword",
+                  id: range === 2 ? "dragon_halberd" : "bronze_shortsword",
                   attackRange: range,
                 },
               },

--- a/packages/shared/src/systems/shared/death/__tests__/SafeAreaDeathHandler.test.ts
+++ b/packages/shared/src/systems/shared/death/__tests__/SafeAreaDeathHandler.test.ts
@@ -81,7 +81,7 @@ function createTestItems() {
   return [
     {
       id: "item_1",
-      itemId: "bronze_sword",
+      itemId: "bronze_shortsword",
       quantity: 1,
       slot: 0,
       metadata: null,

--- a/packages/shared/src/systems/shared/entities/ItemSpawnerSystem.ts
+++ b/packages/shared/src/systems/shared/entities/ItemSpawnerSystem.ts
@@ -448,7 +448,7 @@ export class ItemSpawnerSystem extends SystemBase {
     if (difficulty === 1) {
       // Bronze equipment
       itemIds.push(
-        "bronze_sword",
+        "bronze_shortsword",
         "bronze_shield",
         "bronze_helmet",
         "bronze_body",
@@ -458,7 +458,7 @@ export class ItemSpawnerSystem extends SystemBase {
     } else if (difficulty === 2) {
       // Steel equipment
       itemIds.push(
-        "steel_sword",
+        "steel_shortsword",
         "steel_shield",
         "steel_helmet",
         "steel_body",
@@ -468,7 +468,7 @@ export class ItemSpawnerSystem extends SystemBase {
     } else if (difficulty === 3) {
       // Mithril equipment
       itemIds.push(
-        "mithril_sword",
+        "mithril_shortsword",
         "mithril_shield",
         "mithril_helmet",
         "mithril_body",
@@ -499,11 +499,11 @@ export class ItemSpawnerSystem extends SystemBase {
 
     if (tier === ItemRarity.RARE) {
       // Steel equipment and valuable items
-      itemIds.push("steel_sword", "steel_helmet", "arrows", "coins");
+      itemIds.push("steel_shortsword", "steel_helmet", "arrows", "coins");
     } else if (tier === ItemRarity.LEGENDARY) {
       // Mithril equipment and best items
       itemIds.push(
-        "mithril_sword",
+        "mithril_shortsword",
         "mithril_helmet",
         "mithril_body",
         "willow_bow",

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -93,7 +93,9 @@ describe("ToolUtils", () => {
       });
 
       it("rejects non-pickaxe items", () => {
-        expect(itemMatchesToolCategory("bronze_sword", "pickaxe")).toBe(false);
+        expect(itemMatchesToolCategory("bronze_shortsword", "pickaxe")).toBe(
+          false,
+        );
         expect(itemMatchesToolCategory("bronze_axe", "pickaxe")).toBe(false);
         expect(itemMatchesToolCategory("logs", "pickaxe")).toBe(false);
       });
@@ -113,7 +115,9 @@ describe("ToolUtils", () => {
       });
 
       it("rejects non-hatchet items", () => {
-        expect(itemMatchesToolCategory("bronze_sword", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("bronze_shortsword", "hatchet")).toBe(
+          false,
+        );
         expect(itemMatchesToolCategory("logs", "hatchet")).toBe(false);
       });
 

--- a/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
+++ b/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
@@ -1492,7 +1492,7 @@ function setupAPI(world: World, systems: Systems): void {
       spawnTestItem: (
         x: number,
         z: number,
-        itemType = "bronze_sword",
+        itemType = "bronze_shortsword",
         color = "#0000FF",
       ) => {
         // Only work on client side where THREE.js scene is available

--- a/packages/shared/src/systems/shared/interaction/SmithingSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/SmithingSystem.ts
@@ -27,7 +27,7 @@ import type { World } from "../../../types/index";
 /** Active smithing session for a player */
 interface SmithingSession {
   playerId: string;
-  recipeId: string; // Output item ID (e.g., "bronze_sword")
+  recipeId: string; // Output item ID (e.g., "bronze_shortsword")
   anvilId: string;
   startTime: number;
   quantity: number;

--- a/packages/shared/src/systems/shared/interaction/__tests__/RunecraftingSystem.test.ts
+++ b/packages/shared/src/systems/shared/interaction/__tests__/RunecraftingSystem.test.ts
@@ -389,7 +389,7 @@ describe("RunecraftingSystem", () => {
 
       await setupSystem({
         inventory: [
-          createItem("bronze_sword", 1),
+          createItem("bronze_shortsword", 1),
           createItem("logs", 5),
           createItem("rune_essence", 2),
         ],
@@ -539,7 +539,7 @@ describe("RunecraftingSystem", () => {
   describe("edge cases", () => {
     it("sends error when no essence in inventory", async () => {
       await setupSystem({
-        inventory: [createItem("bronze_sword", 1)],
+        inventory: [createItem("bronze_shortsword", 1)],
         skills: { runecrafting: { level: 99, xp: 0 } },
       });
 

--- a/packages/shared/src/systems/shared/loot/__tests__/GravestoneLootSystem.test.ts
+++ b/packages/shared/src/systems/shared/loot/__tests__/GravestoneLootSystem.test.ts
@@ -193,7 +193,7 @@ describe("GravestoneLootSystem", () => {
     ITEMS.clear();
     registerStackableItem("coins");
     registerStackableItem("lobster");
-    registerNonStackableItem("bronze_sword");
+    registerNonStackableItem("bronze_shortsword");
     registerNonStackableItem("iron_shield");
 
     world = createMockWorld(true);
@@ -219,7 +219,7 @@ describe("GravestoneLootSystem", () => {
   describe("single item loot", () => {
     it("owner loots item successfully", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       world.entities.set("grave_1", grave);
 
@@ -231,7 +231,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -242,7 +242,7 @@ describe("GravestoneLootSystem", () => {
         expect.objectContaining({
           playerId: "player_1",
           item: expect.objectContaining({
-            itemId: "bronze_sword",
+            itemId: "bronze_shortsword",
             quantity: 1,
           }),
         }),
@@ -267,14 +267,14 @@ describe("GravestoneLootSystem", () => {
 
     it("non-owner is blocked from looting", async () => {
       const grave = createMockGravestone("grave_1", "owner_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       world.entities.set("grave_1", grave);
 
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "stranger",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -311,7 +311,7 @@ describe("GravestoneLootSystem", () => {
 
     it("inventory full with non-stackable item returns INVENTORY_FULL", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       world.entities.set("grave_1", grave);
 
@@ -325,7 +325,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -452,7 +452,7 @@ describe("GravestoneLootSystem", () => {
 
     it("dead player is blocked from looting", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       world.entities.set("grave_1", grave);
 
@@ -463,7 +463,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -479,7 +479,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "nonexistent",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -496,7 +496,7 @@ describe("GravestoneLootSystem", () => {
   describe("loot all", () => {
     it("loots all items into empty inventory", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1, 0),
+        createTestItem("bronze_shortsword", 1, 0),
         createTestItem("coins", 100, 1),
       ]);
       world.entities.set("grave_1", grave);
@@ -519,7 +519,7 @@ describe("GravestoneLootSystem", () => {
         expect.objectContaining({
           action: "LOOT_ALL_SUCCESS",
           items: expect.arrayContaining([
-            expect.objectContaining({ itemId: "bronze_sword" }),
+            expect.objectContaining({ itemId: "bronze_shortsword" }),
             expect.objectContaining({ itemId: "coins" }),
           ]),
         }),
@@ -528,7 +528,7 @@ describe("GravestoneLootSystem", () => {
 
     it("stops when inventory full (non-stackable items)", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1, 0),
+        createTestItem("bronze_shortsword", 1, 0),
         createTestItem("iron_shield", 1, 1),
       ]);
       world.entities.set("grave_1", grave);
@@ -550,7 +550,7 @@ describe("GravestoneLootSystem", () => {
 
       // Only first item fits (pre-calculation: 27 used, 1 slot available)
       expect(grave.removeItem).toHaveBeenCalledTimes(1);
-      expect(grave.removeItem).toHaveBeenCalledWith("bronze_sword", 1);
+      expect(grave.removeItem).toHaveBeenCalledWith("bronze_shortsword", 1);
     });
 
     it("stackable items don't consume new slots when stacking", async () => {
@@ -608,7 +608,7 @@ describe("GravestoneLootSystem", () => {
   describe("rate limiting", () => {
     it("rejects requests within 100ms window", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
         createTestItem("coins", 100),
       ]);
       world.entities.set("grave_1", grave);
@@ -620,7 +620,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
 
@@ -748,7 +748,7 @@ describe("GravestoneLootSystem", () => {
       const callOrder: string[] = [];
 
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1, 0),
+        createTestItem("bronze_shortsword", 1, 0),
         createTestItem("coins", 100, 1),
       ]);
       // Track removeItem call order
@@ -765,7 +765,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
         transactionId: "tx_1",
       });
@@ -783,7 +783,7 @@ describe("GravestoneLootSystem", () => {
       await tick();
 
       // Both processed in order
-      expect(callOrder).toEqual(["bronze_sword", "coins"]);
+      expect(callOrder).toEqual(["bronze_shortsword", "coins"]);
 
       vi.restoreAllMocks();
     });
@@ -800,14 +800,14 @@ describe("GravestoneLootSystem", () => {
       await clientSystem.init();
 
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       clientWorld.entities.set("grave_1", grave);
 
       clientWorld.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();
@@ -826,7 +826,7 @@ describe("GravestoneLootSystem", () => {
   describe("memory cleanup", () => {
     it("destroy clears internal state", async () => {
       const grave = createMockGravestone("grave_1", "player_1", [
-        createTestItem("bronze_sword", 1),
+        createTestItem("bronze_shortsword", 1),
       ]);
       world.entities.set("grave_1", grave);
 
@@ -837,7 +837,7 @@ describe("GravestoneLootSystem", () => {
       world.emit(EventType.CORPSE_LOOT_REQUEST, {
         corpseId: "grave_1",
         playerId: "player_1",
-        itemId: "bronze_sword",
+        itemId: "bronze_shortsword",
         quantity: 1,
       });
       await tick();

--- a/packages/shared/src/types/game/item-types.ts
+++ b/packages/shared/src/types/game/item-types.ts
@@ -20,6 +20,8 @@ export enum WeaponType {
   WAND = "wand",
   SHIELD = "shield",
   SCIMITAR = "scimitar",
+  LONGSWORD = "longsword",
+  TWO_HAND_SWORD = "two_hand_sword",
   HALBERD = "halberd",
   NONE = "none",
 }
@@ -134,7 +136,7 @@ export interface ItemRequirement {
 
 // Item types
 export interface Item {
-  id: string; // Unique item ID (e.g., "bronze_sword", "cooked_fish")
+  id: string; // Unique item ID (e.g., "bronze_shortsword", "cooked_fish")
   name: string; // Display name
   type: ItemType; // Item category
 

--- a/packages/shared/src/utils/__tests__/item-helpers.test.ts
+++ b/packages/shared/src/utils/__tests__/item-helpers.test.ts
@@ -77,7 +77,7 @@ describe("Item Helpers", () => {
 
     it("returns false for non-consumable", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         type: "weapon",
         healAmount: 5,
       });
@@ -165,7 +165,7 @@ describe("Item Helpers", () => {
   describe("isWeapon", () => {
     it("returns true for equipSlot weapon", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         equipSlot: "weapon",
       });
       expect(isWeapon(weapon)).toBe(true);
@@ -223,7 +223,7 @@ describe("Item Helpers", () => {
 
     it("returns false for weapon", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         equipSlot: "weapon",
       });
       expect(isShield(weapon)).toBe(false);
@@ -241,7 +241,7 @@ describe("Item Helpers", () => {
   describe("usesWield", () => {
     it("returns true for weapons", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         equipSlot: "weapon",
       });
       expect(usesWield(weapon)).toBe(true);
@@ -293,7 +293,7 @@ describe("Item Helpers", () => {
 
     it("returns false for weapon", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         equipSlot: "weapon",
         equipable: true,
       });
@@ -466,7 +466,7 @@ describe("Item Helpers", () => {
 
     it("falls back to heuristic for weapon without manifest", () => {
       const weapon = createItem({
-        id: "bronze_sword",
+        id: "bronze_shortsword",
         equipSlot: "weapon",
       });
       expect(getPrimaryAction(weapon, false)).toBe("wield");

--- a/packages/shared/src/utils/__tests__/typeGuards.test.ts
+++ b/packages/shared/src/utils/__tests__/typeGuards.test.ts
@@ -100,7 +100,7 @@ describe("Type Guards", () => {
     it("returns true for valid equipment system", () => {
       const system = {
         getPlayerEquipment: (_playerId: string) => ({
-          weapon: { item: { weaponType: "SWORD", id: "bronze_sword" } },
+          weapon: { item: { weaponType: "SWORD", id: "bronze_shortsword" } },
         }),
       };
       expect(isEquipmentSystem(system)).toBe(true);

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
…pon review

- Rename generic sword items to shortsword (IDs and display names) across entire codebase
- Add 2h sword combat emotes (2h_idle stance, 2h_slash attack) with full client pipeline
- Map all melee weapon types to sword_swing animation in CombatAnimationManager
- Weapon-aware idle emote reset (2h weapons return to 2h_idle instead of idle)
- Add batch weapon review and export flow to Asset Forge equipment viewer
- Update WeaponType enum and weapon style configs for new weapon categories