### PR TITLE
fix: drop keeper railway status probe

### DIFF
--- a/.github/workflows/deploy-betting-keeper.yml
+++ b/.github/workflows/deploy-betting-keeper.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Railway CLI
         run: bun add -g @railway/cli
 
-      - name: Seed Railway keeper context
+      - name: Write Railway keeper context
         working-directory: packages/gold-betting-demo/keeper
         run: |
           keeper_path="$(pwd)"
@@ -89,7 +89,6 @@ jobs:
             }
           }
           EOF
-          railway status
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 


### PR DESCRIPTION
## Summary
- remove the Railway CLI status probe that exits nonzero under the CI token mode
- keep the explicit keeper Railway context and deploy IDs in place
- allow the workflow to proceed directly to railway up and endpoint verification

## Testing
- python - <<'PY' ... yaml.safe_load('.github/workflows/deploy-betting-keeper.yml') ...
