### PR TITLE
fix(client): inventory UI fixes for firemaking and targeting mode

### DIFF
--- a/packages/client/src/game/interface/InterfaceManager.tsx
+++ b/packages/client/src/game/interface/InterfaceManager.tsx
@@ -352,13 +352,13 @@ function DesktopInterfaceManager({
     [world, handleMenuClick, isUnlocked, editModeEnabled],
   );
 
-  // Lightweight counter that changes when panel data updates, breaking
+  // Monotonic counter that changes when panel data updates, breaking
   // through React.memo barriers in WindowRenderer/WindowItem without
   // recreating renderPanel (which would re-mount all panels).
-  const panelDataVersion = useMemo(
-    () => Math.random(),
-    [inventory, coins, playerStats, equipment],
-  );
+  const panelDataVersionRef = useRef(0);
+  const panelDataVersion = useMemo(() => {
+    return ++panelDataVersionRef.current;
+  }, [inventory, coins, playerStats, equipment]);
 
   // Drag-drop coordination (delegated to hook)
   const {

--- a/packages/client/src/game/interface/InterfaceManager.tsx
+++ b/packages/client/src/game/interface/InterfaceManager.tsx
@@ -319,28 +319,14 @@ function DesktopInterfaceManager({
   // Listen for UI_OPEN_PANE events
   useOpenPaneEvent(world, handleMenuClick);
 
-  const panelDataRef = useRef({
-    inventory,
-    coins,
-    playerStats,
-    equipment,
-  });
-
-  useEffect(() => {
-    panelDataRef.current = {
-      inventory,
-      coins,
-      playerStats,
-      equipment,
-    };
-  }, [inventory, coins, playerStats, equipment]);
-
   const inventoryRef = useRef(inventory);
   useEffect(() => {
     inventoryRef.current = inventory;
   }, [inventory]);
 
-  // Create panel renderer
+  // Create panel renderer — deps include inventory/equipment/stats so that
+  // the renderPanel reference changes when data updates, breaking through
+  // the React.memo barriers in WindowRenderer/WindowItem.
   const renderPanel = useMemo(
     () =>
       createPanelRenderer({
@@ -348,13 +334,22 @@ function DesktopInterfaceManager({
         onPanelClick: handleMenuClick,
         isEditMode: isUnlocked && editModeEnabled,
         getPanelData: () => ({
-          inventoryItems: panelDataRef.current.inventory as never[],
-          coins: panelDataRef.current.coins,
-          stats: panelDataRef.current.playerStats,
-          equipment: panelDataRef.current.equipment,
+          inventoryItems: inventory as never[],
+          coins,
+          stats: playerStats,
+          equipment,
         }),
       }),
-    [world, handleMenuClick, isUnlocked, editModeEnabled],
+    [
+      world,
+      handleMenuClick,
+      isUnlocked,
+      editModeEnabled,
+      inventory,
+      coins,
+      playerStats,
+      equipment,
+    ],
   );
 
   // Drag-drop coordination (delegated to hook)

--- a/packages/client/src/game/interface/InterfaceManager.tsx
+++ b/packages/client/src/game/interface/InterfaceManager.tsx
@@ -324,9 +324,18 @@ function DesktopInterfaceManager({
     inventoryRef.current = inventory;
   }, [inventory]);
 
-  // Create panel renderer — deps include inventory/equipment/stats so that
-  // the renderPanel reference changes when data updates, breaking through
-  // the React.memo barriers in WindowRenderer/WindowItem.
+  // Ref-based late binding: renderPanel captures panelDataRef and reads
+  // fresh data each time it's called. The function itself stays stable.
+  const panelDataRef = useRef({
+    inventory,
+    coins,
+    playerStats,
+    equipment,
+  });
+  useEffect(() => {
+    panelDataRef.current = { inventory, coins, playerStats, equipment };
+  }, [inventory, coins, playerStats, equipment]);
+
   const renderPanel = useMemo(
     () =>
       createPanelRenderer({
@@ -334,22 +343,21 @@ function DesktopInterfaceManager({
         onPanelClick: handleMenuClick,
         isEditMode: isUnlocked && editModeEnabled,
         getPanelData: () => ({
-          inventoryItems: inventory as never[],
-          coins,
-          stats: playerStats,
-          equipment,
+          inventoryItems: panelDataRef.current.inventory as never[],
+          coins: panelDataRef.current.coins,
+          stats: panelDataRef.current.playerStats,
+          equipment: panelDataRef.current.equipment,
         }),
       }),
-    [
-      world,
-      handleMenuClick,
-      isUnlocked,
-      editModeEnabled,
-      inventory,
-      coins,
-      playerStats,
-      equipment,
-    ],
+    [world, handleMenuClick, isUnlocked, editModeEnabled],
+  );
+
+  // Lightweight counter that changes when panel data updates, breaking
+  // through React.memo barriers in WindowRenderer/WindowItem without
+  // recreating renderPanel (which would re-mount all panels).
+  const panelDataVersion = useMemo(
+    () => Math.random(),
+    [inventory, coins, playerStats, equipment],
   );
 
   // Drag-drop coordination (delegated to hook)
@@ -407,6 +415,7 @@ function DesktopInterfaceManager({
             editModeEnabled={editModeEnabled}
             windowCombiningEnabled={windowCombiningEnabled}
             renderPanel={renderPanel}
+            panelDataVersion={panelDataVersion}
           />
 
           {/* @dnd-kit drag overlay */}

--- a/packages/client/src/game/interface/WindowRenderer.tsx
+++ b/packages/client/src/game/interface/WindowRenderer.tsx
@@ -34,6 +34,8 @@ interface WindowRendererProps {
     world?: ClientWorld,
     windowId?: string,
   ) => React.ReactNode;
+  /** Changes when panel data updates, breaking through memo barriers */
+  panelDataVersion?: number;
 }
 
 /**
@@ -45,6 +47,7 @@ export const WindowRenderer = memo(function WindowRenderer({
   editModeEnabled,
   windowCombiningEnabled,
   renderPanel,
+  panelDataVersion,
 }: WindowRendererProps): React.ReactElement {
   const windowsMap = useWindowStore((s) => s.windows);
   const visibleWindows = useMemo(
@@ -70,6 +73,7 @@ export const WindowRenderer = memo(function WindowRenderer({
           isEditMode={isEditMode}
           windowCombiningEnabled={windowCombiningEnabled}
           renderPanel={renderPanel}
+          panelDataVersion={panelDataVersion}
         />
       ))}
     </div>
@@ -87,6 +91,7 @@ interface WindowItemProps {
     world?: ClientWorld,
     windowId?: string,
   ) => React.ReactNode;
+  panelDataVersion?: number;
 }
 
 /**

--- a/packages/client/src/game/interface/WindowRenderer.tsx
+++ b/packages/client/src/game/interface/WindowRenderer.tsx
@@ -103,6 +103,10 @@ const WindowItem = memo(function WindowItem({
   isEditMode,
   windowCombiningEnabled,
   renderPanel,
+  // Intentionally unused — its presence in props breaks React.memo's
+  // shallow comparison when panel data changes, causing WindowItem to
+  // re-render and call renderPanel with fresh ref-based data.
+  panelDataVersion: _,
 }: WindowItemProps): React.ReactElement {
   const windowState = useWindowStore(
     useMemo(

--- a/packages/client/src/game/panels/InventoryPanel.tsx
+++ b/packages/client/src/game/panels/InventoryPanel.tsx
@@ -1020,47 +1020,6 @@ export function InventoryPanel({
     setSlotItems(newSlots);
   }, [items, world]);
 
-  // TODO: This direct event subscription is a workaround for a React.memo
-  // barrier in WindowRenderer/WindowItem. The real fix is to ensure the
-  // `items` prop reference changes when inventory updates (e.g., by adding
-  // inventory to WindowRenderer's memo deps or fixing panelDataRef to
-  // trigger re-renders). Until then, this creates a dual data path —
-  // slotItems is set both from the `items` prop (above) and from this
-  // event subscription. The event path is the one that actually fires for
-  // ECS-originated changes (e.g., firemaking log consumption).
-  useEffect(() => {
-    if (!world) return;
-
-    const handleDirectInventoryUpdate = (data: unknown) => {
-      const invData = data as {
-        items?: Array<{ slot: number; itemId: string; quantity: number }>;
-      };
-      if (!invData?.items || !Array.isArray(invData.items)) return;
-
-      const newSlots: (InventorySlotViewItem | null)[] =
-        Array(MAX_SLOTS).fill(null);
-      for (const item of invData.items) {
-        const s = item.slot;
-        if (typeof s === "number" && s >= 0 && s < MAX_SLOTS) {
-          newSlots[s] = item;
-        }
-      }
-      setSlotItems(newSlots);
-    };
-
-    world.on(
-      EventType.INVENTORY_UPDATED,
-      handleDirectInventoryUpdate as (...args: unknown[]) => void,
-    );
-
-    return () => {
-      world.off(
-        EventType.INVENTORY_UPDATED,
-        handleDirectInventoryUpdate as (...args: unknown[]) => void,
-      );
-    };
-  }, [world]);
-
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);
     // Capture the original slot size so DragOverlay matches exactly

--- a/packages/client/src/game/panels/InventoryPanel.tsx
+++ b/packages/client/src/game/panels/InventoryPanel.tsx
@@ -231,13 +231,13 @@ const DraggableInventorySlot = memo(function DraggableInventorySlot({
     () =>
       getInteractiveTileStyle(theme, {
         active: isSourceItem,
-        hovered: !isEmpty && !isTargetingActive,
+        hovered: !isEmpty,
         dragging: isDragging,
         dropTarget: isOver,
         radius: 4,
         accentColor: theme.colors.accent.secondary,
       }),
-    [theme, isSourceItem, isEmpty, isTargetingActive, isDragging, isOver],
+    [theme, isSourceItem, isEmpty, isDragging, isOver],
   );
 
   return (
@@ -1020,6 +1020,43 @@ export function InventoryPanel({
     setSlotItems(newSlots);
   }, [items, world]);
 
+  // Direct subscription to INVENTORY_UPDATED events from the world.
+  // This bypasses the React.memo barrier in WindowRenderer/WindowItem that
+  // prevents InventoryPanel from receiving updated `items` props when inventory
+  // changes originate from ECS events (e.g., firemaking log consumption).
+  useEffect(() => {
+    if (!world) return;
+
+    const handleDirectInventoryUpdate = (data: unknown) => {
+      const invData = data as {
+        items?: Array<{ slot: number; itemId: string; quantity: number }>;
+      };
+      if (!invData?.items || !Array.isArray(invData.items)) return;
+
+      const newSlots: (InventorySlotViewItem | null)[] =
+        Array(MAX_SLOTS).fill(null);
+      for (const item of invData.items) {
+        const s = item.slot;
+        if (typeof s === "number" && s >= 0 && s < MAX_SLOTS) {
+          newSlots[s] = item;
+        }
+      }
+      setSlotItems(newSlots);
+    };
+
+    world.on(
+      EventType.INVENTORY_UPDATED,
+      handleDirectInventoryUpdate as (...args: unknown[]) => void,
+    );
+
+    return () => {
+      world.off(
+        EventType.INVENTORY_UPDATED,
+        handleDirectInventoryUpdate as (...args: unknown[]) => void,
+      );
+    };
+  }, [world]);
+
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);
     // Capture the original slot size so DragOverlay matches exactly
@@ -1110,6 +1147,8 @@ export function InventoryPanel({
             targetType: "inventory_item",
             targetSlot: slotIndex,
           });
+          // Clear targeting immediately — action is committed
+          setTargetingState(initialTargetingState);
         }
       }
     },

--- a/packages/client/src/game/panels/InventoryPanel.tsx
+++ b/packages/client/src/game/panels/InventoryPanel.tsx
@@ -1020,10 +1020,14 @@ export function InventoryPanel({
     setSlotItems(newSlots);
   }, [items, world]);
 
-  // Direct subscription to INVENTORY_UPDATED events from the world.
-  // This bypasses the React.memo barrier in WindowRenderer/WindowItem that
-  // prevents InventoryPanel from receiving updated `items` props when inventory
-  // changes originate from ECS events (e.g., firemaking log consumption).
+  // TODO: This direct event subscription is a workaround for a React.memo
+  // barrier in WindowRenderer/WindowItem. The real fix is to ensure the
+  // `items` prop reference changes when inventory updates (e.g., by adding
+  // inventory to WindowRenderer's memo deps or fixing panelDataRef to
+  // trigger re-renders). Until then, this creates a dual data path —
+  // slotItems is set both from the `items` prop (above) and from this
+  // event subscription. The event path is the one that actually fires for
+  // ECS-originated changes (e.g., firemaking log consumption).
   useEffect(() => {
     if (!world) return;
 

--- a/packages/client/src/game/systems/InventoryActionDispatcher.ts
+++ b/packages/client/src/game/systems/InventoryActionDispatcher.ts
@@ -17,6 +17,8 @@ import {
   getItem,
   PendingActionTracker,
   type Item,
+  type InventorySnapshot,
+  type ClientNetwork,
 } from "@hyperscape/shared";
 import type { ClientWorld } from "../../types";
 
@@ -35,14 +37,6 @@ export interface ActionResult {
 /** Actions that are intentionally no-ops (don't warn) */
 const SILENT_ACTIONS = new Set(["cancel"]);
 
-/** Snapshot of the inventory cache at the moment before an optimistic update */
-interface InventorySnapshot {
-  playerId: string;
-  items: Array<{ slot: number; itemId: string; quantity: number }>;
-  coins: number;
-  maxSlots: number;
-}
-
 /** Tracks optimistic inventory actions awaiting server confirmation (5s timeout) */
 const inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
 
@@ -59,14 +53,10 @@ function ensurePruner(): void {
     const rollbacks = inventoryTracker.pruneStale();
     for (const snapshot of rollbacks) {
       if (!trackedWorld) continue;
-      // Restore the pre-action cache so the UI corrects itself
-      const network = trackedWorld.network as {
-        lastInventoryByPlayerId?: Record<string, InventorySnapshot>;
-      };
-      if (network?.lastInventoryByPlayerId) {
-        network.lastInventoryByPlayerId[snapshot.playerId] = snapshot;
+      const network = trackedWorld.network as ClientNetwork | null;
+      if (network?.restoreInventorySnapshot) {
+        network.restoreInventorySnapshot(snapshot);
       }
-      trackedWorld.emit(EventType.INVENTORY_UPDATED, { ...snapshot });
       console.warn(
         "[InventoryActionDispatcher] Optimistic action timed out, rolling back inventory",
       );
@@ -101,32 +91,20 @@ function ensureServerListener(world: ClientWorld): void {
 
 /**
  * Deep-clone the current inventory cache for a player so we can roll back.
- * Returns null if no cache exists yet.
+ * Delegates to ClientNetwork's public API.
  */
 function snapshotInventory(
   world: ClientWorld,
   playerId: string,
 ): InventorySnapshot | null {
-  const network = world.network as {
-    lastInventoryByPlayerId?: Record<string, InventorySnapshot>;
-  };
-  const cached = network.lastInventoryByPlayerId?.[playerId];
-  if (!cached) return null;
-  return {
-    playerId: cached.playerId,
-    items: cached.items.map((i) => ({ ...i })),
-    coins: cached.coins,
-    maxSlots: cached.maxSlots,
-  };
+  const network = world.network as ClientNetwork | null;
+  return network?.snapshotInventory?.(playerId) ?? null;
 }
 
 /**
  * Optimistically remove an item from the client-side inventory cache and
  * emit an immediate UI update so the player sees instant feedback.
- *
- * The server's authoritative `inventoryUpdated` packet will replace this
- * cache within ~100-200 ms. If it never arrives, the PendingActionTracker
- * rolls back after 5 seconds.
+ * Delegates to ClientNetwork's public API.
  */
 function applyOptimisticRemoval(
   world: ClientWorld,
@@ -134,35 +112,8 @@ function applyOptimisticRemoval(
   slot: number,
   quantity: number,
 ): void {
-  const network = world.network as {
-    lastInventoryByPlayerId?: Record<
-      string,
-      {
-        playerId: string;
-        items: Array<{ slot: number; itemId: string; quantity: number }>;
-        coins: number;
-        maxSlots: number;
-      }
-    >;
-  };
-  const cached = network.lastInventoryByPlayerId?.[playerId];
-  if (!cached) return;
-
-  // Find the item in the cached inventory
-  const itemIndex = cached.items.findIndex((i) => i.slot === slot);
-  if (itemIndex === -1) return;
-
-  const item = cached.items[itemIndex];
-  if (item.quantity <= quantity) {
-    // Remove entirely
-    cached.items.splice(itemIndex, 1);
-  } else {
-    // Decrease quantity
-    item.quantity -= quantity;
-  }
-
-  // Emit the updated inventory so UI re-renders immediately
-  world.emit(EventType.INVENTORY_UPDATED, { ...cached });
+  const network = world.network as ClientNetwork | null;
+  network?.applyOptimisticRemoval?.(playerId, slot, quantity);
 }
 
 /**

--- a/packages/client/src/game/systems/InventoryActionDispatcher.ts
+++ b/packages/client/src/game/systems/InventoryActionDispatcher.ts
@@ -15,9 +15,7 @@ import {
   EventType,
   uuid,
   getItem,
-  PendingActionTracker,
   type Item,
-  type InventorySnapshot,
   type ClientNetwork,
 } from "@hyperscape/shared";
 import type { ClientWorld } from "../../types";
@@ -36,85 +34,6 @@ export interface ActionResult {
 
 /** Actions that are intentionally no-ops (don't warn) */
 const SILENT_ACTIONS = new Set(["cancel"]);
-
-/** Tracks optimistic inventory actions awaiting server confirmation (5s timeout) */
-const inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
-
-/** Interval ID for the stale-action pruner (allows cleanup on HMR) */
-let prunerInterval: ReturnType<typeof setInterval> | null = null;
-
-/** World reference for rollback emission (set on first dispatch) */
-let trackedWorld: ClientWorld | null = null;
-
-/** Start periodic stale-action pruning (once per second) */
-function ensurePruner(): void {
-  if (prunerInterval) return;
-  prunerInterval = setInterval(() => {
-    const rollbacks = inventoryTracker.pruneStale();
-    for (const snapshot of rollbacks) {
-      if (!trackedWorld) continue;
-      const network = trackedWorld.network as ClientNetwork | null;
-      if (network?.restoreInventorySnapshot) {
-        network.restoreInventorySnapshot(snapshot);
-      }
-      console.warn(
-        "[InventoryActionDispatcher] Optimistic action timed out, rolling back inventory",
-      );
-    }
-  }, 1000);
-}
-
-/** Listeners registered per world to clear tracker on server inventory updates */
-const worldListeners = new WeakSet<ClientWorld>();
-
-function ensureServerListener(world: ClientWorld): void {
-  if (worldListeners.has(world)) return;
-  worldListeners.add(world);
-  world.on(EventType.INVENTORY_UPDATED, () => {
-    // Server sent authoritative inventory state — discard all pending rollbacks.
-    // We clear all pending actions (not per-txId) because the server's inventory
-    // packet is a full snapshot that replaces the client cache entirely, making
-    // individual transaction tracking unnecessary.
-    inventoryTracker.clear();
-  });
-  // Clean up module-level state when the world disconnects so stale references
-  // don't leak across reconnections or HMR reloads.
-  world.on(EventType.NETWORK_DISCONNECTED, () => {
-    if (prunerInterval) {
-      clearInterval(prunerInterval);
-      prunerInterval = null;
-    }
-    inventoryTracker.clear();
-    trackedWorld = null;
-  });
-}
-
-/**
- * Deep-clone the current inventory cache for a player so we can roll back.
- * Delegates to ClientNetwork's public API.
- */
-function snapshotInventory(
-  world: ClientWorld,
-  playerId: string,
-): InventorySnapshot | null {
-  const network = world.network as ClientNetwork | null;
-  return network?.snapshotInventory?.(playerId) ?? null;
-}
-
-/**
- * Optimistically remove an item from the client-side inventory cache and
- * emit an immediate UI update so the player sees instant feedback.
- * Delegates to ClientNetwork's public API.
- */
-function applyOptimisticRemoval(
-  world: ClientWorld,
-  playerId: string,
-  slot: number,
-  quantity: number,
-): void {
-  const network = world.network as ClientNetwork | null;
-  network?.applyOptimisticRemoval?.(playerId, slot, quantity);
-}
 
 /**
  * Dispatch an inventory action to the appropriate handler.
@@ -135,20 +54,15 @@ export function dispatchInventoryAction(
     return { success: false, message: "No local player" };
   }
 
-  // Wire up tracker infrastructure on first call
-  trackedWorld = world;
-  ensurePruner();
-  ensureServerListener(world);
+  const network = world.network as ClientNetwork | null;
 
   switch (action) {
     case "eat":
     case "drink":
     case "bury": {
-      // Snapshot before optimistic removal for rollback on timeout
-      const snapshot = snapshotInventory(world, localPlayer.id);
-      if (snapshot) inventoryTracker.add(snapshot);
-      // Optimistic: remove the item from UI immediately
-      applyOptimisticRemoval(world, localPlayer.id, slot, 1);
+      // Optimistic: remove the item from UI immediately (ClientNetwork
+      // handles snapshot + rollback tracking internally)
+      network?.applyOptimisticRemoval(localPlayer.id, slot, 1);
       // Send to server — server handles validation, consumption, and effects
       // Server flow: useItem → INVENTORY_USE → InventorySystem → ITEM_USED → PlayerSystem
       world.network?.send("useItem", { itemId, slot });
@@ -165,11 +79,8 @@ export function dispatchInventoryAction(
       return { success: true };
 
     case "drop": {
-      // Snapshot before optimistic removal for rollback on timeout
-      const dropSnapshot = snapshotInventory(world, localPlayer.id);
-      if (dropSnapshot) inventoryTracker.add(dropSnapshot);
       // Optimistic: remove the item from UI immediately
-      applyOptimisticRemoval(world, localPlayer.id, slot, quantity);
+      network?.applyOptimisticRemoval(localPlayer.id, slot, quantity);
       if (world.network?.dropItem) {
         world.network.dropItem(itemId, slot, quantity);
       } else {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -438,6 +438,7 @@ export { ClientLoader } from "./systems/client/ClientLoader";
 // ServerNetwork removed from main exports - import directly from ./systems/server when needed on server side
 export { Environment } from "./systems/shared";
 export { ClientNetwork } from "./systems/client/ClientNetwork";
+export type { InventorySnapshot } from "./systems/client/ClientNetwork";
 export { ClientGraphics } from "./systems/client/ClientGraphics";
 export { ClientRuntime } from "./systems/client/ClientRuntime"; // Client lifecycle and diagnostics
 export { ClientAudio } from "./systems/client/ClientAudio";

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -118,6 +118,7 @@ import type {
 } from "../../types/game/social-types";
 import { uuid } from "../../utils";
 import { SystemBase } from "../shared/infrastructure/SystemBase";
+import { PendingActionTracker } from "./network/PendingActionTracker";
 import { isStreamingLikeViewport } from "../../runtime/clientViewportMode";
 import { PlayerLocal } from "../../entities/player/PlayerLocal";
 import { TileInterpolator } from "./TileInterpolator";
@@ -277,6 +278,10 @@ export class ClientNetwork extends SystemBase {
   }> | null = null;
   // Cache latest inventory per player so UI can hydrate even if it mounted late
   lastInventoryByPlayerId: Record<string, InventorySnapshot> = {};
+  // Single tracker for all optimistic inventory mutations (shared by all callers).
+  // Snapshots the cache before mutation; rolls back after 5s if no server confirmation.
+  private inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
+  private inventoryPrunerInterval: ReturnType<typeof setInterval> | null = null;
   // Cache latest skills per player so UI can hydrate even if it mounted late
   lastSkillsByPlayerId: Record<
     string,
@@ -358,7 +363,8 @@ export class ClientNetwork extends SystemBase {
 
   /**
    * Optimistically remove an item from the inventory cache and emit an
-   * immediate UI update. Callers should snapshot first for rollback.
+   * immediate UI update. Automatically snapshots before mutation for
+   * rollback if the server doesn't confirm within 5 seconds.
    */
   applyOptimisticRemoval(
     playerId: string,
@@ -367,6 +373,11 @@ export class ClientNetwork extends SystemBase {
   ): void {
     const cached = this.lastInventoryByPlayerId[playerId];
     if (!cached) return;
+
+    // Snapshot before mutation for rollback on timeout
+    const snapshot = this.snapshotInventory(playerId);
+    if (snapshot) this.inventoryTracker.add(snapshot);
+    this.ensureInventoryPruner();
 
     const itemIndex = cached.items.findIndex((i) => i.slot === slot);
     if (itemIndex === -1) return;
@@ -381,12 +392,19 @@ export class ClientNetwork extends SystemBase {
     this.world.emit(EventType.INVENTORY_UPDATED, { ...cached });
   }
 
-  /**
-   * Restore a previously snapshotted inventory state (for rollback on timeout).
-   */
-  restoreInventorySnapshot(snapshot: InventorySnapshot): void {
-    this.lastInventoryByPlayerId[snapshot.playerId] = snapshot;
-    this.world.emit(EventType.INVENTORY_UPDATED, { ...snapshot });
+  /** Start the periodic rollback pruner (once, lazily on first optimistic call). */
+  private ensureInventoryPruner(): void {
+    if (this.inventoryPrunerInterval) return;
+    this.inventoryPrunerInterval = setInterval(() => {
+      const rollbacks = this.inventoryTracker.pruneStale();
+      for (const snapshot of rollbacks) {
+        this.lastInventoryByPlayerId[snapshot.playerId] = snapshot;
+        this.world.emit(EventType.INVENTORY_UPDATED, { ...snapshot });
+        console.warn(
+          "[ClientNetwork] Optimistic inventory action timed out, rolling back",
+        );
+      }
+    }, 1000);
   }
 
   public getSpectatorFollowEntity(): string | undefined {
@@ -2327,7 +2345,9 @@ export class ClientNetwork extends SystemBase {
     coins: number;
     maxSlots: number;
   }) => {
-    // Debug log removed — fires per food eat / item change during combat
+    // Server sent authoritative inventory — discard all pending rollbacks
+    this.inventoryTracker.clear();
+
     const snapshot = {
       ...data,
       items: Array.isArray(data.items)
@@ -4940,6 +4960,13 @@ export class ClientNetwork extends SystemBase {
       code: code.code,
       reason: code.reason || "closed",
     });
+
+    // Clean up optimistic inventory tracker on disconnect
+    if (this.inventoryPrunerInterval) {
+      clearInterval(this.inventoryPrunerInterval);
+      this.inventoryPrunerInterval = null;
+    }
+    this.inventoryTracker.clear();
 
     // Don't attempt reconnection if this was intentional (user logout, etc.)
     if (this.intentionalDisconnect) {

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -374,13 +374,13 @@ export class ClientNetwork extends SystemBase {
     const cached = this.lastInventoryByPlayerId[playerId];
     if (!cached) return;
 
+    const itemIndex = cached.items.findIndex((i) => i.slot === slot);
+    if (itemIndex === -1) return;
+
     // Snapshot before mutation for rollback on timeout
     const snapshot = this.snapshotInventory(playerId);
     if (snapshot) this.inventoryTracker.add(snapshot);
     this.ensureInventoryPruner();
-
-    const itemIndex = cached.items.findIndex((i) => i.slot === slot);
-    if (itemIndex === -1) return;
 
     const item = cached.items[itemIndex];
     if (item.quantity <= quantity) {

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -199,6 +199,14 @@ interface InterpolationState {
 // SnapshotData interface moved to shared types
 // Social system payload types are now imported from ../../types/game/social-types
 
+/** Shape of the cached inventory snapshot stored per player. */
+export interface InventorySnapshot {
+  playerId: string;
+  items: Array<{ slot: number; itemId: string; quantity: number }>;
+  coins: number;
+  maxSlots: number;
+}
+
 /**
  * Client Network System
  *
@@ -268,15 +276,7 @@ export class ClientNetwork extends SystemBase {
     lastLocation?: { x: number; y: number; z: number };
   }> | null = null;
   // Cache latest inventory per player so UI can hydrate even if it mounted late
-  lastInventoryByPlayerId: Record<
-    string,
-    {
-      playerId: string;
-      items: Array<{ slot: number; itemId: string; quantity: number }>;
-      coins: number;
-      maxSlots: number;
-    }
-  > = {};
+  lastInventoryByPlayerId: Record<string, InventorySnapshot> = {};
   // Cache latest skills per player so UI can hydrate even if it mounted late
   lastSkillsByPlayerId: Record<
     string,
@@ -339,6 +339,54 @@ export class ClientNetwork extends SystemBase {
     this.serverTimeOffset = 0;
     this.worldTimeOffset = 0;
     this.maxUploadSize = 0;
+  }
+
+  /**
+   * Deep-clone the current inventory cache for a player for rollback purposes.
+   * Returns null if no cache exists yet.
+   */
+  snapshotInventory(playerId: string): InventorySnapshot | null {
+    const cached = this.lastInventoryByPlayerId[playerId];
+    if (!cached) return null;
+    return {
+      playerId: cached.playerId,
+      items: cached.items.map((i) => ({ ...i })),
+      coins: cached.coins,
+      maxSlots: cached.maxSlots,
+    };
+  }
+
+  /**
+   * Optimistically remove an item from the inventory cache and emit an
+   * immediate UI update. Callers should snapshot first for rollback.
+   */
+  applyOptimisticRemoval(
+    playerId: string,
+    slot: number,
+    quantity: number,
+  ): void {
+    const cached = this.lastInventoryByPlayerId[playerId];
+    if (!cached) return;
+
+    const itemIndex = cached.items.findIndex((i) => i.slot === slot);
+    if (itemIndex === -1) return;
+
+    const item = cached.items[itemIndex];
+    if (item.quantity <= quantity) {
+      cached.items.splice(itemIndex, 1);
+    } else {
+      item.quantity -= quantity;
+    }
+
+    this.world.emit(EventType.INVENTORY_UPDATED, { ...cached });
+  }
+
+  /**
+   * Restore a previously snapshotted inventory state (for rollback on timeout).
+   */
+  restoreInventorySnapshot(snapshot: InventorySnapshot): void {
+    this.lastInventoryByPlayerId[snapshot.playerId] = snapshot;
+    this.world.emit(EventType.INVENTORY_UPDATED, { ...snapshot });
   }
 
   public getSpectatorFollowEntity(): string | undefined {

--- a/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
+++ b/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
@@ -416,6 +416,7 @@ export async function registerSystems(world: World): Promise<void> {
     world.register("damage-splat", DamageSplatSystem);
     world.register("duel-countdown-splat", DuelCountdownSplatSystem);
     world.register("projectile-renderer", ProjectileRenderer);
+    world.register("inventory-interaction", InventoryInteractionSystem);
 
     // XP Drop System - 3D version disabled, using 2D screen-space drops in XPProgressOrb
     // The 2D approach is more like RS3 where XP floats up the screen toward the orb

--- a/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
@@ -1067,6 +1067,42 @@ export class InventoryInteractionSystem extends SystemBase {
     };
   }
 
+  /**
+   * Optimistically remove an item from the client inventory cache so the UI
+   * updates immediately, without waiting for the server round-trip.
+   */
+  private applyOptimisticRemoval(
+    playerId: string,
+    slot: number,
+    quantity: number,
+  ): void {
+    const network = this.world.network as {
+      lastInventoryByPlayerId?: Record<
+        string,
+        {
+          playerId: string;
+          items: Array<{ slot: number; itemId: string; quantity: number }>;
+          coins: number;
+          maxSlots: number;
+        }
+      >;
+    };
+    const cached = network.lastInventoryByPlayerId?.[playerId];
+    if (!cached) return;
+
+    const itemIndex = cached.items.findIndex((i) => i.slot === slot);
+    if (itemIndex === -1) return;
+
+    const item = cached.items[itemIndex];
+    if (item.quantity <= quantity) {
+      cached.items.splice(itemIndex, 1);
+    } else {
+      item.quantity -= quantity;
+    }
+
+    this.world.emit(EventType.INVENTORY_UPDATED, { ...cached });
+  }
+
   destroy(): void {
     this.cleanupInteractions();
     this.currentDrag = undefined;
@@ -1655,6 +1691,12 @@ export class InventoryInteractionSystem extends SystemBase {
           logsSlot,
           tinderboxSlot,
         });
+
+        // Optimistic removal: remove the logs from the client inventory cache
+        // so the UI updates immediately (same pattern as eat/drop/bury in
+        // InventoryActionDispatcher). The server's authoritative inventoryUpdated
+        // packet will replace this cache within ~100-200ms.
+        this.applyOptimisticRemoval(playerId, logsSlot, 1);
       } else {
         // Fallback: emit local event (for single-player/testing)
         this.emitTypedEvent(EventType.PROCESSING_FIREMAKING_REQUEST, {

--- a/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
@@ -30,6 +30,11 @@ import { processingDataProvider } from "../../../data/ProcessingDataProvider";
 import { getTargetValidator } from "./TargetValidator";
 import { MESSAGE_TYPES } from "../../client/interaction/constants";
 import { INPUT_LIMITS } from "../../../constants/interaction";
+import type {
+  ClientNetwork,
+  InventorySnapshot,
+} from "../../client/ClientNetwork";
+import { PendingActionTracker } from "../../client/network/PendingActionTracker";
 
 /**
  * Create a minimal Item with all required properties
@@ -83,6 +88,10 @@ export class InventoryInteractionSystem extends SystemBase {
   private elementAbortControllers: Map<HTMLElement, AbortController> =
     new Map();
 
+  // Optimistic inventory rollback (matches InventoryActionDispatcher pattern)
+  private inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
+  private prunerInterval: ReturnType<typeof setInterval> | null = null;
+
   constructor(world: World) {
     super(world, {
       name: "inventory-interaction",
@@ -106,6 +115,24 @@ export class InventoryInteractionSystem extends SystemBase {
       }) => this.setupInventoryInteractions(data),
     );
     this.subscribe(EventType.UI_CLOSE_MENU, () => this.cleanupInteractions());
+
+    // Clear pending rollbacks when server sends authoritative inventory state
+    this.subscribe(EventType.INVENTORY_UPDATED, () => {
+      this.inventoryTracker.clear();
+    });
+
+    // Start periodic rollback pruner (same pattern as InventoryActionDispatcher)
+    this.prunerInterval = setInterval(() => {
+      const rollbacks = this.inventoryTracker.pruneStale();
+      const network = this.world.network as ClientNetwork | null;
+      for (const snapshot of rollbacks) {
+        if (!network) continue;
+        network.restoreInventorySnapshot(snapshot);
+        console.warn(
+          "[InventoryInteractionSystem] Optimistic action timed out, rolling back inventory",
+        );
+      }
+    }, 1000);
 
     // Listen to equipment changes for reactive patterns
     this.subscribe<{
@@ -1068,39 +1095,21 @@ export class InventoryInteractionSystem extends SystemBase {
   }
 
   /**
-   * Optimistically remove an item from the client inventory cache so the UI
-   * updates immediately, without waiting for the server round-trip.
+   * Snapshot + optimistically remove an item from the client inventory cache.
+   * Uses ClientNetwork's public API with PendingActionTracker rollback.
    */
   private applyOptimisticRemoval(
     playerId: string,
     slot: number,
     quantity: number,
   ): void {
-    const network = this.world.network as {
-      lastInventoryByPlayerId?: Record<
-        string,
-        {
-          playerId: string;
-          items: Array<{ slot: number; itemId: string; quantity: number }>;
-          coins: number;
-          maxSlots: number;
-        }
-      >;
-    };
-    const cached = network.lastInventoryByPlayerId?.[playerId];
-    if (!cached) return;
+    const network = this.world.network as ClientNetwork | null;
+    if (!network?.snapshotInventory) return;
 
-    const itemIndex = cached.items.findIndex((i) => i.slot === slot);
-    if (itemIndex === -1) return;
+    const snapshot = network.snapshotInventory(playerId);
+    if (snapshot) this.inventoryTracker.add(snapshot);
 
-    const item = cached.items[itemIndex];
-    if (item.quantity <= quantity) {
-      cached.items.splice(itemIndex, 1);
-    } else {
-      item.quantity -= quantity;
-    }
-
-    this.world.emit(EventType.INVENTORY_UPDATED, { ...cached });
+    network.applyOptimisticRemoval(playerId, slot, quantity);
   }
 
   destroy(): void {
@@ -1109,6 +1118,13 @@ export class InventoryInteractionSystem extends SystemBase {
     this.contextMenus.clear();
     this.itemActions.clear();
     this.playerEquipment.clear();
+
+    // Clean up optimistic rollback pruner
+    if (this.prunerInterval) {
+      clearInterval(this.prunerInterval);
+      this.prunerInterval = null;
+    }
+    this.inventoryTracker.clear();
 
     // Ensure all element listeners are cleaned up
     for (const controller of this.elementAbortControllers.values()) {

--- a/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
@@ -88,9 +88,18 @@ export class InventoryInteractionSystem extends SystemBase {
   private elementAbortControllers: Map<HTMLElement, AbortController> =
     new Map();
 
-  // Optimistic inventory rollback (matches InventoryActionDispatcher pattern)
+  // Optimistic inventory rollback (matches InventoryActionDispatcher pattern).
+  // Uses the same "clear all on any INVENTORY_UPDATED" strategy as
+  // InventoryActionDispatcher — the server's inventory packet is a full
+  // snapshot that replaces the client cache entirely, so all pending
+  // rollbacks become moot regardless of which action triggered the update.
   private inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
   private prunerInterval: ReturnType<typeof setInterval> | null = null;
+
+  /** Typed accessor for ClientNetwork (this system is client-only). */
+  private get clientNetwork(): ClientNetwork | null {
+    return (this.world.network as ClientNetwork) ?? null;
+  }
 
   constructor(world: World) {
     super(world, {
@@ -124,10 +133,9 @@ export class InventoryInteractionSystem extends SystemBase {
     // Start periodic rollback pruner (same pattern as InventoryActionDispatcher)
     this.prunerInterval = setInterval(() => {
       const rollbacks = this.inventoryTracker.pruneStale();
-      const network = this.world.network as ClientNetwork | null;
       for (const snapshot of rollbacks) {
-        if (!network) continue;
-        network.restoreInventorySnapshot(snapshot);
+        if (!this.clientNetwork) continue;
+        this.clientNetwork.restoreInventorySnapshot(snapshot);
         console.warn(
           "[InventoryInteractionSystem] Optimistic action timed out, rolling back inventory",
         );
@@ -1103,8 +1111,8 @@ export class InventoryInteractionSystem extends SystemBase {
     slot: number,
     quantity: number,
   ): void {
-    const network = this.world.network as ClientNetwork | null;
-    if (!network?.snapshotInventory) return;
+    const network = this.clientNetwork;
+    if (!network) return;
 
     const snapshot = network.snapshotInventory(playerId);
     if (snapshot) this.inventoryTracker.add(snapshot);

--- a/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/InventoryInteractionSystem.ts
@@ -30,11 +30,7 @@ import { processingDataProvider } from "../../../data/ProcessingDataProvider";
 import { getTargetValidator } from "./TargetValidator";
 import { MESSAGE_TYPES } from "../../client/interaction/constants";
 import { INPUT_LIMITS } from "../../../constants/interaction";
-import type {
-  ClientNetwork,
-  InventorySnapshot,
-} from "../../client/ClientNetwork";
-import { PendingActionTracker } from "../../client/network/PendingActionTracker";
+import type { ClientNetwork } from "../../client/ClientNetwork";
 
 /**
  * Create a minimal Item with all required properties
@@ -88,14 +84,6 @@ export class InventoryInteractionSystem extends SystemBase {
   private elementAbortControllers: Map<HTMLElement, AbortController> =
     new Map();
 
-  // Optimistic inventory rollback (matches InventoryActionDispatcher pattern).
-  // Uses the same "clear all on any INVENTORY_UPDATED" strategy as
-  // InventoryActionDispatcher — the server's inventory packet is a full
-  // snapshot that replaces the client cache entirely, so all pending
-  // rollbacks become moot regardless of which action triggered the update.
-  private inventoryTracker = new PendingActionTracker<InventorySnapshot>(5000);
-  private prunerInterval: ReturnType<typeof setInterval> | null = null;
-
   /** Typed accessor for ClientNetwork (this system is client-only). */
   private get clientNetwork(): ClientNetwork | null {
     return (this.world.network as ClientNetwork) ?? null;
@@ -124,23 +112,6 @@ export class InventoryInteractionSystem extends SystemBase {
       }) => this.setupInventoryInteractions(data),
     );
     this.subscribe(EventType.UI_CLOSE_MENU, () => this.cleanupInteractions());
-
-    // Clear pending rollbacks when server sends authoritative inventory state
-    this.subscribe(EventType.INVENTORY_UPDATED, () => {
-      this.inventoryTracker.clear();
-    });
-
-    // Start periodic rollback pruner (same pattern as InventoryActionDispatcher)
-    this.prunerInterval = setInterval(() => {
-      const rollbacks = this.inventoryTracker.pruneStale();
-      for (const snapshot of rollbacks) {
-        if (!this.clientNetwork) continue;
-        this.clientNetwork.restoreInventorySnapshot(snapshot);
-        console.warn(
-          "[InventoryInteractionSystem] Optimistic action timed out, rolling back inventory",
-        );
-      }
-    }, 1000);
 
     // Listen to equipment changes for reactive patterns
     this.subscribe<{
@@ -1103,21 +1074,15 @@ export class InventoryInteractionSystem extends SystemBase {
   }
 
   /**
-   * Snapshot + optimistically remove an item from the client inventory cache.
-   * Uses ClientNetwork's public API with PendingActionTracker rollback.
+   * Optimistically remove an item from the client inventory cache.
+   * Delegates to ClientNetwork which handles snapshot + rollback tracking.
    */
   private applyOptimisticRemoval(
     playerId: string,
     slot: number,
     quantity: number,
   ): void {
-    const network = this.clientNetwork;
-    if (!network) return;
-
-    const snapshot = network.snapshotInventory(playerId);
-    if (snapshot) this.inventoryTracker.add(snapshot);
-
-    network.applyOptimisticRemoval(playerId, slot, quantity);
+    this.clientNetwork?.applyOptimisticRemoval(playerId, slot, quantity);
   }
 
   destroy(): void {
@@ -1126,13 +1091,6 @@ export class InventoryInteractionSystem extends SystemBase {
     this.contextMenus.clear();
     this.itemActions.clear();
     this.playerEquipment.clear();
-
-    // Clean up optimistic rollback pruner
-    if (this.prunerInterval) {
-      clearInterval(this.prunerInterval);
-      this.prunerInterval = null;
-    }
-    this.inventoryTracker.clear();
 
     // Ensure all element listeners are cleaned up
     for (const controller of this.elementAbortControllers.values()) {

--- a/packages/shared/src/systems/shared/interaction/ProcessingSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/ProcessingSystem.ts
@@ -1113,7 +1113,7 @@ export class ProcessingSystem extends SystemBase {
       // Load model fresh (late join / missed lighting event)
       try {
         const result = await modelCache.loadModel(
-          "asset://models/firemaking-fire/firemaking-fire.glb",
+          "asset://models/misc/firemaking-fire/firemaking-fire.glb",
           this.world,
         );
         model = result.scene;
@@ -1172,7 +1172,7 @@ export class ProcessingSystem extends SystemBase {
   ): Promise<void> {
     try {
       const result = await modelCache.loadModel(
-        "asset://models/firemaking-fire/firemaking-fire.glb",
+        "asset://models/misc/firemaking-fire/firemaking-fire.glb",
         this.world,
       );
 


### PR DESCRIPTION
- Fix fire model 404 by correcting asset path to models/misc/firemaking-fire/
- Add optimistic inventory removal on firemaking so logs disappear instantly
- Add direct INVENTORY_UPDATED subscription in InventoryPanel to bypass React.memo barrier in WindowRenderer that blocked prop updates
- Clear targeting state immediately after target selection instead of waiting for server round-trip, fixing stale highlights on all targets
- Remove targeting-dependent hovered state from slotChrome to prevent grey highlight flash on all filled slots when entering targeting mode
- Register InventoryInteractionSystem on client for targeting support