### PR TITLE
fix: skip keeper upload on workflow-only pushes

### DIFF
--- a/.github/workflows/deploy-betting-keeper.yml
+++ b/.github/workflows/deploy-betting-keeper.yml
@@ -35,6 +35,24 @@ jobs:
         with:
           bun-version: 1.1.38
 
+      - name: Detect keeper source changes
+        id: keeper_changes
+        run: |
+          base_ref="${{ github.event.before }}"
+          if [ -z "$base_ref" ] || [ "$base_ref" = "0000000000000000000000000000000000000000" ]; then
+            base_ref="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
+          fi
+
+          changed_files="$(git diff --name-only "$base_ref" "${{ github.sha }}" || true)"
+          printf '%s\n' "$changed_files"
+
+          keeper_source_changed=false
+          if printf '%s\n' "$changed_files" | grep -Eq '^packages/gold-betting-demo/keeper/'; then
+            keeper_source_changed=true
+          fi
+
+          echo "keeper_source_changed=${keeper_source_changed}" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         run: |
           bun install --frozen-lockfile
@@ -68,9 +86,11 @@ jobs:
           exit 1
 
       - name: Install Railway CLI
+        if: steps.keeper_changes.outputs.keeper_source_changed == 'true'
         run: bun add -g @railway/cli
 
       - name: Write Railway keeper context
+        if: steps.keeper_changes.outputs.keeper_source_changed == 'true'
         working-directory: packages/gold-betting-demo/keeper
         run: |
           keeper_path="$(pwd)"
@@ -96,6 +116,7 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
 
       - name: Deploy keeper
+        if: steps.keeper_changes.outputs.keeper_source_changed == 'true'
         working-directory: packages/gold-betting-demo/keeper
         run: |
           railway up . \


### PR DESCRIPTION
## Summary
- detect whether the pushed commit range actually changed keeper source files
- only run Railway upload steps when keeper source changed
- always keep keeper endpoint verification active

## Why
The live keeper code for the betting release is already deployed and healthy. The follow-up main commits after that were workflow-only changes, so forcing another Railway CLI upload on those commits creates false-negative workflow failures without changing runtime behavior.

## Testing
- python - <<'PY' ... yaml.safe_load('.github/workflows/deploy-betting-keeper.yml') ...
- live keeper health verification on production endpoints
