### PR TITLE
dev server watcher burns 100% CPU when idle

### DIFF
--- a/packages/server/scripts/dev.mjs
+++ b/packages/server/scripts/dev.mjs
@@ -506,7 +506,7 @@ async function startPollingFallback() {
         void rebuild(changedPath);
       }
     });
-  }, 1000);
+  }, 5000);
 }
 
 const forcePolling = process.env.SERVER_DEV_USE_POLLING === "true";
@@ -517,10 +517,6 @@ const watcher = chokidar.watch(watchRoots, {
   interval: forcePolling ? 250 : undefined,
   binaryInterval: forcePolling ? 500 : undefined,
   ignoreInitial: true,
-  awaitWriteFinish: {
-    stabilityThreshold: 300,
-    pollInterval: 100,
-  },
 });
 
 let rebuildTimeout = null;


### PR DESCRIPTION
Ok so 2 compounding issues on the dev script that cause it to literally CPU core at 100% while completely idle... Found because a forgotten bun scripts/dev.mjs process ran for 13 days at 99.9% CPU / 3,500 minutes of CPU time. So:
- awaitWriteFinish polls every watched file at 100ms... redundant since the script already debounces rebuilds itself. Removed.
- Polling fallback does a full recursive directory walk every 1s. Changed to 5s.