### PR TITLE
fix: persist railway user token in keeper workflow

### DIFF
--- a/.github/workflows/deploy-betting-keeper.yml
+++ b/.github/workflows/deploy-betting-keeper.yml
@@ -86,6 +86,9 @@ jobs:
                 "environmentName": "production",
                 "service": "${RAILWAY_KEEPER_SERVICE_ID}"
               }
+            },
+            "user": {
+              "token": "${RAILWAY_TOKEN}"
             }
           }
           EOF


### PR DESCRIPTION
## Summary
- add the Railway user token to the generated runner-local config used by keeper deploys
- preserve the explicit keeper project/environment/service context for railway up
- keep existing keeper deploy verification unchanged

## Testing
- python - <<'PY' ... yaml.safe_load('.github/workflows/deploy-betting-keeper.yml') ...
- local clean-home railway up reproduction with generated config including user.token
