### PR TITLE
feat(ui): comprehensive UI panel upgrade

### DIFF
--- a/packages/client/src/constants/index.ts
+++ b/packages/client/src/constants/index.ts
@@ -122,6 +122,20 @@ export {
 export type { MobileSpacing, MobileBarHeight } from "./mobileStyles";
 
 // ===========================================
+// PANEL LAYOUT CONSTANTS
+// ===========================================
+export {
+  PANEL_ICON_SIZE,
+  PANEL_GRID_GAP,
+  PANEL_PADDING,
+  PANEL_GRID_PADDING,
+  PANEL_MOBILE_PADDING,
+  PANEL_MOBILE_ICON_SIZE,
+  PANEL_MOBILE_GRID_GAP,
+  PANEL_SLOT_RADIUS,
+} from "./panelLayout";
+
+// ===========================================
 // GAME CONSTANTS (Re-exports from @hyperscape/shared)
 // ===========================================
 // Use constants from the shared package instead of duplicating here:

--- a/packages/client/src/constants/panelLayout.ts
+++ b/packages/client/src/constants/panelLayout.ts
@@ -1,0 +1,76 @@
+/**
+ * Panel Layout Constants
+ *
+ * Single source of truth for icon-grid panel dimensions used by:
+ *   - InventoryPanel   (4px outer padding, 4px grid gap, 3px mobile)
+ *   - EquipmentPanel   (4px outer padding, 6px grid gap, 3px mobile)
+ *   - PrayerPanel
+ *   - SpellsPanel
+ *   - SkillsPanel
+ *
+ * Values are derived from what InventoryPanel and EquipmentPanel already use.
+ * All other panels should defer to these.
+ *
+ * Desktop reference (EquipmentPanel renderEquipmentGrid):
+ *   gap = 6, padding = 3 (inner), outer = 4
+ * Desktop reference (InventoryPanel):
+ *   outer padding = theme.spacing.xs = 4px
+ *   inner grid gap = clamp(2px, 0.5cqw, 3px) ≈ 3px
+ *   inner grid padding = clamp(2px, 0.5cqw, 3px) ≈ 3px
+ *
+ * We unify on:
+ *   PANEL_PADDING = 4   (outer panel wrapper, matches theme.spacing.xs)
+ *   PANEL_GRID_GAP = 4  (gap between icons — matches equipment desktop gap)
+ *   PANEL_GRID_PADDING = 4  (inner grid inset)
+ *   PANEL_ICON_SIZE = 36  (matches equipment slot height on desktop)
+ */
+
+// ─── Desktop ───────────────────────────────────────────────────────────────
+
+/**
+ * Outer padding for every panel container.
+ * Matches InventoryPanel's `theme.spacing.xs` = 4px.
+ */
+export const PANEL_PADDING = 4;
+
+/**
+ * Gap between icons/slots in every grid panel.
+ * EquipmentPanel uses 6px for its slot grid; InventoryPanel uses ~3px.
+ * We align Prayer/Spells/Skills to 4px — a clean midpoint.
+ */
+export const PANEL_GRID_GAP = 4;
+
+/**
+ * Inner padding inside the scrollable grid inset area.
+ * Matches InventoryPanel's inner grid padding (~3–4px).
+ */
+export const PANEL_GRID_PADDING = 4;
+
+/**
+ * Shared icon/slot size for icon-grid panels (Prayer, Spells).
+ * Matches EquipmentPanel's desktop slot height (36px).
+ */
+export const PANEL_ICON_SIZE = 36;
+
+// ─── Mobile ────────────────────────────────────────────────────────────────
+
+/**
+ * Mobile outer/grid padding.
+ * InventoryPanel uses 3px mobile, EquipmentPanel uses 2–3px.
+ */
+export const PANEL_MOBILE_PADDING = 3;
+
+/**
+ * Mobile icon/slot size — matches MOBILE_TOUCH_TARGET (48px).
+ */
+export const PANEL_MOBILE_ICON_SIZE = 48;
+
+/**
+ * Mobile gap between icons — matches EquipmentPanel mobile gap.
+ */
+export const PANEL_MOBILE_GRID_GAP = 4;
+
+// ─── Border radius ──────────────────────────────────────────────────────────
+
+/** Square aesthetic radius for all panel slots/icons. */
+export const PANEL_SLOT_RADIUS = 4;

--- a/packages/client/src/game/character/CharacterPreview.tsx
+++ b/packages/client/src/game/character/CharacterPreview.tsx
@@ -68,7 +68,7 @@ export const CharacterPreview: React.FC<CharacterPreviewProps> = ({
   const rendererRef = useRef<WebGPURenderer | null>(null);
   const vrmRef = useRef<VRM | null>(null);
   const mixerRef = useRef<THREE.AnimationMixer | null>(null);
-  const clockRef = useRef<THREE.Clock>(new THREE.Clock());
+  const lastTimeRef = useRef<number>(0);
   const frameIdRef = useRef<number>(0);
   const rendererInitializedRef = useRef<boolean>(false);
   // Store lights in refs for proper disposal
@@ -318,7 +318,10 @@ export const CharacterPreview: React.FC<CharacterPreviewProps> = ({
 
     const animate = () => {
       frameIdRef.current = requestAnimationFrame(animate);
-      const delta = clockRef.current.getDelta();
+      const time = performance.now();
+      const delta =
+        lastTimeRef.current === 0 ? 0 : (time - lastTimeRef.current) / 1000;
+      lastTimeRef.current = time;
 
       if (vrmRef.current) {
         vrmRef.current.update(delta);

--- a/packages/client/src/game/character/avatarPreviewViewport.ts
+++ b/packages/client/src/game/character/avatarPreviewViewport.ts
@@ -16,12 +16,14 @@ export async function createAvatarPreviewViewport(options: {
   canvas: HTMLCanvasElement;
   cameraPosition?: THREE.Vector3;
   fov?: number;
+  adjustCameraDepth?: boolean;
 }): Promise<AvatarPreviewViewport> {
   const {
     container,
     canvas,
     cameraPosition = new THREE.Vector3(0, 1.4, 3.0),
     fov = 30,
+    adjustCameraDepth = true,
   } = options;
 
   const scene = new THREE.Scene();
@@ -64,10 +66,10 @@ export async function createAvatarPreviewViewport(options: {
     const aspect = width / height;
     camera.aspect = aspect;
 
-    if (aspect < baseAspect) {
+    if (adjustCameraDepth && aspect < baseAspect) {
       const zoomFactor = baseAspect / aspect;
       camera.position.z = baseCameraZ * Math.min(zoomFactor, 1.5);
-    } else {
+    } else if (adjustCameraDepth) {
       camera.position.z = baseCameraZ;
     }
 

--- a/packages/client/src/game/character/avatarPreviewViewport.ts
+++ b/packages/client/src/game/character/avatarPreviewViewport.ts
@@ -77,13 +77,15 @@ export async function createAvatarPreviewViewport(options: {
     renderer.setSize(width, height);
   };
 
-  const clock = new THREE.Clock();
+  let lastTime = 0;
   let frameId = 0;
   let frameCallback: ((delta: number) => void) | undefined;
 
   const renderFrame = () => {
     frameId = window.requestAnimationFrame(renderFrame);
-    const delta = clock.getDelta();
+    const time = performance.now();
+    const delta = lastTime === 0 ? 0 : (time - lastTime) / 1000;
+    lastTime = time;
     frameCallback?.(delta);
     renderer.render(scene, camera);
   };
@@ -98,7 +100,7 @@ export async function createAvatarPreviewViewport(options: {
   const start = (onFrame?: (delta: number) => void) => {
     frameCallback = onFrame;
     stop();
-    clock.start();
+    lastTime = performance.now();
     renderFrame();
   };
 

--- a/packages/client/src/game/character/avatarPreviewViewport.ts
+++ b/packages/client/src/game/character/avatarPreviewViewport.ts
@@ -1,0 +1,126 @@
+import { THREE, createRenderer, type WebGPURenderer } from "@hyperscape/shared";
+import { ThreeResourceManager } from "@/lib/ThreeResourceManager";
+
+export interface AvatarPreviewViewport {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: WebGPURenderer;
+  resize: () => void;
+  start: (onFrame?: (delta: number) => void) => void;
+  stop: () => void;
+  dispose: () => void;
+}
+
+export async function createAvatarPreviewViewport(options: {
+  container: HTMLDivElement;
+  canvas: HTMLCanvasElement;
+  cameraPosition?: THREE.Vector3;
+  fov?: number;
+}): Promise<AvatarPreviewViewport> {
+  const {
+    container,
+    canvas,
+    cameraPosition = new THREE.Vector3(0, 1.4, 3.0),
+    fov = 30,
+  } = options;
+
+  const scene = new THREE.Scene();
+
+  const keyLight = new THREE.DirectionalLight(0xffffff, 1.0);
+  keyLight.position.set(1, 1, 1).normalize();
+  scene.add(keyLight);
+
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+  scene.add(ambientLight);
+
+  const camera = new THREE.PerspectiveCamera(
+    fov,
+    container.clientWidth / Math.max(container.clientHeight, 1),
+    0.1,
+    20,
+  );
+  camera.position.copy(cameraPosition);
+  camera.layers.enableAll();
+
+  const renderer = await createRenderer({
+    canvas,
+    alpha: true,
+    antialias: true,
+  });
+
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+
+  const baseAspect = 16 / 9;
+  const baseCameraZ = cameraPosition.z;
+
+  const resize = () => {
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    const aspect = width / height;
+    camera.aspect = aspect;
+
+    if (aspect < baseAspect) {
+      const zoomFactor = baseAspect / aspect;
+      camera.position.z = baseCameraZ * Math.min(zoomFactor, 1.5);
+    } else {
+      camera.position.z = baseCameraZ;
+    }
+
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, height);
+  };
+
+  const clock = new THREE.Clock();
+  let frameId = 0;
+  let frameCallback: ((delta: number) => void) | undefined;
+
+  const renderFrame = () => {
+    frameId = window.requestAnimationFrame(renderFrame);
+    const delta = clock.getDelta();
+    frameCallback?.(delta);
+    renderer.render(scene, camera);
+  };
+
+  const stop = () => {
+    if (frameId) {
+      window.cancelAnimationFrame(frameId);
+      frameId = 0;
+    }
+  };
+
+  const start = (onFrame?: (delta: number) => void) => {
+    frameCallback = onFrame;
+    stop();
+    clock.start();
+    renderFrame();
+  };
+
+  const dispose = () => {
+    stop();
+    ThreeResourceManager.disposeObject(keyLight, {
+      removeFromParent: true,
+    });
+    ThreeResourceManager.disposeObject(ambientLight, {
+      removeFromParent: true,
+    });
+    ThreeResourceManager.disposeRenderer(renderer);
+    ThreeResourceManager.disposeScene(scene);
+  };
+
+  resize();
+
+  return {
+    scene,
+    camera,
+    renderer,
+    resize,
+    start,
+    stop,
+    dispose,
+  };
+}

--- a/packages/client/src/game/components/quest/QuestLog.tsx
+++ b/packages/client/src/game/components/quest/QuestLog.tsx
@@ -15,24 +15,21 @@ import React, {
   useEffect,
   type CSSProperties,
 } from "react";
-
-/** Mobile breakpoint (matches client/constants breakpoints.md) */
-const MOBILE_BREAKPOINT = 640;
-
-/** Filter icon SVG */
-const FilterIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-    <path d="M1 2h14v2H1V2zm2 4h10v2H3V6zm2 4h6v2H5v-2z" />
-  </svg>
-);
-
-/** Search icon SVG */
-const SearchIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-    <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
-  </svg>
-);
 import { useTheme, useAccessibilityStore, useMobileLayout } from "@/ui";
+import {
+  getPanelSurfaceStyle,
+  getPanelInsetStyle,
+  getPanelHeaderStyle,
+  getInteractiveTileStyle,
+  getWindowSurfaceStyle,
+  getDecorativeBorderStyle,
+} from "@/ui/theme/themes";
+import {
+  PANEL_PADDING,
+  PANEL_GRID_GAP,
+  PANEL_MOBILE_PADDING,
+  PANEL_SLOT_RADIUS,
+} from "../../../constants/panelLayout";
 import {
   type Quest,
   type QuestState,
@@ -46,6 +43,29 @@ import {
 } from "@/game/systems";
 import { QuestObjective } from "./QuestObjective";
 import { QuestRewards } from "./QuestRewards";
+
+/** Filter icon SVG */
+const FilterIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+    <path d="M1 2h14v2H1V2zm2 4h10v2H3V6zm2 4h6v2H5v-2z" />
+  </svg>
+);
+
+/** Search icon SVG */
+const SearchIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+    <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
+  </svg>
+);
+
+/** Category icon map */
+const CATEGORY_ICONS: Record<string, string> = {
+  crown: "\u{1F451}",
+  scroll: "\u{1F4DC}",
+  sun: "\u2600\uFE0F",
+  calendar: "\u{1F4C5}",
+  star: "\u2B50",
+};
 
 /** Props for QuestLog component */
 export interface QuestLogProps {
@@ -121,13 +141,10 @@ export interface QuestLogProps {
   onQuestClick?: (quest: Quest) => void;
 }
 
-// OSRS-style status colors
-const STATUS_COLORS: Record<QuestState, string> = {
-  available: "#ff4444", // Red - not started
-  active: "#ffff00", // Yellow - in progress
-  completed: "#00ff00", // Green - complete
-  failed: "#888888", // Gray - failed
-};
+/** Get quest state color from theme-compatible STATE_CONFIG */
+function getStateColor(state: QuestState): string {
+  return STATE_CONFIG[state].color;
+}
 
 /** Props for Quest Detail Popup Component */
 export interface QuestDetailPopupProps {
@@ -154,28 +171,17 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
   onTrackQuest,
 }: QuestDetailPopupProps): React.ReactElement {
   const theme = useTheme();
+  const { shouldUseMobileUI: isMobile } = useMobileLayout();
   const progress = calculateQuestProgress(quest);
   const categoryConfig = CATEGORY_CONFIG[quest.category];
 
   const canAccept = quest.state === "available";
   const canComplete = quest.state === "active" && progress === 100;
 
-  // Mobile responsiveness
-  const [isMobile, setIsMobile] = useState(() =>
-    typeof window !== "undefined"
-      ? window.innerWidth < MOBILE_BREAKPOINT
-      : false,
-  );
+  const stateColor = getStateColor(quest.state);
+  const categoryIcon =
+    CATEGORY_ICONS[categoryConfig.icon] || categoryConfig.icon;
 
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  // Overlay styles
   const overlayStyle: CSSProperties = {
     position: "fixed",
     inset: 0,
@@ -183,207 +189,184 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "rgba(0, 0, 0, 0.8)",
-    backdropFilter: "blur(2px)",
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+    backdropFilter: "blur(6px)",
     padding: isMobile ? `${theme.spacing.sm}px` : 0,
   };
 
-  // Popup container - using theme colors (responsive)
+  // Use the actual game window surface for an immersive feel
+  const windowBase = getWindowSurfaceStyle(theme, { state: "focused" });
+  const decorBorder = getDecorativeBorderStyle(theme);
   const popupStyle: CSSProperties = {
+    ...windowBase,
+    ...decorBorder,
     width: isMobile ? "100%" : "400px",
-    maxWidth: "90vw",
-    maxHeight: isMobile ? "90vh" : "80vh",
-    background: theme.colors.background.primary,
-    border: `1px solid ${theme.colors.border.decorative}`,
-    borderRadius: `${theme.borderRadius.lg}px`,
+    maxWidth: "92vw",
+    maxHeight: isMobile ? "90vh" : "78vh",
+    borderTop: `2px solid ${stateColor}`,
     padding: "0",
-    boxShadow: theme.shadows.window,
     display: "flex",
     flexDirection: "column",
     overflow: "hidden",
   };
 
-  // Header styles (responsive)
+  // Game-style header with gradient
+  const panelHeader = getPanelHeaderStyle(theme);
   const headerStyle: CSSProperties = {
+    ...panelHeader,
     display: "flex",
     alignItems: "center",
-    gap: isMobile ? theme.spacing.xs : theme.spacing.sm,
-    padding: isMobile
-      ? `${theme.spacing.sm}px ${theme.spacing.sm}px`
-      : `${theme.spacing.sm}px ${theme.spacing.md}px`,
-    borderBottom: `1px solid ${theme.colors.border.default}`,
-    background: theme.colors.background.secondary,
-    minHeight: isMobile ? "48px" : "44px",
+    gap: isMobile ? "8px" : "6px",
+    padding: isMobile ? "10px 12px" : "8px 10px",
+    minHeight: isMobile ? "48px" : "38px",
   };
 
-  // Back button (larger on mobile for touch)
-  const buttonSize = isMobile ? "36px" : "24px";
-  const backButtonStyle: CSSProperties = {
+  const buttonSize = isMobile ? "32px" : "24px";
+  const headerBtnStyle: CSSProperties = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
     width: buttonSize,
     height: buttonSize,
-    background: "transparent",
-    border: "none",
+    background: `${theme.colors.slot.empty}`,
+    border: `1px solid ${theme.colors.border.default}40`,
     color: theme.colors.text.muted,
     cursor: "pointer",
     padding: 0,
-    borderRadius: `${theme.borderRadius.sm}px`,
-    transition: theme.transitions.fast,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
   };
 
   const titleStyle: CSSProperties = {
     flex: 1,
-    color: STATUS_COLORS[quest.state],
+    color: theme.colors.text.primary,
     fontSize: isMobile
       ? theme.typography.fontSize.lg
-      : theme.typography.fontSize.base,
-    fontWeight: theme.typography.fontWeight.semibold,
+      : theme.typography.fontSize.sm,
+    fontWeight: theme.typography.fontWeight.bold,
     margin: 0,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   };
 
-  const closeButtonStyle: CSSProperties = {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    width: buttonSize,
-    height: buttonSize,
-    background: "transparent",
-    border: "none",
-    color: theme.colors.text.muted,
-    cursor: "pointer",
-    padding: 0,
-    borderRadius: `${theme.borderRadius.sm}px`,
-    fontSize: isMobile ? "22px" : "18px",
-    lineHeight: 1,
+  // State indicator dot next to title
+  const stateDotStyle: CSSProperties = {
+    width: isMobile ? "8px" : "6px",
+    height: isMobile ? "8px" : "6px",
+    borderRadius: "50%",
+    backgroundColor: stateColor,
+    flexShrink: 0,
+    boxShadow: `0 0 4px ${stateColor}60`,
   };
 
-  // Content area with scrollbar (responsive padding)
+  const contentPad = isMobile ? "10px" : "8px";
   const contentStyle: CSSProperties = {
     flex: 1,
     overflowY: "auto",
-    padding: isMobile ? theme.spacing.sm : theme.spacing.md,
-    WebkitOverflowScrolling: "touch", // Smooth scrolling on iOS
+    padding: contentPad,
+    display: "flex",
+    flexDirection: "column",
+    gap: isMobile ? "8px" : "6px",
+    WebkitOverflowScrolling: "touch",
   };
 
-  // Section styles
-  const sectionStyle: CSSProperties = {
-    marginBottom: isMobile ? theme.spacing.sm : theme.spacing.md,
+  // Inset section cards — the core "game panel" feel
+  const sectionCardStyle: CSSProperties = {
+    ...getPanelInsetStyle(theme, { radius: PANEL_SLOT_RADIUS }),
+    padding: isMobile ? "8px 10px" : "6px 8px",
   };
 
   const sectionTitleStyle: CSSProperties = {
-    color: theme.colors.accent.primary,
-    fontSize: isMobile
-      ? theme.typography.fontSize.sm
-      : theme.typography.fontSize.xs,
-    fontWeight: theme.typography.fontWeight.semibold,
+    color: theme.colors.accent.gold,
+    fontSize: "9px",
+    fontWeight: theme.typography.fontWeight.bold,
     textTransform: "uppercase",
-    letterSpacing: "0.5px",
-    marginBottom: theme.spacing.xs,
+    letterSpacing: "1.2px",
+    marginBottom: isMobile ? "6px" : "4px",
   };
 
   const descriptionStyle: CSSProperties = {
     color: theme.colors.text.secondary,
     fontSize: isMobile
-      ? theme.typography.fontSize.base
-      : theme.typography.fontSize.sm,
-    lineHeight: theme.typography.lineHeight.normal,
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    lineHeight: theme.typography.lineHeight.relaxed,
     margin: 0,
   };
 
-  // Meta info row (responsive - wrap on mobile)
-  const metaRowStyle: CSSProperties = {
-    display: "flex",
-    flexWrap: isMobile ? "wrap" : "nowrap",
-    gap: isMobile ? theme.spacing.sm : theme.spacing.md,
-    marginBottom: isMobile ? theme.spacing.sm : theme.spacing.md,
-    padding: theme.spacing.sm,
-    background: theme.colors.background.tertiary,
-    borderRadius: `${theme.borderRadius.md}px`,
-    border: `1px solid ${theme.colors.border.default}`,
-    fontSize: isMobile
-      ? theme.typography.fontSize.base
-      : theme.typography.fontSize.sm,
-  };
+  // Compact pill badges for meta info
+  const metaBadgeStyle = (color: string): CSSProperties => ({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "3px",
+    padding: isMobile ? "3px 7px" : "2px 5px",
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
+    backgroundColor: `${color}15`,
+    border: `1px solid ${color}25`,
+    color,
+    fontSize: isMobile ? "11px" : "9px",
+    fontWeight: theme.typography.fontWeight.semibold,
+    lineHeight: `${theme.typography.lineHeight.tight}`,
+  });
 
-  const metaItemStyle: CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    gap: "2px",
-    minWidth: isMobile ? "calc(50% - 8px)" : "auto",
-  };
-
-  const metaLabelStyle: CSSProperties = {
-    color: theme.colors.text.muted,
-    fontSize: isMobile
-      ? theme.typography.fontSize.sm
-      : theme.typography.fontSize.xs,
-    textTransform: "uppercase",
-  };
-
-  const metaValueStyle: CSSProperties = {
-    color: theme.colors.text.primary,
-    fontWeight: theme.typography.fontWeight.medium,
-  };
-
-  // Progress bar (taller on mobile for visibility)
   const progressBarContainerStyle: CSSProperties = {
-    height: isMobile ? "6px" : "4px",
-    backgroundColor: theme.colors.background.tertiary,
-    borderRadius: `${theme.borderRadius.sm}px`,
+    height: isMobile ? "5px" : "3px",
+    backgroundColor: `${theme.colors.background.primary}80`,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     overflow: "hidden",
-    marginTop: theme.spacing.xs,
   };
 
   const progressBarFillStyle: CSSProperties = {
     height: "100%",
     width: `${progress}%`,
-    backgroundColor:
-      progress === 100
-        ? theme.colors.state.success
-        : theme.colors.accent.primary,
+    backgroundColor: progress === 100 ? theme.colors.state.success : stateColor,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     transition: "width 0.3s ease",
   };
 
-  // Action buttons container (responsive)
+  // Action footer with game-style buttons
   const actionsStyle: CSSProperties = {
+    ...panelHeader,
     display: "flex",
     flexDirection: isMobile ? "column" : "row",
-    gap: theme.spacing.sm,
-    padding: isMobile ? theme.spacing.sm : theme.spacing.md,
-    borderTop: `1px solid ${theme.colors.border.default}`,
-    background: theme.colors.background.secondary,
+    gap: `${PANEL_GRID_GAP + 2}px`,
+    padding: isMobile ? "10px 12px" : "8px 10px",
+    borderTop: `1px solid ${theme.colors.border.default}30`,
+    borderBottom: "none",
   };
 
   const buttonBaseStyle: CSSProperties = {
     flex: isMobile ? "none" : 1,
-    padding: isMobile
-      ? `${theme.spacing.md}px ${theme.spacing.md}px`
-      : `${theme.spacing.sm}px ${theme.spacing.md}px`,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "5px",
+    padding: isMobile ? "8px 14px" : "5px 10px",
     border: "none",
-    borderRadius: `${theme.borderRadius.md}px`,
-    minHeight: isMobile ? "44px" : "auto", // Touch-friendly on mobile
-    fontSize: theme.typography.fontSize.sm,
-    fontWeight: theme.typography.fontWeight.semibold,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
+    minHeight: isMobile ? "44px" : "28px",
+    fontSize: isMobile
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    fontWeight: theme.typography.fontWeight.bold,
     cursor: "pointer",
-    transition: theme.transitions.fast,
+    textTransform: "uppercase",
+    letterSpacing: "0.5px",
   };
 
   const primaryButtonStyle: CSSProperties = {
     ...buttonBaseStyle,
-    background: theme.colors.accent.primary,
+    background: `linear-gradient(180deg, ${stateColor}, ${stateColor}cc)`,
     color: theme.colors.background.primary,
+    boxShadow: `0 1px 3px ${stateColor}40, inset 0 1px 0 rgba(255,255,255,0.15)`,
   };
 
   const secondaryButtonStyle: CSSProperties = {
     ...buttonBaseStyle,
-    background: theme.colors.background.tertiary,
-    color: theme.colors.text.primary,
-    border: `1px solid ${theme.colors.border.default}`,
+    background: theme.colors.slot.empty,
+    color: theme.colors.text.secondary,
+    border: `1px solid ${theme.colors.border.default}40`,
+    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
   };
 
   return (
@@ -399,14 +382,18 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
         onMouseDown={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
       >
-        {/* Header with back button */}
+        {/* Header */}
         <div style={headerStyle}>
           <button
-            style={backButtonStyle}
+            style={headerBtnStyle}
             onClick={onClose}
             title="Back to quest list"
           >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <svg
+              width={isMobile ? 18 : 14}
+              height={isMobile ? 18 : 14}
+              viewBox="0 0 16 16"
+            >
               <path
                 d="M11 2L5 8l6 6"
                 stroke="currentColor"
@@ -420,7 +407,7 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
           <h3 style={titleStyle}>
             {quest.pinned && (
               <span
-                style={{ color: "#ffd700", marginRight: "6px" }}
+                style={{ color: theme.colors.accent.gold, marginRight: "6px" }}
                 title="Pinned"
               >
                 ★
@@ -428,38 +415,43 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
             )}
             {quest.title}
           </h3>
-          <button style={closeButtonStyle} onClick={onClose} title="Close">
-            ×
+          <button style={headerBtnStyle} onClick={onClose} title="Close">
+            <svg
+              width={isMobile ? 16 : 12}
+              height={isMobile ? 16 : 12}
+              viewBox="0 0 12 12"
+            >
+              <path
+                d="M2 2l8 8M10 2l-8 8"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
           </button>
         </div>
 
         {/* Content */}
         <div style={contentStyle} className="scrollbar-thin">
-          {/* Meta info */}
-          <div style={metaRowStyle}>
-            <div style={metaItemStyle}>
-              <span style={metaLabelStyle}>Type</span>
-              <span style={{ ...metaValueStyle, color: categoryConfig.color }}>
-                {categoryConfig.label}
-              </span>
-            </div>
-            <div style={metaItemStyle}>
-              <span style={metaLabelStyle}>Level</span>
-              <span style={metaValueStyle}>{quest.level}</span>
-            </div>
-            <div style={metaItemStyle}>
-              <span style={metaLabelStyle}>Status</span>
-              <span
-                style={{ ...metaValueStyle, color: STATUS_COLORS[quest.state] }}
-              >
-                {STATE_CONFIG[quest.state].label}
-              </span>
-            </div>
+          {/* Meta badges row */}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: `${PANEL_GRID_GAP + 2}px`,
+            }}
+          >
+            <span style={metaBadgeStyle(categoryConfig.color)}>
+              {categoryIcon} {categoryConfig.label}
+            </span>
+            <span style={metaBadgeStyle(theme.colors.text.secondary)}>
+              Lv. {quest.level}
+            </span>
+            <span style={metaBadgeStyle(stateColor)}>
+              {STATE_CONFIG[quest.state].label}
+            </span>
             {quest.state === "active" && (
-              <div style={metaItemStyle}>
-                <span style={metaLabelStyle}>Progress</span>
-                <span style={metaValueStyle}>{progress}%</span>
-              </div>
+              <span style={metaBadgeStyle(stateColor)}>{progress}%</span>
             )}
           </div>
 
@@ -467,21 +459,21 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
           {quest.timeRemaining !== undefined && quest.state === "active" && (
             <div
               style={{
-                marginBottom: theme.spacing.md,
-                padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+                ...getPanelInsetStyle(theme, { radius: PANEL_SLOT_RADIUS + 2 }),
+                padding: isMobile ? "8px 10px" : "6px 10px",
                 background:
                   quest.timeRemaining <= 60
-                    ? "rgba(248, 113, 113, 0.15)"
-                    : "rgba(251, 191, 36, 0.15)",
-                borderRadius: `${theme.borderRadius.sm}px`,
+                    ? "rgba(248, 113, 113, 0.12)"
+                    : "rgba(251, 191, 36, 0.12)",
                 color:
                   quest.timeRemaining <= 60
                     ? theme.colors.state.danger
                     : theme.colors.state.warning,
                 fontSize: theme.typography.fontSize.sm,
+                fontWeight: theme.typography.fontWeight.medium,
                 display: "flex",
                 alignItems: "center",
-                gap: theme.spacing.xs,
+                gap: "6px",
               }}
             >
               <svg
@@ -492,47 +484,47 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
               >
                 <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 12A5 5 0 118 3a5 5 0 010 10zm.5-8H7v4.5l3.5 2 .75-1.25-2.75-1.5V5z" />
               </svg>
-              Time remaining: {formatTimeRemaining(quest.timeRemaining)}
+              {formatTimeRemaining(quest.timeRemaining)}
+            </div>
+          )}
+
+          {/* Progress bar for active quests */}
+          {quest.state === "active" && quest.objectives.length > 0 && (
+            <div style={progressBarContainerStyle}>
+              <div style={progressBarFillStyle} />
             </div>
           )}
 
           {/* Description */}
-          <div style={sectionStyle}>
+          <div style={sectionCardStyle}>
             <div style={sectionTitleStyle}>Description</div>
             <p style={descriptionStyle}>{quest.description}</p>
-          </div>
-
-          {/* Quest giver */}
-          {quest.questGiver && (
-            <div style={sectionStyle}>
-              <div style={sectionTitleStyle}>Quest Giver</div>
+            {quest.questGiver && (
               <div
                 style={{
-                  color: theme.colors.text.primary,
-                  fontSize: theme.typography.fontSize.sm,
+                  marginTop: `${PANEL_GRID_GAP + 2}px`,
+                  color: theme.colors.text.muted,
+                  fontSize: theme.typography.fontSize.xs,
                 }}
               >
-                {quest.questGiver}
+                Quest giver:{" "}
+                <span style={{ color: theme.colors.text.primary }}>
+                  {quest.questGiver}
+                </span>
                 {quest.questGiverLocation && (
-                  <span style={{ color: theme.colors.text.muted }}>
-                    {" "}
-                    · {quest.questGiverLocation}
-                  </span>
+                  <span> · {quest.questGiverLocation}</span>
                 )}
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* Objectives */}
           {quest.objectives.length > 0 && (
-            <div style={sectionStyle}>
+            <div style={sectionCardStyle}>
               <div style={sectionTitleStyle}>Objectives</div>
-              {quest.state === "active" && (
-                <div style={progressBarContainerStyle}>
-                  <div style={progressBarFillStyle} />
-                </div>
-              )}
-              <div style={{ marginTop: theme.spacing.sm }}>
+              <div
+                style={{ display: "flex", flexDirection: "column", gap: "2px" }}
+              >
                 {quest.objectives.map((objective) => (
                   <QuestObjective
                     key={objective.id}
@@ -546,7 +538,7 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
 
           {/* Rewards */}
           {quest.rewards.length > 0 && (
-            <div style={sectionStyle}>
+            <div style={sectionCardStyle}>
               <QuestRewards rewards={quest.rewards} showTitle />
             </div>
           )}
@@ -581,7 +573,7 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
               style={secondaryButtonStyle}
               onClick={() => onTogglePin(quest)}
             >
-              {quest.pinned ? "Unpin" : "Pin"}
+              {quest.pinned ? "★ Unpin" : "☆ Pin"}
             </button>
           )}
           {quest.state === "active" && onTrackQuest && (
@@ -603,7 +595,7 @@ export const QuestDetailPopup = memo(function QuestDetailPopup({
   );
 });
 
-/** Quest List Item Component - Clean minimal row */
+/** Quest List Item Component — Themed interactive tile */
 interface QuestListItemProps {
   quest: Quest;
   onClick: () => void;
@@ -617,83 +609,167 @@ const QuestListItem = memo(function QuestListItem({
 }: QuestListItemProps): React.ReactElement {
   const theme = useTheme();
   const { shouldUseMobileUI } = useMobileLayout();
+  const { reducedMotion } = useAccessibilityStore();
   const [isHovered, setIsHovered] = useState(false);
   const progress = calculateQuestProgress(quest);
+  const stateColor = getStateColor(quest.state);
+  const categoryConfig = CATEGORY_CONFIG[quest.category];
 
-  const rowStyle: CSSProperties = {
+  const tileBase = getInteractiveTileStyle(theme, {
+    hovered: isHovered,
+    active: isSelected,
+    radius: PANEL_SLOT_RADIUS,
+  });
+
+  const tileStyle: CSSProperties = {
+    ...tileBase,
     display: "flex",
     alignItems: "center",
-    justifyContent: "space-between",
-    padding: shouldUseMobileUI ? "8px 12px" : "4px 8px",
+    gap: shouldUseMobileUI ? 8 : 6,
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING + 5}px ${PANEL_MOBILE_PADDING + 6}px`
+      : `${PANEL_PADDING + 2}px ${PANEL_PADDING + 4}px`,
     cursor: "pointer",
-    backgroundColor: isSelected
-      ? `${theme.colors.accent.primary}30`
-      : isHovered
-        ? theme.colors.slot.hover
-        : "transparent",
-    borderLeft: isSelected
-      ? `3px solid ${theme.colors.accent.primary}`
-      : "3px solid transparent",
-    transition: "background-color 0.1s ease, border-color 0.1s ease",
-    minHeight: shouldUseMobileUI ? "44px" : "28px",
+    borderLeft: `3px solid ${isSelected ? theme.colors.border.active : stateColor}`,
+    minHeight: shouldUseMobileUI ? 48 : 34,
+    transition: reducedMotion
+      ? "none"
+      : "background-color 0.1s ease, border-color 0.1s ease",
   };
 
-  const nameStyle: CSSProperties = {
-    color: STATUS_COLORS[quest.state],
-    fontSize: shouldUseMobileUI ? "14px" : "11px",
-    fontWeight: 500,
+  const dotStyle: CSSProperties = {
+    width: shouldUseMobileUI ? 8 : 6,
+    height: shouldUseMobileUI ? 8 : 6,
+    borderRadius: "50%",
+    backgroundColor: stateColor,
+    flexShrink: 0,
+  };
+
+  const titleContainerStyle: CSSProperties = {
     flex: 1,
+    minWidth: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+  };
+
+  const titleStyle: CSSProperties = {
+    color: theme.colors.text.primary,
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.base
+      : theme.typography.fontSize.sm,
+    fontWeight: theme.typography.fontWeight.medium,
+    lineHeight: theme.typography.lineHeight.tight,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   };
 
+  const subtitleStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: shouldUseMobileUI ? 6 : 4,
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    color: theme.colors.text.muted,
+    lineHeight: 1.2,
+  };
+
   return (
     <div
-      style={rowStyle}
+      style={tileStyle}
       onClick={onClick}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <span style={nameStyle}>
-        {quest.pinned && (
+      {/* State dot */}
+      <div style={dotStyle} title={STATE_CONFIG[quest.state].label} />
+
+      {/* Title and subtitle */}
+      <div style={titleContainerStyle}>
+        <span style={titleStyle}>
+          {quest.pinned && (
+            <span
+              style={{
+                color: theme.colors.accent.gold,
+                marginRight: shouldUseMobileUI ? 5 : 3,
+              }}
+              title="Pinned"
+            >
+              ★
+            </span>
+          )}
+          {quest.title}
+        </span>
+        <div style={subtitleStyle}>
           <span
             style={{
-              color: "#ffd700", // Gold star for pinned quests
-              marginRight: shouldUseMobileUI ? "6px" : "4px",
+              color: categoryConfig.color,
+              fontWeight: theme.typography.fontWeight.medium,
             }}
-            title="Pinned"
           >
-            ★
+            {categoryConfig.label}
           </span>
-        )}
-        {quest.title}
-      </span>
-      {quest.state === "active" && progress > 0 && progress < 100 && (
-        <span
+          <span style={{ opacity: 0.4 }}>·</span>
+          <span>Lv. {quest.level}</span>
+        </div>
+      </div>
+
+      {/* Progress (active quests) */}
+      {quest.state === "active" && (
+        <div
           style={{
-            color: theme.colors.text.muted,
-            fontSize: shouldUseMobileUI ? "12px" : "9px",
-            marginLeft: shouldUseMobileUI ? "8px" : "6px",
+            display: "flex",
+            alignItems: "center",
+            gap: shouldUseMobileUI ? 6 : 4,
+            flexShrink: 0,
           }}
         >
-          {progress}%
-        </span>
+          <div
+            style={{
+              width: shouldUseMobileUI ? 48 : 36,
+              height: shouldUseMobileUI ? 5 : 3,
+              backgroundColor: theme.colors.background.tertiary,
+              borderRadius: PANEL_SLOT_RADIUS,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${progress}%`,
+                backgroundColor:
+                  progress === 100
+                    ? theme.colors.state.success
+                    : theme.colors.accent.primary,
+                transition: reducedMotion ? "none" : "width 0.3s ease",
+              }}
+            />
+          </div>
+          <span
+            style={{
+              fontSize: shouldUseMobileUI
+                ? theme.typography.fontSize.xs
+                : theme.typography.fontSize.xs,
+              color:
+                progress === 100
+                  ? theme.colors.state.success
+                  : theme.colors.text.muted,
+              fontWeight: theme.typography.fontWeight.medium,
+              minWidth: shouldUseMobileUI ? 28 : 24,
+              textAlign: "right",
+            }}
+          >
+            {progress}%
+          </span>
+        </div>
       )}
-      <span
-        style={{
-          color: theme.colors.text.muted,
-          marginLeft: shouldUseMobileUI ? "8px" : "6px",
-          fontSize: shouldUseMobileUI ? "12px" : "9px",
-        }}
-      >
-        Lv. {quest.level}
-      </span>
     </div>
   );
 });
 
-/** Category Group Component - Clean minimal header */
+/** Category Group Component — Themed header with accent bar */
 interface CategoryGroupProps {
   category: QuestCategory;
   quests: Quest[];
@@ -714,49 +790,66 @@ const CategoryGroup = memo(function CategoryGroup({
   const { shouldUseMobileUI } = useMobileLayout();
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const config = CATEGORY_CONFIG[category];
+  const categoryIcon = CATEGORY_ICONS[config.icon] || "";
 
   if (quests.length === 0) {
     return null;
   }
 
+  const insetBase = getPanelInsetStyle(theme, {
+    emphasis: "normal",
+    radius: PANEL_SLOT_RADIUS,
+  });
+
   const headerStyle: CSSProperties = {
+    ...insetBase,
     display: "flex",
     alignItems: "center",
-    gap: shouldUseMobileUI ? "8px" : "6px",
-    padding: shouldUseMobileUI ? "8px 12px" : "5px 8px",
+    gap: shouldUseMobileUI ? 8 : 6,
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING + 5}px ${PANEL_MOBILE_PADDING + 6}px`
+      : `${PANEL_PADDING + 1}px ${PANEL_PADDING + 4}px`,
     cursor: "pointer",
     userSelect: "none",
-    backgroundColor: theme.colors.slot.filled,
-    borderBottom: `1px solid ${theme.colors.border.default}30`,
-    minHeight: shouldUseMobileUI ? "40px" : "26px",
+    borderLeft: `3px solid ${config.color}`,
+    minHeight: shouldUseMobileUI ? 40 : 28,
+    marginBottom: 1,
   };
 
   const expandIconStyle: CSSProperties = {
-    width: shouldUseMobileUI ? "14px" : "10px",
-    height: shouldUseMobileUI ? "14px" : "10px",
+    width: shouldUseMobileUI ? 14 : 10,
+    height: shouldUseMobileUI ? 14 : 10,
     color: theme.colors.text.muted,
     transform: collapsed ? "rotate(0deg)" : "rotate(90deg)",
     transition: reducedMotion ? "none" : "transform 0.15s ease",
-  };
-
-  const indicatorStyle: CSSProperties = {
-    width: shouldUseMobileUI ? "8px" : "6px",
-    height: shouldUseMobileUI ? "8px" : "6px",
-    borderRadius: "50%",
-    backgroundColor: config.color,
+    flexShrink: 0,
   };
 
   const nameStyle: CSSProperties = {
     flex: 1,
     color: theme.colors.text.secondary,
-    fontSize: shouldUseMobileUI ? "13px" : "10px",
-    fontWeight: 600,
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    fontWeight: theme.typography.fontWeight.semibold,
     textTransform: "uppercase",
-    letterSpacing: "0.3px",
+    letterSpacing: "0.4px",
+  };
+
+  const countBadgeStyle: CSSProperties = {
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.xs
+      : theme.typography.fontSize.xs,
+    color: theme.colors.text.muted,
+    backgroundColor: `${theme.colors.text.muted}15`,
+    padding: shouldUseMobileUI ? "2px 8px" : "1px 6px",
+    borderRadius: PANEL_SLOT_RADIUS,
+    fontWeight: theme.typography.fontWeight.medium,
+    flexShrink: 0,
   };
 
   return (
-    <div>
+    <div style={{ marginBottom: PANEL_GRID_GAP }}>
       <div
         role="button"
         tabIndex={0}
@@ -781,11 +874,26 @@ const CategoryGroup = memo(function CategoryGroup({
         >
           <path d="M4 2l4 4-4 4V2z" />
         </svg>
-        <div style={indicatorStyle} aria-hidden="true" />
+        {categoryIcon && (
+          <span
+            style={{ fontSize: shouldUseMobileUI ? 14 : 11, lineHeight: 1 }}
+            aria-hidden="true"
+          >
+            {categoryIcon}
+          </span>
+        )}
         <span style={nameStyle}>{config.label}</span>
+        <span style={countBadgeStyle}>{quests.length}</span>
       </div>
       {!collapsed && (
-        <div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: PANEL_GRID_GAP,
+            padding: `${PANEL_GRID_GAP}px 0`,
+          }}
+        >
           {quests.map((quest) => (
             <QuestListItem
               key={quest.id}
@@ -800,7 +908,7 @@ const CategoryGroup = memo(function CategoryGroup({
   );
 });
 
-/** Pinned Group Component - Shows pinned quests at top */
+/** Pinned Group Component — Gold-accented header for pinned quests */
 interface PinnedGroupProps {
   quests: Quest[];
   onQuestClick: (quest: Quest) => void;
@@ -818,50 +926,66 @@ const PinnedGroup = memo(function PinnedGroup({
   const { reducedMotion } = useAccessibilityStore();
   const { shouldUseMobileUI } = useMobileLayout();
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const goldColor = theme.colors.accent.gold;
 
-  // Don't render if no pinned quests
   if (quests.length === 0) {
     return null;
   }
 
+  const insetBase = getPanelInsetStyle(theme, {
+    emphasis: "normal",
+    radius: PANEL_SLOT_RADIUS,
+  });
+
   const headerStyle: CSSProperties = {
+    ...insetBase,
     display: "flex",
     alignItems: "center",
-    gap: shouldUseMobileUI ? "8px" : "6px",
-    padding: shouldUseMobileUI ? "8px 12px" : "5px 8px",
+    gap: shouldUseMobileUI ? 8 : 6,
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING + 5}px ${PANEL_MOBILE_PADDING + 6}px`
+      : `${PANEL_PADDING + 1}px ${PANEL_PADDING + 4}px`,
     cursor: "pointer",
     userSelect: "none",
-    backgroundColor: theme.colors.slot.filled,
-    borderBottom: `1px solid ${theme.colors.border.default}30`,
-    minHeight: shouldUseMobileUI ? "40px" : "26px",
+    borderLeft: `3px solid ${goldColor}`,
+    minHeight: shouldUseMobileUI ? 40 : 28,
+    marginBottom: 1,
   };
 
   const expandIconStyle: CSSProperties = {
-    width: shouldUseMobileUI ? "14px" : "10px",
-    height: shouldUseMobileUI ? "14px" : "10px",
+    width: shouldUseMobileUI ? 14 : 10,
+    height: shouldUseMobileUI ? 14 : 10,
     color: theme.colors.text.muted,
     transform: collapsed ? "rotate(0deg)" : "rotate(90deg)",
     transition: reducedMotion ? "none" : "transform 0.15s ease",
-  };
-
-  const indicatorStyle: CSSProperties = {
-    width: shouldUseMobileUI ? "8px" : "6px",
-    height: shouldUseMobileUI ? "8px" : "6px",
-    borderRadius: "50%",
-    backgroundColor: "#ffd700", // Gold color for pinned
+    flexShrink: 0,
   };
 
   const nameStyle: CSSProperties = {
     flex: 1,
     color: theme.colors.text.secondary,
-    fontSize: shouldUseMobileUI ? "13px" : "10px",
-    fontWeight: 600,
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    fontWeight: theme.typography.fontWeight.semibold,
     textTransform: "uppercase",
-    letterSpacing: "0.3px",
+    letterSpacing: "0.4px",
+  };
+
+  const countBadgeStyle: CSSProperties = {
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.xs
+      : theme.typography.fontSize.xs,
+    color: goldColor,
+    backgroundColor: `${goldColor}15`,
+    padding: shouldUseMobileUI ? "2px 8px" : "1px 6px",
+    borderRadius: PANEL_SLOT_RADIUS,
+    fontWeight: theme.typography.fontWeight.medium,
+    flexShrink: 0,
   };
 
   return (
-    <div>
+    <div style={{ marginBottom: PANEL_GRID_GAP }}>
       <div
         role="button"
         tabIndex={0}
@@ -886,11 +1010,28 @@ const PinnedGroup = memo(function PinnedGroup({
         >
           <path d="M4 2l4 4-4 4V2z" />
         </svg>
-        <div style={indicatorStyle} aria-hidden="true" />
+        <span
+          style={{
+            color: goldColor,
+            fontSize: shouldUseMobileUI ? 14 : 11,
+            lineHeight: 1,
+          }}
+          aria-hidden="true"
+        >
+          ★
+        </span>
         <span style={nameStyle}>Pinned</span>
+        <span style={countBadgeStyle}>{quests.length}</span>
       </div>
       {!collapsed && (
-        <div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: PANEL_GRID_GAP,
+            padding: `${PANEL_GRID_GAP}px 0`,
+          }}
+        >
           {quests.map((quest) => (
             <QuestListItem
               key={quest.id}
@@ -1066,65 +1207,62 @@ export const QuestLog = memo(function QuestLog({
   // Check if any filters are active
   const hasActiveFilters = stateFilter.length > 0 || categoryFilter.length > 0;
 
-  // Container styles - clean minimal
   const containerStyle: CSSProperties = {
+    ...getPanelSurfaceStyle(theme),
     display: "flex",
     flexDirection: "column",
-    backgroundColor: theme.colors.background.panelSecondary,
     overflow: "hidden",
     height: "100%",
     ...style,
   };
 
-  // Compact header with stats and toolbar - mobile responsive
   const headerStyle: CSSProperties = {
+    ...getPanelInsetStyle(theme, { radius: 0 }),
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    padding: shouldUseMobileUI ? "6px 8px" : "4px 6px",
-    backgroundColor: theme.colors.slot.filled,
-    borderBottom: `1px solid ${theme.colors.border.default}30`,
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING * 2}px ${PANEL_MOBILE_PADDING * 2 + 2}px`
+      : `${PANEL_PADDING}px ${PANEL_PADDING + 2}px`,
     minHeight: shouldUseMobileUI ? "36px" : "26px",
-    gap: shouldUseMobileUI ? "6px" : "4px",
+    gap: shouldUseMobileUI ? "6px" : `${PANEL_GRID_GAP}px`,
+    borderBottom: `1px solid ${theme.colors.border.default}30`,
   };
 
-  // Compact stats - mobile responsive
   const statsStyle: CSSProperties = {
     display: "flex",
-    gap: shouldUseMobileUI ? "8px" : "6px",
-    fontSize: shouldUseMobileUI ? "12px" : "10px",
-    color: theme.colors.text.muted,
+    gap: shouldUseMobileUI ? "6px" : `${PANEL_GRID_GAP}px`,
     flex: 1,
+    flexWrap: "wrap",
   };
 
-  // Toolbar buttons
   const toolbarStyle: CSSProperties = {
     display: "flex",
-    gap: shouldUseMobileUI ? "6px" : "3px",
+    gap: shouldUseMobileUI ? "6px" : `${PANEL_GRID_GAP - 1}px`,
     alignItems: "center",
   };
 
-  // Icon button - mobile responsive for touch targets
   const iconButtonStyle = (active: boolean): CSSProperties => ({
-    width: shouldUseMobileUI ? "32px" : "20px",
-    height: shouldUseMobileUI ? "32px" : "20px",
+    width: shouldUseMobileUI ? "32px" : "22px",
+    height: shouldUseMobileUI ? "32px" : "22px",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: active
       ? theme.colors.accent.primary
-      : theme.colors.slot.filled,
+      : theme.colors.slot.empty,
     color: active ? theme.colors.background.primary : theme.colors.text.muted,
     border: `1px solid ${active ? theme.colors.accent.primary : theme.colors.border.default}30`,
-    borderRadius: shouldUseMobileUI ? "4px" : "3px",
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     cursor: "pointer",
     padding: 0,
     transition: reducedMotion ? "none" : "all 0.1s ease",
   });
 
-  // Collapsible search - mobile responsive
   const searchContainerStyle: CSSProperties = {
-    padding: shouldUseMobileUI ? "6px 8px" : "4px 6px",
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING * 2}px`
+      : `${PANEL_PADDING}px ${PANEL_PADDING + 2}px`,
     borderBottom: `1px solid ${theme.colors.border.default}30`,
     display: searchExpanded ? "block" : "none",
   };
@@ -1134,60 +1272,66 @@ export const QuestLog = memo(function QuestLog({
     padding: shouldUseMobileUI ? "8px 12px" : "4px 8px",
     backgroundColor: theme.colors.slot.empty,
     border: `1px solid ${theme.colors.border.default}30`,
-    borderRadius: shouldUseMobileUI ? "4px" : "3px",
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     color: theme.colors.text.primary,
-    fontSize: shouldUseMobileUI ? "14px" : "10px",
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
     outline: "none",
   };
 
-  // Collapsible filters - compact, mobile responsive
   const filtersContainerStyle: CSSProperties = {
-    padding: shouldUseMobileUI ? "6px 8px" : "4px 6px",
+    ...getPanelInsetStyle(theme, { radius: 0 }),
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING * 2}px`
+      : `${PANEL_PADDING}px ${PANEL_PADDING + 2}px`,
     borderBottom: `1px solid ${theme.colors.border.default}30`,
     display: filtersExpanded ? "flex" : "none",
     flexDirection: "column",
-    gap: shouldUseMobileUI ? "6px" : "3px",
-    backgroundColor: theme.colors.slot.filled,
+    gap: shouldUseMobileUI ? "6px" : `${PANEL_GRID_GAP}px`,
   };
 
-  // Compact filter row - mobile responsive
   const filterRowStyle: CSSProperties = {
     display: "flex",
     alignItems: "center",
-    gap: shouldUseMobileUI ? "6px" : "3px",
+    gap: shouldUseMobileUI ? "6px" : `${PANEL_GRID_GAP}px`,
     flexWrap: "wrap",
   };
 
-  // Filter chips - mobile responsive for touch targets
   const getFilterChipStyle = (active: boolean): CSSProperties => ({
-    padding: shouldUseMobileUI ? "6px 10px" : "2px 5px",
-    borderRadius: shouldUseMobileUI ? "4px" : "3px",
+    padding: shouldUseMobileUI ? "4px 8px" : "2px 6px",
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     backgroundColor: active
       ? theme.colors.accent.primary
       : theme.colors.slot.empty,
     color: active ? theme.colors.background.primary : theme.colors.text.muted,
-    fontSize: shouldUseMobileUI ? "12px" : "9px",
-    fontWeight: 500,
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
+    fontWeight: theme.typography.fontWeight.medium,
     cursor: "pointer",
     border: active ? "none" : `1px solid ${theme.colors.border.default}30`,
     transition: reducedMotion ? "none" : "all 0.1s ease",
-    lineHeight: "1.3",
+    lineHeight: `${theme.typography.lineHeight.tight}`,
   });
 
-  // Content area - takes remaining space
   const contentStyle: CSSProperties = {
     flex: 1,
     overflowY: "auto",
     maxHeight: maxHeight,
+    padding: shouldUseMobileUI
+      ? `${PANEL_MOBILE_PADDING}px`
+      : `${PANEL_PADDING}px`,
     WebkitOverflowScrolling: "touch",
   };
 
-  // Empty state - mobile responsive
   const emptyStyle: CSSProperties = {
     padding: shouldUseMobileUI ? "24px" : "16px",
     textAlign: "center",
     color: theme.colors.text.muted,
-    fontSize: shouldUseMobileUI ? "14px" : "11px",
+    fontSize: shouldUseMobileUI
+      ? theme.typography.fontSize.sm
+      : theme.typography.fontSize.xs,
   };
 
   // Sort options
@@ -1215,33 +1359,58 @@ export const QuestLog = memo(function QuestLog({
         {/* Header with Title, Stats and Toolbar */}
         {showHeader && (
           <div style={headerStyle}>
-            {/* Title */}
             <span
               style={{
                 color: theme.colors.text.secondary,
-                fontSize: shouldUseMobileUI ? "13px" : "10px",
-                fontWeight: 600,
+                fontSize: shouldUseMobileUI
+                  ? theme.typography.fontSize.sm
+                  : theme.typography.fontSize.xs,
+                fontWeight: theme.typography.fontWeight.semibold,
                 marginRight: shouldUseMobileUI ? "8px" : "6px",
+                whiteSpace: "nowrap",
               }}
             >
               {title}
             </span>
-            {/* Quest counts - colored numbers */}
             {questCounts && (
               <div style={statsStyle}>
-                <span style={{ color: STATUS_COLORS.active, fontWeight: 600 }}>
-                  {questCounts.active}
-                </span>
-                <span
-                  style={{ color: STATUS_COLORS.available, fontWeight: 600 }}
-                >
-                  {questCounts.available}
-                </span>
-                <span
-                  style={{ color: STATUS_COLORS.completed, fontWeight: 600 }}
-                >
-                  {questCounts.completed}
-                </span>
+                {(
+                  [
+                    {
+                      state: "active" as QuestState,
+                      count: questCounts.active,
+                      label: "Active",
+                    },
+                    {
+                      state: "available" as QuestState,
+                      count: questCounts.available,
+                      label: "Avail",
+                    },
+                    {
+                      state: "completed" as QuestState,
+                      count: questCounts.completed,
+                      label: "Done",
+                    },
+                  ] as const
+                ).map(({ state, count, label }) => (
+                  <span
+                    key={state}
+                    style={{
+                      backgroundColor: `${getStateColor(state)}18`,
+                      color: getStateColor(state),
+                      padding: shouldUseMobileUI ? "2px 6px" : "1px 4px",
+                      borderRadius: `${PANEL_SLOT_RADIUS}px`,
+                      fontSize: shouldUseMobileUI
+                        ? theme.typography.fontSize.xs
+                        : "9px",
+                      fontWeight: theme.typography.fontWeight.semibold,
+                      lineHeight: `${theme.typography.lineHeight.tight}`,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {count} {label}
+                  </span>
+                ))}
               </div>
             )}
             <div style={toolbarStyle}>
@@ -1252,7 +1421,7 @@ export const QuestLog = memo(function QuestLog({
                   onClick={() => setSearchExpanded(!searchExpanded)}
                   title="Search"
                 >
-                  <SearchIcon />
+                  <SearchIcon size={shouldUseMobileUI ? 16 : 12} />
                 </button>
               )}
               {/* Filter toggle */}
@@ -1263,7 +1432,7 @@ export const QuestLog = memo(function QuestLog({
                     onClick={() => setFiltersExpanded(!filtersExpanded)}
                     title="Filters"
                   >
-                    <FilterIcon />
+                    <FilterIcon size={shouldUseMobileUI ? 16 : 12} />
                   </button>
                 )}
               {/* Sort dropdown with direction toggle */}
@@ -1275,12 +1444,14 @@ export const QuestLog = memo(function QuestLog({
                       onSortChange(e.target.value as QuestSortOption)
                     }
                     style={{
-                      padding: shouldUseMobileUI ? "6px 8px" : "2px 4px",
+                      padding: shouldUseMobileUI ? "4px 6px" : "2px 4px",
                       backgroundColor: theme.colors.slot.empty,
                       border: `1px solid ${theme.colors.border.default}30`,
-                      borderRadius: shouldUseMobileUI ? "4px" : "3px",
+                      borderRadius: `${PANEL_SLOT_RADIUS}px`,
                       color: theme.colors.text.muted,
-                      fontSize: shouldUseMobileUI ? "12px" : "9px",
+                      fontSize: shouldUseMobileUI
+                        ? theme.typography.fontSize.xs
+                        : "9px",
                       cursor: "pointer",
                       outline: "none",
                     }}
@@ -1295,8 +1466,8 @@ export const QuestLog = memo(function QuestLog({
                     <button
                       style={{
                         ...iconButtonStyle(false),
-                        width: shouldUseMobileUI ? "28px" : "18px",
-                        height: shouldUseMobileUI ? "28px" : "18px",
+                        width: shouldUseMobileUI ? "28px" : "20px",
+                        height: shouldUseMobileUI ? "28px" : "20px",
                       }}
                       onClick={() =>
                         onSortDirectionChange(
@@ -1308,8 +1479,8 @@ export const QuestLog = memo(function QuestLog({
                       }
                     >
                       <svg
-                        width="8"
-                        height="8"
+                        width={shouldUseMobileUI ? 10 : 8}
+                        height={shouldUseMobileUI ? 10 : 8}
                         viewBox="0 0 12 12"
                         fill="currentColor"
                         style={{

--- a/packages/client/src/game/interface/DefaultLayoutFactory.ts
+++ b/packages/client/src/game/interface/DefaultLayoutFactory.ts
@@ -271,6 +271,13 @@ export function createDefaultWindows(): WindowConfig[] {
           content: "prayer",
           closeable: true,
         },
+        {
+          id: "spells",
+          label: "Spells",
+          icon: "🪄",
+          content: "spells",
+          closeable: true,
+        },
       ],
       transparency: 0,
       anchor: "bottom-right",

--- a/packages/client/src/game/interface/InterfaceManager.tsx
+++ b/packages/client/src/game/interface/InterfaceManager.tsx
@@ -404,7 +404,6 @@ function DesktopInterfaceManager({
             editModeEnabled={editModeEnabled}
             windowCombiningEnabled={windowCombiningEnabled}
             renderPanel={renderPanel}
-            panelDataVersion={panelDataVersion}
           />
 
           {/* @dnd-kit drag overlay */}

--- a/packages/client/src/game/interface/InterfaceManager.tsx
+++ b/packages/client/src/game/interface/InterfaceManager.tsx
@@ -319,22 +319,6 @@ function DesktopInterfaceManager({
   // Listen for UI_OPEN_PANE events
   useOpenPaneEvent(world, handleMenuClick);
 
-  const panelDataRef = useRef({
-    inventory,
-    coins,
-    playerStats,
-    equipment,
-  });
-
-  useEffect(() => {
-    panelDataRef.current = {
-      inventory,
-      coins,
-      playerStats,
-      equipment,
-    };
-  }, [inventory, coins, playerStats, equipment]);
-
   const inventoryRef = useRef(inventory);
   useEffect(() => {
     inventoryRef.current = inventory;
@@ -348,16 +332,24 @@ function DesktopInterfaceManager({
         onPanelClick: handleMenuClick,
         isEditMode: isUnlocked && editModeEnabled,
         getPanelData: () => ({
-          inventoryItems: panelDataRef.current.inventory as never[],
-          coins: panelDataRef.current.coins,
-          stats: panelDataRef.current.playerStats,
-          equipment: panelDataRef.current.equipment,
+          inventoryItems: inventory as never[],
+          coins,
+          stats: playerStats,
+          equipment,
         }),
       }),
-    [world, handleMenuClick, isUnlocked, editModeEnabled],
+    [
+      world,
+      handleMenuClick,
+      isUnlocked,
+      editModeEnabled,
+      inventory,
+      coins,
+      playerStats,
+      equipment,
+    ],
   );
 
-  // Drag-drop coordination (delegated to hook)
   const {
     handleDragEnd,
     handleDndKitDragStart,

--- a/packages/client/src/game/interface/InterfacePanels.tsx
+++ b/packages/client/src/game/interface/InterfacePanels.tsx
@@ -42,33 +42,48 @@ export function WindowContent({
 
   if (!activeTab) return null;
 
-  // If content is a string (panel ID), use the renderPanel function
-  if (typeof activeTab.content === "string") {
-    const panelContent = renderPanel(activeTab.content, undefined, windowId);
+  // Component fills available space, panels handle their own scrolling
+  // Multi-tab windows use TabBar for drop zones, not the content area
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+        overflow: "hidden",
+        position: "relative",
+      }}
+    >
+      {tabs.map((tab, idx) => {
+        const isActive = idx === activeTabIndex;
+        const panelContent =
+          typeof tab.content === "string"
+            ? renderPanel(tab.content, undefined, windowId)
+            : tab.content;
 
-    // Action bars have no padding
-    const isActionBar = activeTab.content.startsWith("actionbar-");
+        const isActionBar =
+          typeof tab.content === "string" &&
+          tab.content.startsWith("actionbar-");
 
-    // Container fills available space, panels handle their own scrolling
-    // Multi-tab windows use TabBar for drop zones, not the content area
-    return (
-      <div
-        style={{
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-          minHeight: 0,
-          overflow: "hidden",
-          padding: isActionBar ? 0 : 4,
-        }}
-      >
-        {panelContent}
-      </div>
-    );
-  }
-
-  // Otherwise render the content directly
-  return <>{activeTab.content}</>;
+        return (
+          <div
+            key={tab.id || idx}
+            style={{
+              display: isActive ? "flex" : "none",
+              position: "absolute",
+              inset: 0,
+              flexDirection: "column",
+              padding: isActionBar ? 0 : 4,
+              overflow: "hidden",
+            }}
+          >
+            {panelContent}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 /**
@@ -230,7 +245,7 @@ export function DraggableContentWrapper({
           </div>
         )}
       </div>
-      {/* Panel content */}
+      {/* Panel content area keeps mounting all tabs to retain state */}
       <div
         style={{
           flex: 1,
@@ -238,9 +253,31 @@ export function DraggableContentWrapper({
           flexDirection: "column",
           minHeight: 0,
           overflow: "hidden",
+          position: "relative",
         }}
       >
-        {panelContent}
+        {tabs.map((tab, idx) => {
+          const isActive = idx === activeTabIndex;
+          const panelContent =
+            typeof tab.content === "string"
+              ? renderPanel(tab.content, undefined, windowId)
+              : tab.content;
+
+          return (
+            <div
+              key={tab.id || idx}
+              style={{
+                display: isActive ? "flex" : "none",
+                position: "absolute",
+                inset: 0,
+                flexDirection: "column",
+                overflow: "hidden",
+              }}
+            >
+              {panelContent}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/client/src/game/interface/PanelRegistry.tsx
+++ b/packages/client/src/game/interface/PanelRegistry.tsx
@@ -255,16 +255,16 @@ export const PANEL_CONFIG: Record<string, PanelConfig> = {
   // Equipment - fixed layout, needs specific dimensions for slot arrangement
   // Min/max width aligned with skills panel for consistent right column sizing
   equipment: {
-    minSize: { width: 300, height: 430 },
-    preferredSize: { width: 340, height: 510 },
-    maxSize: { width: 430, height: 620 },
+    minSize: { width: 235, height: 340 },
+    preferredSize: { width: 260, height: 390 },
+    maxSize: { width: 340, height: 520 },
     scrollable: false,
     resizable: true,
     scaleFactor: { min: 0.85, max: 1.15 },
     responsive: {
-      mobile: { width: 300, height: 430 },
-      tablet: { width: 320, height: 470 },
-      desktop: { width: 340, height: 510 },
+      mobile: { width: 235, height: 340 },
+      tablet: { width: 250, height: 370 },
+      desktop: { width: 260, height: 390 },
     },
     mobileLayout: {
       drawerType: "sheet",

--- a/packages/client/src/game/interface/PanelRegistry.tsx
+++ b/packages/client/src/game/interface/PanelRegistry.tsx
@@ -255,16 +255,16 @@ export const PANEL_CONFIG: Record<string, PanelConfig> = {
   // Equipment - fixed layout, needs specific dimensions for slot arrangement
   // Min/max width aligned with skills panel for consistent right column sizing
   equipment: {
-    minSize: { width: 235, height: 290 },
-    preferredSize: { width: 260, height: 360 },
-    maxSize: { width: 390, height: 550 },
+    minSize: { width: 300, height: 430 },
+    preferredSize: { width: 340, height: 510 },
+    maxSize: { width: 430, height: 620 },
     scrollable: false,
     resizable: true,
     scaleFactor: { min: 0.85, max: 1.15 },
     responsive: {
-      mobile: { width: 235, height: 310 },
-      tablet: { width: 235, height: 340 },
-      desktop: { width: 260, height: 360 },
+      mobile: { width: 300, height: 430 },
+      tablet: { width: 320, height: 470 },
+      desktop: { width: 340, height: 510 },
     },
     mobileLayout: {
       drawerType: "sheet",

--- a/packages/client/src/game/interface/WindowRenderer.tsx
+++ b/packages/client/src/game/interface/WindowRenderer.tsx
@@ -34,8 +34,6 @@ interface WindowRendererProps {
     world?: ClientWorld,
     windowId?: string,
   ) => React.ReactNode;
-  /** Changes when panel data updates, breaking through memo barriers */
-  panelDataVersion?: number;
 }
 
 /**
@@ -47,7 +45,6 @@ export const WindowRenderer = memo(function WindowRenderer({
   editModeEnabled,
   windowCombiningEnabled,
   renderPanel,
-  panelDataVersion,
 }: WindowRendererProps): React.ReactElement {
   const windowsMap = useWindowStore((s) => s.windows);
   const visibleWindows = useMemo(
@@ -73,7 +70,6 @@ export const WindowRenderer = memo(function WindowRenderer({
           isEditMode={isEditMode}
           windowCombiningEnabled={windowCombiningEnabled}
           renderPanel={renderPanel}
-          panelDataVersion={panelDataVersion}
         />
       ))}
     </div>
@@ -91,7 +87,6 @@ interface WindowItemProps {
     world?: ClientWorld,
     windowId?: string,
   ) => React.ReactNode;
-  panelDataVersion?: number;
 }
 
 /**
@@ -103,10 +98,6 @@ const WindowItem = memo(function WindowItem({
   isEditMode,
   windowCombiningEnabled,
   renderPanel,
-  // Intentionally unused — its presence in props breaks React.memo's
-  // shallow comparison when panel data changes, causing WindowItem to
-  // re-render and call renderPanel with fresh ref-based data.
-  panelDataVersion: _,
 }: WindowItemProps): React.ReactElement {
   const windowState = useWindowStore(
     useMemo(

--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -959,18 +959,6 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
       setAutoRetaliate(enabled);
     });
 
-    // Direct fallback: read from player entity if callback doesn't fire
-    // This ensures we get the correct value even if the event system has issues
-    const player = world.entities?.player;
-    if (player) {
-      const playerCombat = (player as { combat?: { autoRetaliate?: boolean } })
-        ?.combat;
-      if (typeof playerCombat?.autoRetaliate === "boolean") {
-        autoRetaliateCache.set(playerId, playerCombat.autoRetaliate);
-        setAutoRetaliate(playerCombat.autoRetaliate);
-      }
-    }
-
     const onUpdate = (data: unknown) => {
       if (!isStyleUpdateEvent(data)) return;
       if (data.playerId !== playerId) return;

--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -509,6 +509,8 @@ const CombatStyleBanner = ({
   return (
     <div
       ref={setNodeRef}
+      {...attributes}
+      {...listeners}
       style={{
         flex: "0 0 calc((100% - 3 * (var(--banner-gap))) / 4)",
         maxWidth: "calc((100% - 3 * (var(--banner-gap))) / 4)",
@@ -517,6 +519,7 @@ const CombatStyleBanner = ({
         opacity: disabled ? 0.5 : isDragging ? 0.6 : 1,
         transform: isDragging ? "scale(0.95)" : "scale(1)",
         transition: "opacity 0.15s ease, transform 0.15s ease",
+        touchAction: "none",
       }}
     >
       <button
@@ -712,28 +715,6 @@ const CombatStyleBanner = ({
           </span>
         </div>
       </button>
-
-      {/* Drag handle overlay — also handles clicks since it sits on top */}
-      <div
-        {...attributes}
-        {...listeners}
-        aria-label={`Drag ${styleInfo.label} style to action bar`}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (!disabled) onClick();
-        }}
-        style={{
-          position: "absolute",
-          inset: 0,
-          cursor: disabled
-            ? "not-allowed"
-            : isDragging
-              ? "grabbing"
-              : "pointer",
-          touchAction: "none",
-          pointerEvents: disabled ? "none" : "auto",
-        }}
-      />
     </div>
   );
 };
@@ -1093,11 +1074,6 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     const playerId = world.entities?.player?.id;
     if (!playerId) return;
 
-    // Optimistic UI update — immediately show the change
-    combatStyleCache.set(playerId, next);
-    setStyle(next);
-
-    // Send to server (server event callback will confirm/correct the state)
     const actions = world.getSystem("actions") as {
       actionMethods?: {
         changeAttackStyle?: (id: string, style: string) => void;
@@ -1105,6 +1081,10 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     } | null;
 
     if (!actions?.actionMethods?.changeAttackStyle) return;
+
+    // Optimistic: update UI instantly (OSRS has zero visible delay)
+    combatStyleCache.set(playerId, next);
+    setStyle(next);
 
     // Send to server — server confirms via attackStyleChanged packet,
     // which will overwrite our optimistic value with the authoritative one
@@ -1152,12 +1132,6 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     const playerId = world.entities?.player?.id;
     if (!playerId) return;
 
-    // Optimistic UI update — immediately show the toggle
-    const newValue = !autoRetaliate;
-    autoRetaliateCache.set(playerId, newValue);
-    setAutoRetaliate(newValue);
-
-    // Send to server (server event callback will confirm/correct the state)
     const actions = world.getSystem("actions") as {
       actionMethods?: {
         setAutoRetaliate?: (id: string, enabled: boolean) => void;
@@ -1165,6 +1139,12 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     } | null;
 
     if (!actions?.actionMethods?.setAutoRetaliate) return;
+
+    const newValue = !autoRetaliate;
+
+    // Optimistic: update UI instantly (OSRS has zero visible delay)
+    autoRetaliateCache.set(playerId, newValue);
+    setAutoRetaliate(newValue);
 
     // Send to server — server confirms via autoRetaliateChanged packet,
     // which will overwrite our optimistic value with the authoritative one

--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -713,11 +713,15 @@ const CombatStyleBanner = ({
         </div>
       </button>
 
-      {/* Invisible drag handle */}
+      {/* Drag handle overlay — also handles clicks since it sits on top */}
       <div
         {...attributes}
         {...listeners}
         aria-label={`Drag ${styleInfo.label} style to action bar`}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!disabled) onClick();
+        }}
         style={{
           position: "absolute",
           inset: 0,

--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -7,6 +7,11 @@ import {
   getPanelSurfaceStyle,
 } from "@/ui/theme/themes";
 import { EventType, getAvailableStyles, WeaponType } from "@hyperscape/shared";
+import {
+  PANEL_PADDING,
+  PANEL_MOBILE_PADDING,
+  PANEL_GRID_GAP,
+} from "../../constants/panelLayout";
 import type {
   ClientWorld,
   PlayerStats,
@@ -224,8 +229,241 @@ interface CombatStyleInfo {
   color: string;
 }
 
-/** Draggable combat style button component */
-const DraggableCombatStyleButton = ({
+/** Short XP labels for compact banner display */
+const XP_SHORT_LABELS: Record<string, string> = {
+  Attack: "+ATK",
+  Strength: "+STR",
+  Defense: "+DEF",
+  All: "+ALL",
+  Ranged: "+RNG",
+  "Rng+Def": "+R/D",
+  Magic: "+MAG",
+};
+
+/** Filled game-style icons for combat banners — bold, solid fills for fantasy UI */
+const BannerStyleIcon = ({
+  style,
+  size = 24,
+  color = "currentColor",
+  muted = false,
+}: {
+  style: string;
+  size?: number;
+  color?: string;
+  muted?: boolean;
+}) => {
+  const fo = muted ? 0.25 : 0.55;
+  const so = muted ? 0.45 : 1;
+
+  switch (style) {
+    case "accurate":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24">
+          <circle
+            cx="12"
+            cy="12"
+            r="10.5"
+            fill={color}
+            fillOpacity={fo * 0.35}
+            stroke={color}
+            strokeWidth="1.4"
+            strokeOpacity={so}
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="7"
+            fill={color}
+            fillOpacity={fo * 0.55}
+            stroke={color}
+            strokeWidth="1.1"
+            strokeOpacity={so * 0.85}
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="3.5"
+            fill={color}
+            fillOpacity={fo * 0.85}
+            stroke={color}
+            strokeWidth="0.9"
+            strokeOpacity={so * 0.9}
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="1.3"
+            fill={color}
+            fillOpacity={muted ? 0.4 : 0.95}
+          />
+        </svg>
+      );
+    case "aggressive":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+          <path
+            d="M5 4l12 8-12 8Z"
+            fill={color}
+            fillOpacity={fo * 0.6}
+            stroke={color}
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+            strokeOpacity={so}
+          />
+          <path
+            d="M11 7l8 5-8 5Z"
+            fill={color}
+            fillOpacity={fo * 0.35}
+            stroke={color}
+            strokeWidth="1.4"
+            strokeLinejoin="round"
+            strokeOpacity={so * 0.7}
+          />
+        </svg>
+      );
+    case "defensive":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24">
+          <path
+            d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"
+            fill={color}
+            fillOpacity={fo * 0.55}
+            stroke={color}
+            strokeWidth="1.5"
+            strokeLinejoin="round"
+            strokeOpacity={so}
+          />
+          <path
+            d="M12 18.5s5.5-2.5 5.5-7V6.5L12 4.5 6.5 6.5V11.5c0 4.5 5.5 7 5.5 7z"
+            fill={color}
+            fillOpacity={fo * 0.3}
+            stroke={color}
+            strokeWidth="0.7"
+            strokeOpacity={so * 0.5}
+          />
+        </svg>
+      );
+    case "controlled":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            fill={color}
+            fillOpacity={fo * 0.2}
+            stroke={color}
+            strokeWidth="1.4"
+            strokeOpacity={so}
+          />
+          <line
+            x1="12"
+            y1="3"
+            x2="12"
+            y2="21"
+            stroke={color}
+            strokeWidth="1.4"
+            strokeOpacity={so}
+          />
+          <line
+            x1="3"
+            y1="12"
+            x2="21"
+            y2="12"
+            stroke={color}
+            strokeWidth="1.4"
+            strokeOpacity={so}
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r="3"
+            fill={color}
+            fillOpacity={fo * 0.6}
+            stroke={color}
+            strokeWidth="1"
+            strokeOpacity={so * 0.85}
+          />
+        </svg>
+      );
+    case "rapid":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24">
+          <polygon
+            points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"
+            fill={color}
+            fillOpacity={fo * 0.65}
+            stroke={color}
+            strokeWidth="1.4"
+            strokeLinejoin="round"
+            strokeOpacity={so}
+          />
+        </svg>
+      );
+    case "longrange":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            fill={color}
+            fillOpacity={fo * 0.12}
+            stroke={color}
+            strokeWidth="1.2"
+            strokeOpacity={so * 0.5}
+          />
+          <path
+            d="m3 12 5-4v8l-5-4z"
+            fill={color}
+            fillOpacity={fo * 0.55}
+            stroke={color}
+            strokeWidth="1.2"
+            strokeOpacity={so}
+          />
+          <path
+            d="M10 12h11"
+            stroke={color}
+            strokeWidth="2"
+            strokeOpacity={so}
+            strokeLinecap="round"
+          />
+          <path
+            d="M17 8l4 4-4 4"
+            stroke={color}
+            strokeWidth="1.5"
+            strokeOpacity={so}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case "autocast":
+      return (
+        <svg width={size} height={size} viewBox="0 0 24 24">
+          <path
+            d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"
+            fill={color}
+            fillOpacity={fo * 0.6}
+            stroke={color}
+            strokeWidth="1.3"
+            strokeOpacity={so}
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+};
+
+// Shield/crest SVG paths for combat banners
+const SHIELD_OUTER =
+  "M 5 0 L 95 0 Q 100 0 100 5 L 100 82 Q 100 102 50 128 Q 0 102 0 82 L 0 5 Q 0 0 5 0 Z";
+const SHIELD_INNER =
+  "M 8 3 L 92 3 Q 97 3 97 7 L 97 80 Q 97 99 50 123 Q 3 99 3 80 L 3 7 Q 3 3 8 3 Z";
+
+/** Combat style banner — heraldic shield using theme colors */
+const CombatStyleBanner = ({
   style: styleInfo,
   isActive,
   disabled,
@@ -240,7 +478,6 @@ const DraggableCombatStyleButton = ({
   onClick: () => void;
   theme: ReturnType<typeof useThemeStore.getState>["theme"];
 }) => {
-  // Make combat style draggable for action bar
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `combatstyle-${styleInfo.id}`,
     data: {
@@ -254,27 +491,31 @@ const DraggableCombatStyleButton = ({
     disabled,
   });
 
+  const shortXp =
+    XP_SHORT_LABELS[styleInfo.xp] ||
+    `+${styleInfo.xp.slice(0, 3).toUpperCase()}`;
+  const baseGradId = `banner-base-${styleInfo.id}`;
+  const tintGradId = `banner-tint-${styleInfo.id}`;
+
+  // Theme-derived colors
+  const bgDark = theme.colors.background.primary;
+  const bgMid = theme.colors.background.secondary;
+  const bgLight = theme.colors.background.tertiary;
+  const accentGold = theme.colors.accent.primary;
+  const borderClr = theme.colors.border.default;
+  const textMuted = theme.colors.text.muted;
+  const textPrimary = theme.colors.text.primary;
+
   return (
     <div
       ref={setNodeRef}
       style={{
+        flex: 1,
         minWidth: 0,
-        padding: isMobile ? "5px 6px" : "4px 6px",
-        transition: "all 0.12s ease",
-        ...getInteractiveTileStyle(theme, {
-          active: isActive,
-          disabled,
-          dragging: isDragging,
-          radius: 5,
-          accentColor: styleInfo.color,
-        }),
-        display: "flex",
-        alignItems: "center",
-        gap: "6px",
-        opacity: disabled ? 0.5 : isDragging ? 0.7 : 1,
-        transform: isDragging ? "scale(1.01)" : "scale(1)",
-        width: "100%",
         position: "relative",
+        opacity: disabled ? 0.5 : isDragging ? 0.6 : 1,
+        transform: isDragging ? "scale(0.95)" : "scale(1)",
+        transition: "opacity 0.15s ease, transform 0.15s ease",
       }}
     >
       <button
@@ -285,81 +526,209 @@ const DraggableCombatStyleButton = ({
         }}
         disabled={disabled}
         aria-pressed={isActive}
-        className="style-btn focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-400/50"
+        className="combat-banner focus-visible:outline-none"
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "6px",
-          flex: 1,
-          minWidth: 0,
+          position: "relative",
+          width: "100%",
+          aspectRatio: isMobile ? "0.58" : "0.52",
           background: "transparent",
           border: "none",
           padding: 0,
-          margin: 0,
           cursor: disabled ? "not-allowed" : "pointer",
-          color: isActive ? styleInfo.color : theme.colors.text.secondary,
-          textAlign: "left",
           touchAction: "manipulation",
         }}
       >
-        <StyleIcon
-          style={styleInfo.id}
-          size={isMobile ? 14 : 13}
-          color={isActive ? styleInfo.color : theme.colors.text.muted}
-        />
-        <span
+        {/* SVG shield / crest shape */}
+        <svg
+          viewBox="0 0 100 130"
+          preserveAspectRatio="none"
           style={{
-            fontWeight: 600,
-            lineHeight: 1,
-            fontSize: isMobile ? "11px" : "10px",
-            color: isActive
-              ? theme.colors.text.primary
-              : theme.colors.text.secondary,
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            flex: 1,
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            filter: isActive
+              ? `drop-shadow(0 3px 8px ${styleInfo.color}35) drop-shadow(0 1px 2px rgba(0,0,0,0.6))`
+              : "drop-shadow(0 2px 5px rgba(0,0,0,0.5))",
+            transition: "filter 0.2s ease",
           }}
         >
-          {styleInfo.label}
-        </span>
-        <span
+          <defs>
+            {/* Theme base gradient */}
+            <linearGradient id={baseGradId} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor={isActive ? bgLight : bgMid}
+                stopOpacity={1}
+              />
+              <stop
+                offset="50%"
+                stopColor={isActive ? bgMid : bgDark}
+                stopOpacity={1}
+              />
+              <stop offset="100%" stopColor={bgDark} stopOpacity={1} />
+            </linearGradient>
+            {/* Color tint overlay for active state */}
+            {isActive && (
+              <linearGradient id={tintGradId} x1="0" y1="0" x2="0" y2="1">
+                <stop
+                  offset="0%"
+                  stopColor={styleInfo.color}
+                  stopOpacity={0.28}
+                />
+                <stop
+                  offset="55%"
+                  stopColor={styleInfo.color}
+                  stopOpacity={0.1}
+                />
+                <stop
+                  offset="100%"
+                  stopColor={styleInfo.color}
+                  stopOpacity={0.03}
+                />
+              </linearGradient>
+            )}
+          </defs>
+
+          {/* Outer shadow edge */}
+          <path
+            d={SHIELD_OUTER}
+            fill="none"
+            stroke="rgba(0,0,0,0.7)"
+            strokeWidth={3.5}
+          />
+          {/* Base fill */}
+          <path d={SHIELD_OUTER} fill={`url(#${baseGradId})`} />
+          {/* Active color tint overlay */}
+          {isActive && <path d={SHIELD_OUTER} fill={`url(#${tintGradId})`} />}
+          {/* Border stroke — gold accent inactive, style color active */}
+          <path
+            d={SHIELD_OUTER}
+            fill="none"
+            stroke={isActive ? `${styleInfo.color}aa` : `${borderClr}`}
+            strokeWidth={isActive ? 1.8 : 1.2}
+          />
+          {/* Top edge highlight */}
+          <line
+            x1="10"
+            y1="1.2"
+            x2="90"
+            y2="1.2"
+            stroke={isActive ? `${styleInfo.color}44` : `${accentGold}18`}
+            strokeWidth={0.8}
+            strokeLinecap="round"
+          />
+          {/* Inner bevel for depth */}
+          <path
+            d={SHIELD_INNER}
+            fill="none"
+            stroke={
+              isActive ? "rgba(255,255,255,0.07)" : "rgba(255,255,255,0.025)"
+            }
+            strokeWidth={0.6}
+          />
+        </svg>
+
+        {/* Icon protruding from top of shield */}
+        <div
           style={{
-            fontSize: isMobile ? "9px" : "8px",
-            color: isActive ? styleInfo.color : theme.colors.text.muted,
-            fontWeight: 600,
-            opacity: 0.8,
-            whiteSpace: "nowrap",
+            position: "absolute",
+            top: 0,
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            zIndex: 2,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: isMobile ? 28 : 34,
+            height: isMobile ? 28 : 34,
+            borderRadius: "50%",
+            background: isActive
+              ? `radial-gradient(circle, ${bgLight} 40%, ${bgMid} 100%)`
+              : `radial-gradient(circle, ${bgMid} 40%, ${bgDark} 100%)`,
+            border: isActive
+              ? `1.5px solid ${styleInfo.color}88`
+              : `1px solid ${borderClr}`,
+            boxShadow: isActive
+              ? `0 2px 6px ${styleInfo.color}30, 0 1px 3px rgba(0,0,0,0.4)`
+              : "0 2px 4px rgba(0,0,0,0.4)",
           }}
         >
-          {styleInfo.xp}
-        </span>
+          <BannerStyleIcon
+            style={styleInfo.id}
+            size={isMobile ? 16 : 20}
+            color={isActive ? styleInfo.color : accentGold}
+            muted={!isActive}
+          />
+        </div>
+
+        {/* Content overlay */}
+        <div
+          style={{
+            position: "relative",
+            zIndex: 1,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "100%",
+            paddingTop: isMobile ? "16px" : "20px",
+            paddingBottom: isMobile ? "18px" : "22px",
+            gap: isMobile ? "2px" : "3px",
+          }}
+        >
+          {/* Style name */}
+          <span
+            style={{
+              fontSize: isMobile ? "8.5px" : "10px",
+              fontWeight: 700,
+              color: isActive ? textPrimary : textMuted,
+              lineHeight: 1.15,
+              textAlign: "center",
+              whiteSpace: "nowrap",
+              letterSpacing: "0.01em",
+              textShadow: isActive
+                ? `0 1px 3px rgba(0,0,0,0.7), 0 0 8px ${styleInfo.color}25`
+                : "0 1px 2px rgba(0,0,0,0.6)",
+            }}
+          >
+            {styleInfo.label}
+          </span>
+
+          {/* XP bonus label */}
+          <span
+            style={{
+              fontSize: isMobile ? "8.5px" : "10px",
+              fontWeight: 700,
+              color: isActive ? styleInfo.color : `${accentGold}88`,
+              lineHeight: 1,
+              textAlign: "center",
+              letterSpacing: "0.05em",
+              textShadow: isActive ? `0 0 6px ${styleInfo.color}35` : "none",
+            }}
+          >
+            {shortXp}
+          </span>
+        </div>
       </button>
-      {/* Separate drag handle so dnd-kit doesn't intercept clicks */}
+
+      {/* Invisible drag handle */}
       <div
         {...attributes}
         {...listeners}
         aria-label={`Drag ${styleInfo.label} style to action bar`}
         style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          width: "14px",
-          height: "14px",
-          cursor: disabled ? "not-allowed" : isDragging ? "grabbing" : "grab",
-          color: theme.colors.text.muted,
-          opacity: disabled ? 0.35 : 0.5,
-          flexShrink: 0,
+          position: "absolute",
+          inset: 0,
+          cursor: disabled
+            ? "not-allowed"
+            : isDragging
+              ? "grabbing"
+              : "pointer",
           touchAction: "none",
+          pointerEvents: "none",
         }}
-      >
-        <svg width="8" height="8" viewBox="0 0 10 10" fill="currentColor">
-          <circle cx="3" cy="3" r="0.9" />
-          <circle cx="7" cy="3" r="0.9" />
-          <circle cx="3" cy="7" r="0.9" />
-          <circle cx="7" cy="7" r="0.9" />
-        </svg>
-      </div>
+      />
     </div>
   );
 };
@@ -719,15 +1088,24 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     const playerId = world.entities?.player?.id;
     if (!playerId) return;
 
+    // Optimistic UI update — immediately show the change
+    combatStyleCache.set(playerId, next);
+    setStyle(next);
+
+    // Send to server (server event callback will confirm/correct the state)
     const actions = world.getSystem("actions") as {
       actionMethods?: {
         changeAttackStyle?: (id: string, style: string) => void;
       };
     } | null;
 
-    if (!actions?.actionMethods?.changeAttackStyle) return;
-
-    actions.actionMethods.changeAttackStyle(playerId, next);
+    if (actions?.actionMethods?.changeAttackStyle) {
+      actions.actionMethods.changeAttackStyle(playerId, next);
+    } else {
+      console.warn(
+        "[CombatPanel] changeStyle: actions system missing changeAttackStyle",
+      );
+    }
 
     // OSRS-accurate: selecting autocast opens the spells panel for spell selection
     if (next === "autocast") {
@@ -771,15 +1149,25 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     const playerId = world.entities?.player?.id;
     if (!playerId) return;
 
+    // Optimistic UI update — immediately show the toggle
+    const newValue = !autoRetaliate;
+    autoRetaliateCache.set(playerId, newValue);
+    setAutoRetaliate(newValue);
+
+    // Send to server (server event callback will confirm/correct the state)
     const actions = world.getSystem("actions") as {
       actionMethods?: {
         setAutoRetaliate?: (id: string, enabled: boolean) => void;
       };
     } | null;
 
-    if (!actions?.actionMethods?.setAutoRetaliate) return;
-
-    actions.actionMethods.setAutoRetaliate(playerId, !autoRetaliate);
+    if (actions?.actionMethods?.setAutoRetaliate) {
+      actions.actionMethods.setAutoRetaliate(playerId, newValue);
+    } else {
+      console.warn(
+        "[CombatPanel] toggleAutoRetaliate: actions system missing setAutoRetaliate",
+      );
+    }
   };
 
   // All possible combat styles with their XP training info and colors
@@ -873,13 +1261,20 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
     return () => observer.disconnect();
   }, []);
 
-  // Responsive padding/sizing - compact for both mobile and desktop
+  // Responsive padding/sizing — built from shared panelLayout constants
+  // compact = mobile or small panel; outer/inner/gap scale accordingly
   const compactPanel =
     shouldUseMobileUI || panelSize.height < 330 || panelSize.width < 250;
   const ultraCompactPanel = panelSize.height < 290 || panelSize.width < 220;
   const p = compactPanel
-    ? { outer: 3, inner: 4, gap: 3 }
-    : { outer: 4, inner: 6, gap: 4 };
+    ? {
+        outer: PANEL_MOBILE_PADDING,
+        inner: PANEL_PADDING,
+        gap: PANEL_MOBILE_PADDING,
+      }
+    : { outer: PANEL_PADDING, inner: PANEL_PADDING + 2, gap: PANEL_GRID_GAP };
+  // ultraCompactPanel is available for future use if needed (currently unused)
+  void ultraCompactPanel;
   return (
     <div
       ref={panelRef}
@@ -894,182 +1289,23 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
       <style>{`
         @keyframes combat-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.6; } }
         .combat-pulse { animation: combat-pulse 1.5s ease-in-out infinite; }
-        .style-btn:hover:not(:disabled) { transform: translateY(-1px); }
-        .style-btn:active:not(:disabled) { transform: translateY(0); }
+        .combat-banner { transition: transform 0.15s ease, filter 0.15s ease; }
+        .combat-banner:hover:not(:disabled) { transform: translateY(-2px) scale(1.03); filter: brightness(1.15) contrast(1.05); }
+        .combat-banner:active:not(:disabled) { transform: translateY(0) scale(0.98); filter: brightness(0.9); }
       `}</style>
 
-      {/* HP + Combat Level — single compact row */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "6px",
-          padding: `${p.inner}px`,
-          background:
-            theme.name === "hyperscape"
-              ? "linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(0, 0, 0, 0.12) 100%)"
-              : theme.colors.slot.filled,
-          border: inCombat
-            ? `1px solid ${theme.colors.state.danger}50`
-            : `1px solid ${theme.colors.border.default}35`,
-          borderRadius: theme.borderRadius.md,
-          flexShrink: 0,
-        }}
-      >
-        <svg width={12} height={12} viewBox="0 0 24 24" fill="#ef4444">
-          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-        </svg>
-        {/* HP bar inline */}
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              width: "100%",
-              height: "5px",
-              background: theme.colors.background.panelPrimary,
-              borderRadius: 3,
-              overflow: "hidden",
-              border: `1px solid ${theme.colors.border.default}30`,
-            }}
-          >
-            <div
-              style={{
-                height: "100%",
-                width: `${healthPercent}%`,
-                borderRadius: 3,
-                transition: "width 0.2s ease",
-                background: "linear-gradient(180deg, #f87171, #dc2626)",
-              }}
-            />
-          </div>
-        </div>
-        <span
-          style={{
-            fontSize: "11px",
-            color: theme.colors.text.primary,
-            fontWeight: 700,
-            fontFamily: "var(--font-mono, monospace)",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {health.current}/{health.max}
-        </span>
-        {inCombat && (
-          <span
-            className="combat-pulse"
-            style={{
-              fontSize: "9px",
-              color: theme.colors.state.danger,
-              fontWeight: 600,
-            }}
-          >
-            ⚔
-          </span>
-        )}
-        <span
-          style={{
-            borderLeft: `1px solid ${theme.colors.border.default}25`,
-            paddingLeft: "6px",
-            fontSize: "10px",
-            color: theme.colors.text.muted,
-            whiteSpace: "nowrap",
-          }}
-        >
-          Lvl{" "}
-          <span
-            style={{
-              color: "#f59e0b",
-              fontWeight: 700,
-              fontFamily: "var(--font-mono, monospace)",
-              fontSize: "12px",
-            }}
-          >
-            {combatLevel}
-          </span>
-        </span>
-      </div>
-
-      {/* Target health — only when in combat */}
-      {targetName && targetHealth && !ultraCompactPanel && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "6px",
-            padding: `${p.inner - 1}px ${p.inner}px`,
-            background: `${theme.colors.state.danger}08`,
-            border: `1px solid ${theme.colors.state.danger}30`,
-            borderRadius: theme.borderRadius.sm,
-            flexShrink: 0,
-          }}
-        >
-          <span
-            style={{
-              fontSize: "10px",
-              color: theme.colors.state.danger,
-              fontWeight: 600,
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              maxWidth: "80px",
-            }}
-          >
-            🎯 {targetName}
-          </span>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                width: "100%",
-                height: "4px",
-                background: theme.colors.background.panelPrimary,
-                borderRadius: 2,
-                overflow: "hidden",
-              }}
-            >
-              <div
-                style={{
-                  height: "100%",
-                  width: `${targetHealthPercent}%`,
-                  borderRadius: 2,
-                  background: "linear-gradient(180deg, #f87171, #dc2626)",
-                }}
-              />
-            </div>
-          </div>
-          <span
-            style={{
-              fontSize: "10px",
-              color: theme.colors.state.danger,
-              fontWeight: 700,
-              fontFamily: "var(--font-mono, monospace)",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {targetHealth.current}/{targetHealth.max}
-          </span>
-        </div>
-      )}
-
-      {/* Stats Row */}
-      <CombatStatsRow
-        attackLevel={attackLevel}
-        strengthLevel={strengthLevel}
-        defenseLevel={defenseLevel}
-        isMobile={shouldUseMobileUI}
-      />
-
-      {/* Attack Styles */}
+      {/* Attack Styles — Banner Grid (top) */}
       <div
         style={{
           ...getPanelInsetStyle(theme, {
             emphasis: "strong",
-            radius: theme.borderRadius.md,
+            radius: 4,
             padding: `${p.inner}px`,
           }),
-          flex: 1,
-          minHeight: 0,
           display: "flex",
           flexDirection: "column",
-          overflow: "hidden",
+          overflow: "visible",
+          flexShrink: 0,
         }}
       >
         <div
@@ -1077,7 +1313,7 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
-            marginBottom: 2,
+            marginBottom: compactPanel ? 6 : 8,
             flexShrink: 0,
           }}
         >
@@ -1097,7 +1333,7 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
             <span
               style={{
                 padding: "2px 5px",
-                borderRadius: theme.borderRadius.sm,
+                borderRadius: 4,
                 background: "#8b5cf618",
                 border: "1px solid #8b5cf633",
                 fontSize: "8px",
@@ -1114,62 +1350,222 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
         <div
           style={{
             display: "flex",
-            flexDirection: "column",
-            gap: "2px",
+            gap: compactPanel ? "4px" : "6px",
             width: "100%",
-            flex: 1,
-            minHeight: 0,
-            overflowY: "auto",
+            marginTop: compactPanel ? 14 : 17,
+            justifyContent: "center",
           }}
         >
           {styles.map((s) => (
-            <DraggableCombatStyleButton
+            <CombatStyleBanner
               key={s.id}
               style={s}
               isActive={style === s.id}
               disabled={cooldown > 0}
-              isMobile={shouldUseMobileUI}
+              isMobile={compactPanel}
               onClick={() => changeStyle(s.id)}
               theme={theme}
             />
           ))}
         </div>
-      </div>
 
-      {cooldown > 0 && (
+        {cooldown > 0 && (
+          <div
+            style={{
+              textAlign: "center",
+              fontSize: "9px",
+              color: theme.colors.state.warning,
+              background: `${theme.colors.state.warning}10`,
+              padding: "2px 5px",
+              borderRadius: 4,
+              border: `1px solid ${theme.colors.state.warning}25`,
+              marginTop: compactPanel ? 4 : 6,
+            }}
+          >
+            Style change in {Math.ceil(cooldown / 1000)}s
+          </div>
+        )}
+
+        {/* HP + Combat Level */}
         <div
           style={{
-            textAlign: "center",
-            fontSize: "9px",
-            color: theme.colors.state.warning,
-            background: `${theme.colors.state.warning}10`,
-            padding: "2px 5px",
-            borderRadius: theme.borderRadius.sm,
-            border: `1px solid ${theme.colors.state.warning}25`,
-            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            padding: `${p.inner}px`,
+            marginTop: compactPanel ? 16 : 22,
+            background:
+              theme.name === "hyperscape"
+                ? "linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(0, 0, 0, 0.12) 100%)"
+                : theme.colors.slot.filled,
+            border: inCombat
+              ? `1px solid ${theme.colors.state.danger}50`
+              : `1px solid ${theme.colors.border.default}35`,
+            borderRadius: 4,
           }}
         >
-          Style change in {Math.ceil(cooldown / 1000)}s
+          <svg width={12} height={12} viewBox="0 0 24 24" fill="#ef4444">
+            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+          </svg>
+          {/* HP bar inline */}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                width: "100%",
+                height: "5px",
+                background: theme.colors.background.panelPrimary,
+                borderRadius: 3,
+                overflow: "hidden",
+                border: `1px solid ${theme.colors.border.default}30`,
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${healthPercent}%`,
+                  borderRadius: 3,
+                  transition: "width 0.2s ease",
+                  background: "linear-gradient(180deg, #f87171, #dc2626)",
+                }}
+              />
+            </div>
+          </div>
+          <span
+            style={{
+              fontSize: "11px",
+              color: theme.colors.text.primary,
+              fontWeight: 700,
+              fontFamily: "var(--font-mono, monospace)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {health.current}/{health.max}
+          </span>
+          {inCombat && (
+            <span
+              className="combat-pulse"
+              style={{
+                fontSize: "9px",
+                color: theme.colors.state.danger,
+                fontWeight: 600,
+              }}
+            >
+              ⚔
+            </span>
+          )}
+          <span
+            style={{
+              borderLeft: `1px solid ${theme.colors.border.default}25`,
+              paddingLeft: "6px",
+              fontSize: "10px",
+              color: theme.colors.text.muted,
+              whiteSpace: "nowrap",
+            }}
+          >
+            Lvl{" "}
+            <span
+              style={{
+                color: "#f59e0b",
+                fontWeight: 700,
+                fontFamily: "var(--font-mono, monospace)",
+                fontSize: "12px",
+              }}
+            >
+              {combatLevel}
+            </span>
+          </span>
         </div>
-      )}
 
-      {/* Auto Retaliate — compact single row */}
+        {/* Target health — only when in combat */}
+        {targetName && targetHealth && !ultraCompactPanel && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              padding: `${p.inner - 1}px ${p.inner}px`,
+              marginTop: compactPanel ? 3 : 4,
+              background: `${theme.colors.state.danger}08`,
+              border: `1px solid ${theme.colors.state.danger}30`,
+              borderRadius: 4,
+            }}
+          >
+            <span
+              style={{
+                fontSize: "10px",
+                color: theme.colors.state.danger,
+                fontWeight: 600,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                maxWidth: "80px",
+              }}
+            >
+              🎯 {targetName}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  width: "100%",
+                  height: "4px",
+                  background: theme.colors.background.panelPrimary,
+                  borderRadius: 2,
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${targetHealthPercent}%`,
+                    borderRadius: 2,
+                    background: "linear-gradient(180deg, #f87171, #dc2626)",
+                  }}
+                />
+              </div>
+            </div>
+            <span
+              style={{
+                fontSize: "10px",
+                color: theme.colors.state.danger,
+                fontWeight: 700,
+                fontFamily: "var(--font-mono, monospace)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {targetHealth.current}/{targetHealth.max}
+            </span>
+          </div>
+        )}
+
+        {/* Stats Row */}
+        <CombatStatsRow
+          attackLevel={attackLevel}
+          strengthLevel={strengthLevel}
+          defenseLevel={defenseLevel}
+          isMobile={shouldUseMobileUI}
+        />
+      </div>
+
+      {/* Spacer to push auto-retaliate to bottom */}
+      <div style={{ flex: 1 }} />
+
+      {/* Auto Retaliate — pinned to bottom */}
       <button
         onClick={toggleAutoRetaliate}
         aria-pressed={autoRetaliate}
         className="focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-400/50"
         style={{
-          padding: "4px 6px",
+          padding: `${PANEL_PADDING}px 6px`,
           cursor: "pointer",
           transition: "all 0.1s ease",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           touchAction: "manipulation",
-          borderRadius: theme.borderRadius.sm,
+          borderRadius: 4,
           ...getInteractiveTileStyle(theme, {
             active: autoRetaliate,
-            radius: theme.borderRadius.sm,
+            radius: 4,
             accentColor: autoRetaliate
               ? theme.colors.state.success
               : theme.colors.accent.secondary,

--- a/packages/client/src/game/panels/CombatPanel.tsx
+++ b/packages/client/src/game/panels/CombatPanel.tsx
@@ -510,7 +510,8 @@ const CombatStyleBanner = ({
     <div
       ref={setNodeRef}
       style={{
-        flex: 1,
+        flex: "0 0 calc((100% - 3 * (var(--banner-gap))) / 4)",
+        maxWidth: "calc((100% - 3 * (var(--banner-gap))) / 4)",
         minWidth: 0,
         position: "relative",
         opacity: disabled ? 0.5 : isDragging ? 0.6 : 1,
@@ -1348,13 +1349,16 @@ export function CombatPanel({ world, stats, equipment }: CombatPanelProps) {
           )}
         </div>
         <div
-          style={{
-            display: "flex",
-            gap: compactPanel ? "4px" : "6px",
-            width: "100%",
-            marginTop: compactPanel ? 14 : 17,
-            justifyContent: "center",
-          }}
+          style={
+            {
+              display: "flex",
+              gap: compactPanel ? "4px" : "6px",
+              width: "100%",
+              marginTop: compactPanel ? 14 : 17,
+              justifyContent: "center",
+              "--banner-gap": compactPanel ? "4px" : "6px",
+            } as React.CSSProperties
+          }
         >
           {styles.map((s) => (
             <CombatStyleBanner

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -657,8 +657,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
 
   const renderEquipmentGrid = (isMobile: boolean) => {
     const slotWidth = isMobile ? 34 : 38;
-    const slotHeight = isMobile ? 36 : 40;
-    const portraitWidth = isMobile ? 68 : 80;
+    const slotHeight = isMobile ? 34 : 38;
+    const portraitWidth = isMobile ? 66 : 78;
     const gap = isMobile ? 2 : 3;
     const padding = isMobile ? 2 : 3;
 

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -70,15 +70,17 @@ function UtilityButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex items-center justify-center rounded transition-all duration-150 hover:scale-105 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-2 focus-visible:outline-none"
+      className="flex h-10 w-10 items-center justify-center rounded-[10px] transition-all duration-150 hover:scale-[1.03] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
       title={label}
       style={{
-        background: `${theme.colors.background.tertiary}80`,
-        border: `1px solid ${theme.colors.border.default}60`,
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+        background:
+          "linear-gradient(180deg, rgba(73, 62, 54, 0.92) 0%, rgba(45, 37, 34, 0.96) 100%)",
+        border: `1px solid ${theme.colors.border.default}66`,
+        boxShadow:
+          "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 12px rgba(0,0,0,0.18)",
       }}
     >
-      <div className="w-5 h-5" style={{ color: theme.colors.accent.primary }}>
+      <div className="h-5 w-5" style={{ color: theme.colors.accent.primary }}>
         {icon}
       </div>
     </button>
@@ -605,17 +607,17 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotSize = isMobile ? MOBILE_EQUIPMENT.slotHeight : 72;
-    const gap = isMobile ? MOBILE_EQUIPMENT.gap : 8;
-    const padding = isMobile ? MOBILE_EQUIPMENT.padding : 10;
-    const portraitMin = isMobile ? 96 : 128;
+    const slotSize = isMobile ? 42 : 46;
+    const centerMin = isMobile ? 24 : 32;
+    const gap = isMobile ? 4 : 5;
+    const padding = isMobile ? 5 : 6;
 
     return (
       <div
         data-equipment-grid="paperdoll"
         className="grid h-full"
         style={{
-          gridTemplateColumns: `${slotSize}px minmax(0, 1fr) minmax(0, 1fr) ${slotSize}px`,
+          gridTemplateColumns: `${slotSize}px minmax(${centerMin}px, 1fr) minmax(${centerMin}px, 1fr) ${slotSize}px`,
           gridTemplateRows: `repeat(5, ${slotSize}px)`,
           gridTemplateAreas: `
           "cape portrait portrait ammo"
@@ -662,8 +664,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         className="flex flex-col h-full overflow-hidden"
         style={{
           ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-          padding: shouldUseMobileUI ? "6px" : `${theme.spacing.xs}px`,
-          gap: shouldUseMobileUI ? "6px" : `${theme.spacing.xs}px`,
+          padding: shouldUseMobileUI ? "5px" : "6px",
+          gap: shouldUseMobileUI ? "5px" : "6px",
           border: "none",
           borderRadius: 0,
           boxShadow: "none",
@@ -676,7 +678,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
               "linear-gradient(180deg, rgba(38, 31, 29, 0.98) 0%, rgba(20, 17, 18, 0.99) 100%)",
             border: `1px solid ${theme.colors.border.default}70`,
             borderRadius: `${theme.borderRadius.lg}px`,
-            padding: shouldUseMobileUI ? 0 : `${theme.spacing.sm}px`,
+            padding: shouldUseMobileUI ? 0 : "6px",
             boxShadow:
               "0 12px 30px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.24)",
           }}
@@ -687,13 +689,13 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         {shouldUseMobileUI ? (
           <>
             <div
-              className="flex justify-center gap-4 py-1.5"
+              className="flex justify-center gap-3 py-1"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "11px",
+                fontSize: "10px",
                 boxShadow: theme.shadows.sm,
               }}
             >
@@ -709,7 +711,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
             </div>
 
             <div
-              className="flex items-center justify-center gap-2 px-3 py-1.5"
+              className="flex items-center gap-2 px-3 py-1.5"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
@@ -733,13 +735,13 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         ) : (
           <>
             <div
-              className="flex justify-center gap-4 py-1"
+              className="flex justify-center gap-3 py-1"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "11px",
+                fontSize: "10px",
                 boxShadow: theme.shadows.sm,
               }}
             >
@@ -755,7 +757,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
             </div>
 
             <div
-              className="flex justify-between px-1 py-1.5"
+              className="flex items-center gap-2 px-3 py-1.5"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -5,8 +5,11 @@ import {
   useThemeStore,
   useMobileLayout,
 } from "@/ui";
-import { getPanelSurfaceStyle } from "@/ui/theme/themes";
-import { MOBILE_EQUIPMENT } from "../../constants";
+import {
+  getInteractiveTileStyle,
+  getPanelInsetStyle,
+  getPanelSurfaceStyle,
+} from "@/ui/theme/themes";
 import { useContextMenuState } from "../../hooks";
 import {
   EquipmentSlotName,
@@ -71,16 +74,14 @@ function UtilityButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex items-center justify-center rounded-[9px] transition-all duration-150 hover:scale-[1.03] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
+      className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
       title={label}
       style={{
-        width: compact ? 36 : 40,
-        height: compact ? 36 : 40,
-        background:
-          "linear-gradient(180deg, rgba(73, 62, 54, 0.92) 0%, rgba(45, 37, 34, 0.96) 100%)",
-        border: `1px solid ${theme.colors.border.default}66`,
-        boxShadow:
-          "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 12px rgba(0,0,0,0.18)",
+        width: compact ? 30 : 32,
+        height: compact ? 30 : 32,
+        ...getInteractiveTileStyle(theme, {
+          radius: compact ? 8 : 9,
+        }),
       }}
     >
       <div
@@ -119,6 +120,7 @@ function DroppableEquipmentSlot({
 }: DroppableEquipmentSlotProps) {
   const theme = useThemeStore((s) => s.theme);
   const { shouldUseMobileUI } = useMobileLayout();
+  const [isHovered, setIsHovered] = useState(false);
   const { isOver, setNodeRef } = useDroppable({
     id: `equipment-${slot.key}`,
     data: { slot: slot.key },
@@ -157,6 +159,14 @@ function DroppableEquipmentSlot({
   const slotTitle = slot.item
     ? `${slot.item.name} (${slot.label})`
     : `${slot.label} (empty)`;
+  const invalidDrop = isOver && !isValidDrop;
+  const validDrop = isOver && isValidDrop;
+  const baseTileStyle = getInteractiveTileStyle(theme, {
+    hovered: isHovered && !validDrop && !invalidDrop,
+    dropTarget: validDrop,
+    radius: shouldUseMobileUI ? 10 : 12,
+    accentColor: theme.colors.accent.primary,
+  });
 
   return (
     <button
@@ -172,6 +182,7 @@ function DroppableEquipmentSlot({
       }
       onClick={() => onSlotClick(slot)}
       onMouseEnter={(e) => {
+        setIsHovered(true);
         if (slot.item) {
           onHoverStart(slot, { x: e.clientX, y: e.clientY });
         }
@@ -181,7 +192,11 @@ function DroppableEquipmentSlot({
           onHoverMove({ x: e.clientX, y: e.clientY });
         }
       }}
-      onMouseLeave={() => onHoverEnd()}
+      onBlur={() => setIsHovered(false)}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        onHoverEnd();
+      }}
       onContextMenu={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -231,38 +246,39 @@ function DroppableEquipmentSlot({
       }}
       className="w-full h-full rounded-[14px] transition-all duration-150 cursor-pointer group relative overflow-hidden focus-visible:outline-none"
       style={{
-        background:
-          isOver && isValidDrop
-            ? "rgba(242, 208, 138, 0.18)"
-            : isOver && !isValidDrop
-              ? "rgba(220, 80, 80, 0.18)"
-              : isDraggingInventoryItem && isValidDrop
-                ? "rgba(242, 208, 138, 0.1)"
-                : isEmpty
-                  ? "linear-gradient(180deg, rgba(21, 19, 21, 0.96) 0%, rgba(12, 11, 13, 0.98) 100%)"
-                  : "linear-gradient(180deg, rgba(29, 25, 23, 0.98) 0%, rgba(17, 15, 16, 0.98) 100%)",
-        borderWidth: "1px",
-        borderStyle: isOver
-          ? "solid"
-          : isDraggingInventoryItem && isValidDrop
-            ? "dashed"
-            : "solid",
-        borderColor:
-          isOver && isValidDrop
-            ? "rgba(100, 180, 100, 0.7)"
-            : isOver && !isValidDrop
-              ? "rgba(180, 80, 80, 0.7)"
-              : isDraggingInventoryItem && isValidDrop
-                ? "rgba(180, 160, 100, 0.5)"
-                : "rgba(112, 88, 56, 0.34)",
-        boxShadow:
-          isOver && isValidDrop
-            ? "inset 0 0 8px rgba(100, 180, 100, 0.3)"
-            : isOver && !isValidDrop
-              ? "inset 0 0 8px rgba(180, 80, 80, 0.3)"
+        ...baseTileStyle,
+        background: invalidDrop
+          ? `linear-gradient(180deg, ${theme.colors.state.danger}20 0%, rgba(22, 26, 31, 0.98) 100%)`
+          : validDrop
+            ? baseTileStyle.background
+            : isDraggingInventoryItem && isValidDrop
+              ? `linear-gradient(180deg, ${theme.colors.accent.primary}14 0%, rgba(22, 26, 31, 0.99) 100%)`
               : isEmpty
-                ? "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 18px rgba(0,0,0,0.25), 0 6px 12px rgba(0,0,0,0.14)"
-                : "inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -10px 18px rgba(0,0,0,0.2), 0 8px 14px rgba(0,0,0,0.18)",
+                ? "linear-gradient(180deg, rgba(255,255,255,0.022) 0%, rgba(22,26,31,0.99) 100%)"
+                : "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(26,30,36,0.99) 100%)",
+        borderWidth: "1px",
+        borderStyle:
+          validDrop || invalidDrop
+            ? "solid"
+            : isDraggingInventoryItem && isValidDrop
+              ? "dashed"
+              : "solid",
+        borderColor: invalidDrop
+          ? `${theme.colors.state.danger}99`
+          : validDrop
+            ? theme.colors.border.hover
+            : isDraggingInventoryItem && isValidDrop
+              ? `${theme.colors.accent.primary}7a`
+              : isEmpty
+                ? `${theme.colors.border.default}55`
+                : `${theme.colors.border.default}80`,
+        boxShadow: invalidDrop
+          ? `inset 0 0 8px ${theme.colors.state.danger}26`
+          : validDrop
+            ? `0 0 10px ${theme.colors.accent.primary}12, inset 0 1px 0 rgba(255,255,255,0.05)`
+            : isEmpty
+              ? "inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -8px 12px rgba(0,0,0,0.14)"
+              : "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 14px rgba(0,0,0,0.16)",
         outline: "none",
       }}
     >
@@ -277,8 +293,8 @@ function DroppableEquipmentSlot({
       <div
         className="absolute inset-x-[16%] top-[10%] bottom-[12%] rounded-[12px] pointer-events-none"
         style={{
-          border: `1px solid ${isEmpty ? "rgba(152, 124, 78, 0.18)" : "rgba(202, 168, 108, 0.22)"}`,
-          opacity: isEmpty ? 0.45 : 0.82,
+          border: `1px solid ${isEmpty ? `${theme.colors.border.default}2e` : `${theme.colors.border.hover}44`}`,
+          opacity: isEmpty ? 0.3 : 0.55,
         }}
       />
 
@@ -293,9 +309,9 @@ function DroppableEquipmentSlot({
           <div
             className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
             style={{
-              width: shouldUseMobileUI ? "18px" : "22px",
-              height: shouldUseMobileUI ? "18px" : "22px",
-              color: "rgba(190, 164, 111, 0.34)",
+              width: shouldUseMobileUI ? "14px" : "16px",
+              height: shouldUseMobileUI ? "14px" : "16px",
+              color: `${theme.colors.text.muted}aa`,
             }}
           >
             {slot.icon}
@@ -304,14 +320,14 @@ function DroppableEquipmentSlot({
           <div
             className="transition-transform duration-150 group-hover:scale-105"
             style={{
-              width: shouldUseMobileUI ? "20px" : "24px",
-              height: shouldUseMobileUI ? "20px" : "24px",
+              width: shouldUseMobileUI ? "18px" : "20px",
+              height: shouldUseMobileUI ? "18px" : "20px",
               filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
             }}
           >
             <ItemIcon
               itemId={slot.item!.id}
-              size={shouldUseMobileUI ? 20 : 24}
+              size={shouldUseMobileUI ? 18 : 20}
             />
           </div>
         )}
@@ -331,9 +347,9 @@ function DroppableEquipmentSlot({
           className="absolute bottom-1.5 right-1.5 min-w-[18px] rounded-full px-1 text-center font-bold"
           style={{
             fontSize: shouldUseMobileUI ? "8px" : "9px",
-            color: "#f2d08a",
-            background: "rgba(15, 12, 11, 0.78)",
-            border: "1px solid rgba(181, 145, 85, 0.4)",
+            color: theme.colors.text.primary,
+            background: "rgba(17, 20, 25, 0.86)",
+            border: `1px solid ${theme.colors.border.hover}`,
             textShadow: "0 1px 2px rgba(0, 0, 0, 0.9)",
             lineHeight: shouldUseMobileUI ? "14px" : "15px",
           }}
@@ -594,6 +610,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   const renderSlotCell = (
     slotName: string,
     isMobile: boolean,
+    slotSize: number,
     area?: string,
   ) => (
     <div
@@ -601,7 +618,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
       className={isMobile ? undefined : "w-full h-full"}
       style={{
         gridArea: area,
-        height: isMobile ? MOBILE_EQUIPMENT.slotHeight : undefined,
+        height: isMobile ? slotSize : undefined,
         containerType: "size",
       }}
     >
@@ -617,10 +634,10 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotSize = isMobile ? 36 : 38;
-    const centerMin = isMobile ? 20 : 28;
-    const gap = 4;
-    const padding = 4;
+    const slotSize = isMobile ? 30 : 32;
+    const centerMin = isMobile ? 52 : 60;
+    const gap = isMobile ? 3 : 4;
+    const padding = isMobile ? 3 : 4;
 
     return (
       <div
@@ -647,7 +664,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotSize * 4 + gap * 3 + (isMobile ? 4 : 8),
+            minHeight: slotSize * 4 + gap * 3 + (isMobile ? 2 : 4),
           }}
         >
           <EquipmentPaperdollPortrait
@@ -659,7 +676,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         </div>
 
         {PAPERDOLL_PLACEMENTS.map((placement) =>
-          renderSlotCell(placement.key, isMobile, placement.area),
+          renderSlotCell(placement.key, isMobile, slotSize, placement.area),
         )}
 
         <div style={{ gridArea: "empty" }} />
@@ -683,38 +700,45 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         <div
           className="flex-1 relative overflow-hidden"
           style={{
-            background:
-              "linear-gradient(180deg, rgba(38, 31, 29, 0.98) 0%, rgba(20, 17, 18, 0.99) 100%)",
-            border: `1px solid ${theme.colors.border.default}70`,
-            borderRadius: `${theme.borderRadius.lg}px`,
+            ...getPanelInsetStyle(theme, {
+              emphasis: "strong",
+              radius: theme.borderRadius.lg,
+            }),
             padding: shouldUseMobileUI ? 0 : "4px",
             boxShadow:
-              "0 12px 30px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.24)",
+              "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.18)",
           }}
         >
           {renderEquipmentGrid(shouldUseMobileUI)}
         </div>
 
         <div
-          className="flex justify-center gap-4 py-1"
+          className="flex justify-center gap-3"
           style={{
-            background:
-              "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
-            borderRadius: `${theme.borderRadius.md}px`,
-            border: `1px solid ${theme.colors.border.default}66`,
-            fontSize: "9px",
-            boxShadow: theme.shadows.sm,
+            ...getPanelInsetStyle(theme, {
+              emphasis: "normal",
+              radius: theme.borderRadius.md,
+            }),
+            padding: shouldUseMobileUI ? "3px 6px" : "4px 8px",
+            fontSize: shouldUseMobileUI ? "9px" : "10px",
+            lineHeight: 1,
           }}
         >
-          <span style={{ color: "#cb6c67" }}>{totalBonuses.attack}</span>
-          <span style={{ color: "#5ca97f" }}>{totalBonuses.defense}</span>
-          <span style={{ color: "#5d8fcb" }}>{totalBonuses.strength}</span>
+          <span style={{ color: theme.colors.status.hp }}>
+            {totalBonuses.attack}
+          </span>
+          <span style={{ color: theme.colors.status.energy }}>
+            {totalBonuses.defense}
+          </span>
+          <span style={{ color: theme.colors.status.prayer }}>
+            {totalBonuses.strength}
+          </span>
         </div>
 
         <div
-          className="flex items-center gap-2 px-1"
+          className="flex items-center gap-1.5 px-0.5"
           style={{
-            minHeight: shouldUseMobileUI ? 36 : 40,
+            minHeight: shouldUseMobileUI ? 30 : 32,
           }}
         >
           <UtilityButton

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -661,6 +661,9 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
     const portraitWidth = isMobile ? 66 : 78;
     const gap = isMobile ? 2 : 3;
     const padding = isMobile ? 2 : 3;
+    const portraitHeight = isMobile
+      ? slotHeight * 4 + gap * 3 + 6
+      : slotHeight * 4 + gap * 3 + 10;
 
     return (
       <div
@@ -688,7 +691,9 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotHeight * 5 + gap * 4,
+            height: portraitHeight,
+            minHeight: portraitHeight,
+            alignSelf: "center",
           }}
         >
           <EquipmentPaperdollPortrait

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -695,101 +695,41 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           {renderEquipmentGrid(shouldUseMobileUI)}
         </div>
 
-        {shouldUseMobileUI ? (
-          <>
-            <div
-              className="flex justify-center gap-3 py-1"
-              style={{
-                background:
-                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
-                borderRadius: `${theme.borderRadius.md}px`,
-                border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "9px",
-                boxShadow: theme.shadows.sm,
-              }}
-            >
-              <span style={{ color: theme.colors.state.danger }}>
-                ⚔️ {totalBonuses.attack}
-              </span>
-              <span style={{ color: theme.colors.state.success }}>
-                🛡️ {totalBonuses.defense}
-              </span>
-              <span style={{ color: theme.colors.state.warning }}>
-                💪 {totalBonuses.strength}
-              </span>
-            </div>
+        <div
+          className="flex justify-center gap-4 py-1"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
+            borderRadius: `${theme.borderRadius.md}px`,
+            border: `1px solid ${theme.colors.border.default}66`,
+            fontSize: "9px",
+            boxShadow: theme.shadows.sm,
+          }}
+        >
+          <span style={{ color: "#cb6c67" }}>{totalBonuses.attack}</span>
+          <span style={{ color: "#5ca97f" }}>{totalBonuses.defense}</span>
+          <span style={{ color: "#5d8fcb" }}>{totalBonuses.strength}</span>
+        </div>
 
-            <div
-              className="flex items-center gap-2 px-2 py-1"
-              style={{
-                background:
-                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
-                borderRadius: `${theme.borderRadius.sm}px`,
-                border: `1px solid ${theme.colors.border.default}66`,
-                boxShadow: `${theme.shadows.sm}, inset 1px 1px 3px rgba(0, 0, 0, 0.3)`,
-              }}
-            >
-              <UtilityButton
-                icon={<StatsIcon className="w-full h-full" />}
-                label="Stats"
-                onClick={handleOpenStats}
-                compact
-              />
-              <UtilityButton
-                icon={<DeathIcon className="w-full h-full" />}
-                label="Death"
-                onClick={handleOpenDeath}
-                compact
-              />
-            </div>
-          </>
-        ) : (
-          <>
-            <div
-              className="flex justify-center gap-3 py-1"
-              style={{
-                background:
-                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
-                borderRadius: `${theme.borderRadius.md}px`,
-                border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "9px",
-                boxShadow: theme.shadows.sm,
-              }}
-            >
-              <span style={{ color: theme.colors.state.danger }}>
-                ⚔️ {totalBonuses.attack}
-              </span>
-              <span style={{ color: theme.colors.state.success }}>
-                🛡️ {totalBonuses.defense}
-              </span>
-              <span style={{ color: theme.colors.state.warning }}>
-                💪 {totalBonuses.strength}
-              </span>
-            </div>
-
-            <div
-              className="flex items-center gap-2 px-2 py-1"
-              style={{
-                background:
-                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
-                borderRadius: `${theme.borderRadius.md}px`,
-                border: `1px solid ${theme.colors.border.default}66`,
-                boxShadow: theme.shadows.sm,
-              }}
-            >
-              <UtilityButton
-                icon={<StatsIcon className="w-full h-full" />}
-                label="Stats"
-                onClick={handleOpenStats}
-              />
-              <UtilityButton
-                icon={<DeathIcon className="w-full h-full" />}
-                label="Death"
-                onClick={handleOpenDeath}
-              />
-            </div>
-          </>
-        )}
+        <div
+          className="flex items-center gap-2 px-1"
+          style={{
+            minHeight: shouldUseMobileUI ? 36 : 40,
+          }}
+        >
+          <UtilityButton
+            icon={<StatsIcon className="w-full h-full" />}
+            label="Stats"
+            onClick={handleOpenStats}
+            compact={shouldUseMobileUI}
+          />
+          <UtilityButton
+            icon={<DeathIcon className="w-full h-full" />}
+            label="Death"
+            onClick={handleOpenDeath}
+            compact={shouldUseMobileUI}
+          />
+        </div>
       </div>
 
       {/* Enhanced hover tooltip - rendered via portal */}

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -77,8 +77,8 @@ function UtilityButton({
       className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
       title={label}
       style={{
-        width: compact ? 34 : 38,
-        height: compact ? 34 : 38,
+        width: compact ? 32 : 36,
+        height: compact ? 32 : 36,
         ...getInteractiveTileStyle(theme, {
           radius: compact ? 9 : 10,
         }),
@@ -87,8 +87,8 @@ function UtilityButton({
       <div
         className="flex items-center justify-center"
         style={{
-          width: compact ? 18 : 22,
-          height: compact ? 18 : 22,
+          width: compact ? 17 : 20,
+          height: compact ? 17 : 20,
           color: theme.colors.accent.primary,
         }}
       >
@@ -656,26 +656,26 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotWidth = isMobile ? 36 : 40;
-    const slotHeight = isMobile ? 42 : 46;
-    const portraitWidth = isMobile ? 44 : 50;
-    const gap = isMobile ? 3 : 4;
-    const padding = isMobile ? 3 : 4;
+    const slotWidth = isMobile ? 34 : 38;
+    const slotHeight = isMobile ? 38 : 42;
+    const portraitWidth = isMobile ? 72 : 84;
+    const gap = isMobile ? 2 : 3;
+    const padding = isMobile ? 2 : 3;
 
     return (
       <div
         data-equipment-grid="paperdoll"
         className="grid h-full"
         style={{
-          gridTemplateColumns: `${slotWidth}px minmax(${portraitWidth}px, 1fr) minmax(${portraitWidth}px, 1fr) ${slotWidth}px`,
+          gridTemplateColumns: `${slotWidth}px ${isMobile ? 4 : 6}px minmax(${portraitWidth}px, 1fr) ${isMobile ? 4 : 6}px ${slotWidth}px`,
           gridTemplateRows: `repeat(5, ${slotHeight}px) ${slotHeight}px`,
           gridTemplateAreas: `
-          "cape portrait portrait ammo"
-          "head portrait portrait amulet"
-          "body portrait portrait ring"
-          "legs portrait portrait gloves"
-          "boots portrait portrait empty"
-          ". weapon shield ."
+          "cape . portrait . ammo"
+          "head . portrait . amulet"
+          "body . portrait . ring"
+          "legs . portrait . gloves"
+          "boots . portrait . empty"
+          ". weapon portrait shield ."
         `,
           gap,
           padding,
@@ -688,7 +688,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotHeight * 5 + gap * 4,
+            minHeight: slotHeight * 6 + gap * 5,
           }}
         >
           <EquipmentPaperdollPortrait
@@ -715,8 +715,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         className="flex flex-col h-full overflow-hidden"
         style={{
           ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-          padding: "4px",
-          gap: "4px",
+          padding: shouldUseMobileUI ? "3px" : "4px",
+          gap: shouldUseMobileUI ? "3px" : "4px",
           border: "none",
           borderRadius: 0,
           boxShadow: "none",
@@ -729,7 +729,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
               emphasis: "strong",
               radius: theme.borderRadius.lg,
             }),
-            padding: shouldUseMobileUI ? 0 : "4px",
+            padding: shouldUseMobileUI ? 0 : "3px",
             boxShadow:
               "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.18)",
           }}
@@ -744,8 +744,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
               emphasis: "normal",
               radius: theme.borderRadius.md,
             }),
-            padding: shouldUseMobileUI ? "3px 6px" : "4px 8px",
-            fontSize: shouldUseMobileUI ? "9px" : "10px",
+            padding: shouldUseMobileUI ? "2px 6px" : "4px 8px",
+            fontSize: shouldUseMobileUI ? "8px" : "10px",
             lineHeight: 1,
           }}
         >
@@ -763,7 +763,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         <div
           className="flex items-center gap-1.5 px-0.5"
           style={{
-            minHeight: shouldUseMobileUI ? 30 : 32,
+            minHeight: shouldUseMobileUI ? 28 : 32,
           }}
         >
           <UtilityButton

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -657,7 +657,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
 
   const renderEquipmentGrid = (isMobile: boolean) => {
     const slotWidth = isMobile ? 34 : 38;
-    const slotHeight = isMobile ? 34 : 38;
+    const slotHeight = isMobile ? 32 : 36;
     const portraitWidth = isMobile ? 66 : 78;
     const gap = isMobile ? 2 : 3;
     const padding = isMobile ? 2 : 3;

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -62,6 +62,7 @@ function UtilityButton({
   label,
   onClick,
   disabled,
+  compact = false,
 }: UtilityButtonProps & { compact?: boolean }) {
   const theme = useThemeStore((s) => s.theme);
 
@@ -70,9 +71,11 @@ function UtilityButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex h-10 w-10 items-center justify-center rounded-[10px] transition-all duration-150 hover:scale-[1.03] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
+      className="flex items-center justify-center rounded-[9px] transition-all duration-150 hover:scale-[1.03] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
       title={label}
       style={{
+        width: compact ? 36 : 40,
+        height: compact ? 36 : 40,
         background:
           "linear-gradient(180deg, rgba(73, 62, 54, 0.92) 0%, rgba(45, 37, 34, 0.96) 100%)",
         border: `1px solid ${theme.colors.border.default}66`,
@@ -80,7 +83,14 @@ function UtilityButton({
           "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 12px rgba(0,0,0,0.18)",
       }}
     >
-      <div className="h-5 w-5" style={{ color: theme.colors.accent.primary }}>
+      <div
+        className="flex items-center justify-center"
+        style={{
+          width: compact ? 18 : 20,
+          height: compact ? 18 : 20,
+          color: theme.colors.accent.primary,
+        }}
+      >
         {icon}
       </div>
     </button>
@@ -283,8 +293,8 @@ function DroppableEquipmentSlot({
           <div
             className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
             style={{
-              width: shouldUseMobileUI ? "22px" : "28px",
-              height: shouldUseMobileUI ? "22px" : "28px",
+              width: shouldUseMobileUI ? "18px" : "22px",
+              height: shouldUseMobileUI ? "18px" : "22px",
               color: "rgba(190, 164, 111, 0.34)",
             }}
           >
@@ -294,14 +304,14 @@ function DroppableEquipmentSlot({
           <div
             className="transition-transform duration-150 group-hover:scale-105"
             style={{
-              width: shouldUseMobileUI ? "24px" : "32px",
-              height: shouldUseMobileUI ? "24px" : "32px",
+              width: shouldUseMobileUI ? "20px" : "24px",
+              height: shouldUseMobileUI ? "20px" : "24px",
               filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
             }}
           >
             <ItemIcon
               itemId={slot.item!.id}
-              size={shouldUseMobileUI ? 24 : 32}
+              size={shouldUseMobileUI ? 20 : 24}
             />
           </div>
         )}
@@ -607,10 +617,10 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotSize = isMobile ? 42 : 46;
-    const centerMin = isMobile ? 24 : 32;
-    const gap = isMobile ? 4 : 5;
-    const padding = isMobile ? 5 : 6;
+    const slotSize = isMobile ? 36 : 38;
+    const centerMin = isMobile ? 20 : 28;
+    const gap = 4;
+    const padding = 4;
 
     return (
       <div
@@ -629,6 +639,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           gap,
           padding,
           alignItems: "stretch",
+          justifyItems: "stretch",
         }}
       >
         <div
@@ -636,9 +647,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: isMobile
-              ? slotSize * 4 + gap * 3
-              : slotSize * 4 + gap * 3,
+            minHeight: slotSize * 4 + gap * 3 + (isMobile ? 4 : 8),
           }}
         >
           <EquipmentPaperdollPortrait
@@ -664,8 +673,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         className="flex flex-col h-full overflow-hidden"
         style={{
           ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-          padding: shouldUseMobileUI ? "5px" : "6px",
-          gap: shouldUseMobileUI ? "5px" : "6px",
+          padding: "4px",
+          gap: "4px",
           border: "none",
           borderRadius: 0,
           boxShadow: "none",
@@ -678,7 +687,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
               "linear-gradient(180deg, rgba(38, 31, 29, 0.98) 0%, rgba(20, 17, 18, 0.99) 100%)",
             border: `1px solid ${theme.colors.border.default}70`,
             borderRadius: `${theme.borderRadius.lg}px`,
-            padding: shouldUseMobileUI ? 0 : "6px",
+            padding: shouldUseMobileUI ? 0 : "4px",
             boxShadow:
               "0 12px 30px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.24)",
           }}
@@ -695,7 +704,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "10px",
+                fontSize: "9px",
                 boxShadow: theme.shadows.sm,
               }}
             >
@@ -711,7 +720,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
             </div>
 
             <div
-              className="flex items-center gap-2 px-3 py-1.5"
+              className="flex items-center gap-2 px-2 py-1"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
@@ -724,11 +733,13 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
                 icon={<StatsIcon className="w-full h-full" />}
                 label="Stats"
                 onClick={handleOpenStats}
+                compact
               />
               <UtilityButton
                 icon={<DeathIcon className="w-full h-full" />}
                 label="Death"
                 onClick={handleOpenDeath}
+                compact
               />
             </div>
           </>
@@ -741,7 +752,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
-                fontSize: "10px",
+                fontSize: "9px",
                 boxShadow: theme.shadows.sm,
               }}
             >
@@ -757,7 +768,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
             </div>
 
             <div
-              className="flex items-center gap-2 px-3 py-1.5"
+              className="flex items-center gap-2 px-2 py-1"
               style={{
                 background:
                   "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -77,18 +77,18 @@ function UtilityButton({
       className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
       title={label}
       style={{
-        width: compact ? 30 : 32,
-        height: compact ? 30 : 32,
+        width: compact ? 34 : 38,
+        height: compact ? 34 : 38,
         ...getInteractiveTileStyle(theme, {
-          radius: compact ? 8 : 9,
+          radius: compact ? 9 : 10,
         }),
       }}
     >
       <div
         className="flex items-center justify-center"
         style={{
-          width: compact ? 18 : 20,
-          height: compact ? 18 : 20,
+          width: compact ? 18 : 22,
+          height: compact ? 18 : 22,
           color: theme.colors.accent.primary,
         }}
       >
@@ -291,7 +291,7 @@ function DroppableEquipmentSlot({
       />
 
       <div
-        className="absolute inset-x-[16%] top-[10%] bottom-[12%] rounded-[12px] pointer-events-none"
+        className="absolute inset-x-[14%] top-[10%] bottom-[24%] rounded-[12px] pointer-events-none"
         style={{
           border: `1px solid ${isEmpty ? `${theme.colors.border.default}2e` : `${theme.colors.border.hover}44`}`,
           opacity: isEmpty ? 0.3 : 0.55,
@@ -299,38 +299,60 @@ function DroppableEquipmentSlot({
       />
 
       <div
-        className="flex h-full w-full items-center justify-center"
+        className="flex h-full w-full flex-col items-center justify-between"
         style={{
-          paddingTop: shouldUseMobileUI ? 4 : 6,
-          paddingBottom: shouldUseMobileUI ? 4 : 6,
+          paddingTop: shouldUseMobileUI ? 5 : 6,
+          paddingBottom: shouldUseMobileUI ? 4 : 5,
         }}
       >
-        {isEmpty ? (
-          <div
-            className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
-            style={{
-              width: shouldUseMobileUI ? "14px" : "16px",
-              height: shouldUseMobileUI ? "14px" : "16px",
-              color: `${theme.colors.text.muted}aa`,
-            }}
-          >
-            {slot.icon}
-          </div>
-        ) : (
-          <div
-            className="transition-transform duration-150 group-hover:scale-105"
-            style={{
-              width: shouldUseMobileUI ? "18px" : "20px",
-              height: shouldUseMobileUI ? "18px" : "20px",
-              filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
-            }}
-          >
-            <ItemIcon
-              itemId={slot.item!.id}
-              size={shouldUseMobileUI ? 18 : 20}
-            />
-          </div>
-        )}
+        <div
+          className="flex flex-1 items-center justify-center"
+          style={{
+            minHeight: 0,
+          }}
+        >
+          {isEmpty ? (
+            <div
+              className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
+              style={{
+                width: shouldUseMobileUI ? "14px" : "16px",
+                height: shouldUseMobileUI ? "14px" : "16px",
+                color: `${theme.colors.text.muted}aa`,
+              }}
+            >
+              {slot.icon}
+            </div>
+          ) : (
+            <div
+              className="transition-transform duration-150 group-hover:scale-105"
+              style={{
+                width: shouldUseMobileUI ? "18px" : "20px",
+                height: shouldUseMobileUI ? "18px" : "20px",
+                filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
+              }}
+            >
+              <ItemIcon
+                itemId={slot.item!.id}
+                size={shouldUseMobileUI ? 18 : 20}
+              />
+            </div>
+          )}
+        </div>
+
+        <div
+          className="w-full truncate text-center font-semibold uppercase tracking-[0.14em]"
+          style={{
+            fontSize: shouldUseMobileUI ? "6px" : "7px",
+            lineHeight: 1.1,
+            color: isEmpty
+              ? `${theme.colors.text.muted}bf`
+              : theme.colors.text.secondary,
+            textShadow: "0 1px 1px rgba(0,0,0,0.7)",
+            paddingInline: shouldUseMobileUI ? 3 : 4,
+          }}
+        >
+          {slot.label}
+        </div>
       </div>
 
       {!isEmpty && (
@@ -634,24 +656,26 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotSize = isMobile ? 28 : 30;
-    const portraitWidth = isMobile ? 74 : 84;
-    const gap = isMobile ? 2 : 3;
-    const padding = isMobile ? 2 : 3;
+    const slotWidth = isMobile ? 36 : 40;
+    const slotHeight = isMobile ? 42 : 46;
+    const portraitWidth = isMobile ? 44 : 50;
+    const gap = isMobile ? 3 : 4;
+    const padding = isMobile ? 3 : 4;
 
     return (
       <div
         data-equipment-grid="paperdoll"
         className="grid h-full"
         style={{
-          gridTemplateColumns: `${slotSize}px ${slotSize}px minmax(${portraitWidth}px, 1fr) ${slotSize}px ${slotSize}px`,
-          gridTemplateRows: `repeat(5, ${slotSize}px)`,
+          gridTemplateColumns: `${slotWidth}px minmax(${portraitWidth}px, 1fr) minmax(${portraitWidth}px, 1fr) ${slotWidth}px`,
+          gridTemplateRows: `repeat(5, ${slotHeight}px) ${slotHeight}px`,
           gridTemplateAreas: `
-          "cape . portrait . ammo"
-          "head . portrait . amulet"
-          "body . portrait . ring"
-          "legs . portrait . gloves"
-          "boots weapon portrait shield empty"
+          "cape portrait portrait ammo"
+          "head portrait portrait amulet"
+          "body portrait portrait ring"
+          "legs portrait portrait gloves"
+          "boots portrait portrait empty"
+          ". weapon shield ."
         `,
           gap,
           padding,
@@ -664,7 +688,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotSize * 5 + gap * 4,
+            minHeight: slotHeight * 5 + gap * 4,
           }}
         >
           <EquipmentPaperdollPortrait
@@ -677,7 +701,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         </div>
 
         {PAPERDOLL_PLACEMENTS.map((placement) =>
-          renderSlotCell(placement.key, isMobile, slotSize, placement.area),
+          renderSlotCell(placement.key, isMobile, slotHeight, placement.area),
         )}
 
         <div style={{ gridArea: "empty" }} />

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -31,8 +31,6 @@ import {
   CapeIcon,
   AmuletIcon,
   RingIcon,
-  StatsIcon,
-  DeathIcon,
 } from "./equipment/EquipmentIcons";
 import {
   EquipmentTooltip,
@@ -48,55 +46,6 @@ interface EquipmentPanelProps {
 }
 
 type EquipmentSlot = EquipmentSlotData;
-
-// ============================================================================
-// Utility Button Component
-// ============================================================================
-
-interface UtilityButtonProps {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-}
-
-function UtilityButton({
-  icon,
-  label,
-  onClick,
-  disabled,
-  compact = false,
-}: UtilityButtonProps & { compact?: boolean }) {
-  const theme = useThemeStore((s) => s.theme);
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none"
-      title={label}
-      style={{
-        width: compact ? 32 : 36,
-        height: compact ? 32 : 36,
-        ...getInteractiveTileStyle(theme, {
-          radius: compact ? 9 : 10,
-        }),
-      }}
-    >
-      <div
-        className="flex items-center justify-center"
-        style={{
-          width: compact ? 17 : 20,
-          height: compact ? 17 : 20,
-          color: theme.colors.accent.primary,
-        }}
-      >
-        {icon}
-      </div>
-    </button>
-  );
-}
 
 interface DroppableEquipmentSlotProps {
   slot: EquipmentSlot;
@@ -164,7 +113,7 @@ function DroppableEquipmentSlot({
   const baseTileStyle = getInteractiveTileStyle(theme, {
     hovered: isHovered && !validDrop && !invalidDrop,
     dropTarget: validDrop,
-    radius: shouldUseMobileUI ? 10 : 12,
+    radius: 2,
     accentColor: theme.colors.accent.primary,
   });
 
@@ -172,7 +121,6 @@ function DroppableEquipmentSlot({
     <button
       ref={setNodeRef}
       type="button"
-      title={slotTitle}
       data-equipment-slot={slot.key}
       data-slot-empty={isEmpty ? "true" : "false"}
       aria-label={
@@ -183,14 +131,10 @@ function DroppableEquipmentSlot({
       onClick={() => onSlotClick(slot)}
       onMouseEnter={(e) => {
         setIsHovered(true);
-        if (slot.item) {
-          onHoverStart(slot, { x: e.clientX, y: e.clientY });
-        }
+        onHoverStart(slot, { x: e.clientX, y: e.clientY });
       }}
       onMouseMove={(e) => {
-        if (slot.item) {
-          onHoverMove({ x: e.clientX, y: e.clientY });
-        }
+        onHoverMove({ x: e.clientX, y: e.clientY });
       }}
       onBlur={() => setIsHovered(false)}
       onMouseLeave={() => {
@@ -244,18 +188,19 @@ function DroppableEquipmentSlot({
         });
         window.dispatchEvent(evt);
       }}
-      className="w-full h-full rounded-[14px] transition-all duration-150 cursor-pointer group relative overflow-hidden focus-visible:outline-none"
+      className="w-full h-full rounded-[2px] transition-all duration-150 cursor-pointer group relative overflow-hidden focus-visible:outline-none"
       style={{
         ...baseTileStyle,
         background: invalidDrop
-          ? `linear-gradient(180deg, ${theme.colors.state.danger}20 0%, rgba(22, 26, 31, 0.98) 100%)`
+          ? `linear-gradient(180deg, ${theme.colors.state.danger}20 0%, rgba(22, 26, 31, 0.4) 100%)`
           : validDrop
             ? baseTileStyle.background
             : isDraggingInventoryItem && isValidDrop
-              ? `linear-gradient(180deg, ${theme.colors.accent.primary}14 0%, rgba(22, 26, 31, 0.99) 100%)`
+              ? `linear-gradient(180deg, ${theme.colors.accent.primary}14 0%, rgba(22, 26, 31, 0.4) 100%)`
               : isEmpty
-                ? "linear-gradient(180deg, rgba(255,255,255,0.022) 0%, rgba(22,26,31,0.99) 100%)"
-                : "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(26,30,36,0.99) 100%)",
+                ? "linear-gradient(180deg, rgba(255,255,255,0.022) 0%, rgba(22,26,31,0.25) 100%)"
+                : "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(26,30,36,0.25) 100%)",
+        zIndex: 10,
         borderWidth: "1px",
         borderStyle:
           validDrop || invalidDrop
@@ -290,33 +235,24 @@ function DroppableEquipmentSlot({
         }}
       />
 
-      <div
-        className="absolute inset-x-[14%] top-[10%] bottom-[24%] rounded-[12px] pointer-events-none"
-        style={{
-          border: `1px solid ${isEmpty ? `${theme.colors.border.default}2e` : `${theme.colors.border.hover}44`}`,
-          opacity: isEmpty ? 0.3 : 0.55,
-        }}
-      />
-
-      <div
-        className="flex h-full w-full flex-col items-center justify-between"
-        style={{
-          paddingTop: shouldUseMobileUI ? 5 : 6,
-          paddingBottom: shouldUseMobileUI ? 4 : 5,
-        }}
-      >
+      {isEmpty && (
         <div
-          className="flex flex-1 items-center justify-center"
+          className="absolute inset-x-[14%] top-[14%] bottom-[14%] rounded-[2px] pointer-events-none"
           style={{
-            minHeight: 0,
+            border: `1px solid ${theme.colors.border.default}2e`,
+            opacity: 0.3,
           }}
-        >
+        />
+      )}
+
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="flex items-center justify-center">
           {isEmpty ? (
             <div
               className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
               style={{
-                width: shouldUseMobileUI ? "14px" : "16px",
-                height: shouldUseMobileUI ? "14px" : "16px",
+                width: shouldUseMobileUI ? "20px" : "24px",
+                height: shouldUseMobileUI ? "20px" : "24px",
                 color: `${theme.colors.text.muted}aa`,
               }}
             >
@@ -326,38 +262,23 @@ function DroppableEquipmentSlot({
             <div
               className="transition-transform duration-150 group-hover:scale-105"
               style={{
-                width: shouldUseMobileUI ? "18px" : "20px",
-                height: shouldUseMobileUI ? "18px" : "20px",
+                width: shouldUseMobileUI ? "24px" : "28px",
+                height: shouldUseMobileUI ? "24px" : "28px",
                 filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
               }}
             >
               <ItemIcon
                 itemId={slot.item!.id}
-                size={shouldUseMobileUI ? 18 : 20}
+                size={shouldUseMobileUI ? 24 : 28}
               />
             </div>
           )}
-        </div>
-
-        <div
-          className="w-full truncate text-center font-semibold uppercase tracking-[0.14em]"
-          style={{
-            fontSize: shouldUseMobileUI ? "6px" : "7px",
-            lineHeight: 1.1,
-            color: isEmpty
-              ? `${theme.colors.text.muted}bf`
-              : theme.colors.text.secondary,
-            textShadow: "0 1px 1px rgba(0,0,0,0.7)",
-            paddingInline: shouldUseMobileUI ? 3 : 4,
-          }}
-        >
-          {slot.label}
         </div>
       </div>
 
       {!isEmpty && (
         <div
-          className="absolute inset-0 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none"
+          className="absolute inset-0 rounded-[2px] opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none"
           style={{
             background: `radial-gradient(circle at center, ${theme.colors.accent.primary}15 0%, transparent 70%)`,
           }}
@@ -381,7 +302,7 @@ function DroppableEquipmentSlot({
       )}
 
       <div
-        className="absolute inset-[2px] rounded-[12px] pointer-events-none opacity-0 group-focus-visible:opacity-100 transition-opacity duration-150"
+        className="absolute inset-[2px] rounded-[2px] pointer-events-none opacity-0 group-focus-visible:opacity-100 transition-opacity duration-150"
         style={{
           border: `1px solid ${theme.colors.accent.primary}aa`,
           boxShadow: `0 0 0 1px ${theme.colors.accent.primary}22`,
@@ -397,15 +318,15 @@ interface PaperdollSlotPlacement {
 }
 
 const PAPERDOLL_PLACEMENTS: PaperdollSlotPlacement[] = [
+  { area: "ammo", key: EquipmentSlotName.ARROWS },
   { area: "cape", key: EquipmentSlotName.CAPE },
   { area: "head", key: EquipmentSlotName.HELMET },
-  { area: "body", key: EquipmentSlotName.BODY },
-  { area: "legs", key: EquipmentSlotName.LEGS },
-  { area: "boots", key: EquipmentSlotName.BOOTS },
-  { area: "ammo", key: EquipmentSlotName.ARROWS },
   { area: "amulet", key: EquipmentSlotName.AMULET },
+  { area: "body", key: EquipmentSlotName.BODY },
   { area: "ring", key: EquipmentSlotName.RING },
+  { area: "legs", key: EquipmentSlotName.LEGS },
   { area: "gloves", key: EquipmentSlotName.GLOVES },
+  { area: "boots", key: EquipmentSlotName.BOOTS },
   { area: "weapon", key: EquipmentSlotName.WEAPON },
   { area: "shield", key: EquipmentSlotName.SHIELD },
 ];
@@ -658,27 +579,22 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   const renderEquipmentGrid = (isMobile: boolean) => {
     const slotWidth = isMobile ? 34 : 38;
     const slotHeight = isMobile ? 32 : 36;
-    const portraitWidth = isMobile ? 66 : 78;
-    const gap = isMobile ? 2 : 3;
+    const gap = isMobile ? 5 : 8;
     const padding = isMobile ? 2 : 3;
-    const portraitHeight = isMobile
-      ? slotHeight * 4 + gap * 3 + 6
-      : slotHeight * 4 + gap * 3 + 10;
 
     return (
       <div
         data-equipment-grid="paperdoll"
         className="grid h-full"
         style={{
-          gridTemplateColumns: `${slotWidth}px ${isMobile ? 4 : 6}px minmax(${portraitWidth}px, 1fr) ${isMobile ? 4 : 6}px ${slotWidth}px`,
-          gridTemplateRows: `repeat(5, ${slotHeight}px) ${slotHeight}px`,
+          gridTemplateColumns: `${slotWidth}px ${slotWidth}px 1fr ${slotWidth}px ${slotWidth}px`,
+          gridTemplateRows: `repeat(5, ${slotHeight}px)`,
           gridTemplateAreas: `
-          "cape . portrait . ammo"
-          "head . portrait . amulet"
-          "body . portrait . ring"
-          "legs . portrait . gloves"
-          "boots . portrait . empty"
-          ". weapon . shield ."
+          "head . . . cape"
+          "body . . . amulet"
+          "legs . . . ring"
+          "boots . . . gloves"
+          "ammo weapon . shield ."
         `,
           gap,
           padding,
@@ -689,11 +605,12 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         <div
           data-equipment-center="portrait"
           style={{
-            gridArea: "portrait",
+            gridColumn: "1 / -1",
+            gridRow: "1 / -1",
             minWidth: 0,
-            height: portraitHeight,
-            minHeight: portraitHeight,
-            alignSelf: "center",
+            width: "100%",
+            height: "100%",
+            zIndex: 0,
           }}
         >
           <EquipmentPaperdollPortrait
@@ -708,8 +625,6 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         {PAPERDOLL_PLACEMENTS.map((placement) =>
           renderSlotCell(placement.key, isMobile, slotHeight, placement.area),
         )}
-
-        <div style={{ gridArea: "empty" }} />
       </div>
     );
   };
@@ -732,7 +647,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             ...getPanelInsetStyle(theme, {
               emphasis: "strong",
-              radius: theme.borderRadius.lg,
+              radius: 4,
             }),
             padding: shouldUseMobileUI ? 0 : "3px",
             boxShadow:
@@ -743,11 +658,51 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         </div>
 
         <div
+          className="grid grid-cols-2 gap-1.5 px-0.5"
+          style={{
+            minHeight: shouldUseMobileUI ? 24 : 28,
+          }}
+        >
+          <button
+            type="button"
+            onClick={handleOpenStats}
+            className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 focus-visible:outline-none"
+            style={{
+              height: shouldUseMobileUI ? 24 : 28,
+              ...getInteractiveTileStyle(theme, { radius: 2 }),
+              fontSize: shouldUseMobileUI ? "9px" : "10px",
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: theme.colors.accent.primary,
+              textTransform: "uppercase",
+            }}
+          >
+            Stats
+          </button>
+          <button
+            type="button"
+            onClick={handleOpenDeath}
+            className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 focus-visible:outline-none"
+            style={{
+              height: shouldUseMobileUI ? 24 : 28,
+              ...getInteractiveTileStyle(theme, { radius: 2 }),
+              fontSize: shouldUseMobileUI ? "9px" : "10px",
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: theme.colors.accent.primary,
+              textTransform: "uppercase",
+            }}
+          >
+            On Death
+          </button>
+        </div>
+
+        <div
           className="flex justify-center gap-3"
           style={{
             ...getPanelInsetStyle(theme, {
               emphasis: "normal",
-              radius: theme.borderRadius.md,
+              radius: 4,
             }),
             padding: shouldUseMobileUI ? "2px 6px" : "4px 8px",
             fontSize: shouldUseMobileUI ? "8px" : "10px",
@@ -763,26 +718,6 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           <span style={{ color: theme.colors.status.prayer }}>
             {totalBonuses.strength}
           </span>
-        </div>
-
-        <div
-          className="flex items-center gap-1.5 px-0.5"
-          style={{
-            minHeight: shouldUseMobileUI ? 28 : 32,
-          }}
-        >
-          <UtilityButton
-            icon={<StatsIcon className="w-full h-full" />}
-            label="Stats"
-            onClick={handleOpenStats}
-            compact={shouldUseMobileUI}
-          />
-          <UtilityButton
-            icon={<DeathIcon className="w-full h-full" />}
-            label="Death"
-            onClick={handleOpenDeath}
-            compact={shouldUseMobileUI}
-          />
         </div>
       </div>
 

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -657,8 +657,8 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
 
   const renderEquipmentGrid = (isMobile: boolean) => {
     const slotWidth = isMobile ? 34 : 38;
-    const slotHeight = isMobile ? 38 : 42;
-    const portraitWidth = isMobile ? 72 : 84;
+    const slotHeight = isMobile ? 36 : 40;
+    const portraitWidth = isMobile ? 68 : 80;
     const gap = isMobile ? 2 : 3;
     const padding = isMobile ? 2 : 3;
 
@@ -675,7 +675,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           "body . portrait . ring"
           "legs . portrait . gloves"
           "boots . portrait . empty"
-          ". weapon portrait shield ."
+          ". weapon . shield ."
         `,
           gap,
           padding,
@@ -688,7 +688,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotHeight * 6 + gap * 5,
+            minHeight: slotHeight * 5 + gap * 4,
           }}
         >
           <EquipmentPaperdollPortrait

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -634,24 +634,24 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotSize = isMobile ? 30 : 32;
-    const centerMin = isMobile ? 52 : 60;
-    const gap = isMobile ? 3 : 4;
-    const padding = isMobile ? 3 : 4;
+    const slotSize = isMobile ? 28 : 30;
+    const portraitWidth = isMobile ? 74 : 84;
+    const gap = isMobile ? 2 : 3;
+    const padding = isMobile ? 2 : 3;
 
     return (
       <div
         data-equipment-grid="paperdoll"
         className="grid h-full"
         style={{
-          gridTemplateColumns: `${slotSize}px minmax(${centerMin}px, 1fr) minmax(${centerMin}px, 1fr) ${slotSize}px`,
+          gridTemplateColumns: `${slotSize}px ${slotSize}px minmax(${portraitWidth}px, 1fr) ${slotSize}px ${slotSize}px`,
           gridTemplateRows: `repeat(5, ${slotSize}px)`,
           gridTemplateAreas: `
-          "cape portrait portrait ammo"
-          "head portrait portrait amulet"
-          "body portrait portrait ring"
-          "legs portrait portrait gloves"
-          "boots weapon shield empty"
+          "cape . portrait . ammo"
+          "head . portrait . amulet"
+          "body . portrait . ring"
+          "legs . portrait . gloves"
+          "boots weapon portrait shield empty"
         `,
           gap,
           padding,
@@ -664,11 +664,12 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           style={{
             gridArea: "portrait",
             minWidth: 0,
-            minHeight: slotSize * 4 + gap * 3 + (isMobile ? 2 : 4),
+            minHeight: slotSize * 5 + gap * 4,
           }}
         >
           <EquipmentPaperdollPortrait
             world={world}
+            equipment={equipment}
             equipmentSignature={equipmentSignature}
             compact={isMobile}
             className="h-full w-full"

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   useDroppable,
   useDragStore,
@@ -37,6 +37,7 @@ import {
   type EquipmentHoverState,
 } from "./equipment/EquipmentTooltip";
 import { ItemIcon } from "../../ui/components/ItemIcon";
+import { EquipmentPaperdollPortrait } from "./equipment/EquipmentPaperdollPortrait";
 
 interface EquipmentPanelProps {
   equipment: PlayerEquipmentItems | null;
@@ -66,13 +67,15 @@ function UtilityButton({
 
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={disabled}
-      className="flex items-center justify-center rounded transition-all duration-150 hover:scale-105 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-2"
+      className="flex items-center justify-center rounded transition-all duration-150 hover:scale-105 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-2 focus-visible:outline-none"
       title={label}
       style={{
         background: `${theme.colors.background.tertiary}80`,
         border: `1px solid ${theme.colors.border.default}60`,
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
       }}
     >
       <div className="w-5 h-5" style={{ color: theme.colors.accent.primary }}>
@@ -139,10 +142,17 @@ function DroppableEquipmentSlot({
     isDragging && dragItem?.id?.toString().startsWith("inventory-");
 
   const isEmpty = !slot.item;
+  const slotTitle = slot.item
+    ? `${slot.item.name} (${slot.label})`
+    : `${slot.label} (empty)`;
 
   return (
     <button
       ref={setNodeRef}
+      type="button"
+      title={slotTitle}
+      data-equipment-slot={slot.key}
+      data-slot-empty={isEmpty ? "true" : "false"}
       aria-label={
         slot.item
           ? `${slot.item.name} equipped in ${slot.label} slot`
@@ -207,19 +217,18 @@ function DroppableEquipmentSlot({
         });
         window.dispatchEvent(evt);
       }}
-      className="w-full h-full rounded transition-all duration-150 cursor-pointer group relative"
+      className="w-full h-full rounded-[14px] transition-all duration-150 cursor-pointer group relative overflow-hidden focus-visible:outline-none"
       style={{
-        // Embossed style matching inventory - aligned with theme
         background:
           isOver && isValidDrop
-            ? "rgba(242, 208, 138, 0.15)"
+            ? "rgba(242, 208, 138, 0.18)"
             : isOver && !isValidDrop
-              ? "rgba(220, 80, 80, 0.15)"
+              ? "rgba(220, 80, 80, 0.18)"
               : isDraggingInventoryItem && isValidDrop
-                ? "rgba(242, 208, 138, 0.08)"
+                ? "rgba(242, 208, 138, 0.1)"
                 : isEmpty
-                  ? "rgba(16, 16, 18, 0.95)"
-                  : "rgba(20, 20, 22, 0.95)",
+                  ? "linear-gradient(180deg, rgba(21, 19, 21, 0.96) 0%, rgba(12, 11, 13, 0.98) 100%)"
+                  : "linear-gradient(180deg, rgba(29, 25, 23, 0.98) 0%, rgba(17, 15, 16, 0.98) 100%)",
         borderWidth: "1px",
         borderStyle: isOver
           ? "solid"
@@ -233,96 +242,69 @@ function DroppableEquipmentSlot({
               ? "rgba(180, 80, 80, 0.7)"
               : isDraggingInventoryItem && isValidDrop
                 ? "rgba(180, 160, 100, 0.5)"
-                : "rgba(8, 8, 10, 0.6)",
-        // Embossed shadows: dark on top-left, subtle light on bottom-right
+                : "rgba(112, 88, 56, 0.34)",
         boxShadow:
           isOver && isValidDrop
             ? "inset 0 0 8px rgba(100, 180, 100, 0.3)"
             : isOver && !isValidDrop
               ? "inset 0 0 8px rgba(180, 80, 80, 0.3)"
               : isEmpty
-                ? "inset 2px 2px 4px rgba(0, 0, 0, 0.5), inset -1px -1px 2px rgba(40, 40, 45, 0.15)"
-                : "inset 2px 2px 4px rgba(0, 0, 0, 0.4), inset -1px -1px 2px rgba(50, 50, 55, 0.12)",
+                ? "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -10px 18px rgba(0,0,0,0.25), 0 6px 12px rgba(0,0,0,0.14)"
+                : "inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -10px 18px rgba(0,0,0,0.2), 0 8px 14px rgba(0,0,0,0.18)",
+        outline: "none",
       }}
     >
-      {/* Slot Label - subtle, positioned at top */}
       <div
-        className={`absolute left-0 right-0 text-center ${shouldUseMobileUI ? "top-1" : "top-1.5"}`}
+        className="absolute inset-0"
         style={{
-          fontSize: shouldUseMobileUI ? "8px" : "10px",
-          fontWeight: 600,
-          color: "rgba(200, 180, 140, 0.7)",
-          textShadow: "0 1px 2px rgba(0, 0, 0, 0.9)",
-          textTransform: "uppercase",
-          letterSpacing: "0.05em",
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0) 26%, rgba(0,0,0,0.1) 100%)",
         }}
-      >
-        {slot.label}
-      </div>
+      />
 
-      {/* Slot Content */}
       <div
-        className={`flex flex-col items-center justify-center h-full ${shouldUseMobileUI ? "pt-2.5" : "pt-3"}`}
+        className="absolute inset-x-[16%] top-[10%] bottom-[12%] rounded-[12px] pointer-events-none"
+        style={{
+          border: `1px solid ${isEmpty ? "rgba(152, 124, 78, 0.18)" : "rgba(202, 168, 108, 0.22)"}`,
+          opacity: isEmpty ? 0.45 : 0.82,
+        }}
+      />
+
+      <div
+        className="flex h-full w-full items-center justify-center"
+        style={{
+          paddingTop: shouldUseMobileUI ? 4 : 6,
+          paddingBottom: shouldUseMobileUI ? 4 : 6,
+        }}
       >
         {isEmpty ? (
           <div
             className="transition-all duration-150 group-hover:scale-105 group-hover:opacity-40"
             style={{
-              width: shouldUseMobileUI ? "20px" : "26px",
-              height: shouldUseMobileUI ? "20px" : "26px",
-              color: "rgba(180, 160, 120, 0.3)",
+              width: shouldUseMobileUI ? "22px" : "28px",
+              height: shouldUseMobileUI ? "22px" : "28px",
+              color: "rgba(190, 164, 111, 0.34)",
             }}
           >
             {slot.icon}
           </div>
         ) : (
-          <>
-            <div
-              className="transition-transform duration-150 group-hover:scale-105"
-              style={{
-                width: shouldUseMobileUI ? "18px" : "24px",
-                height: shouldUseMobileUI ? "18px" : "24px",
-                filter: "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7))",
-              }}
-            >
-              <ItemIcon
-                itemId={slot.item!.id}
-                size={shouldUseMobileUI ? 18 : 24}
-              />
-            </div>
-            <div
-              className="text-center px-0.5 mt-0.5"
-              style={{
-                fontSize: shouldUseMobileUI ? "8px" : "9px",
-                color: "rgba(220, 200, 160, 0.9)",
-                fontWeight: 500,
-                lineHeight: "1.1",
-                maxWidth: "100%",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                textShadow: "0 1px 2px rgba(0, 0, 0, 0.8)",
-              }}
-            >
-              {slot.item!.name}
-            </div>
-            {(slot.item!.quantity ?? 1) > 1 && (
-              <div
-                className="absolute bottom-0.5 right-1 font-bold"
-                style={{
-                  fontSize: shouldUseMobileUI ? "8px" : "9px",
-                  color: "#d4b87a",
-                  textShadow: "0 1px 2px rgba(0, 0, 0, 0.9)",
-                }}
-              >
-                {slot.item!.quantity ?? 1}
-              </div>
-            )}
-          </>
+          <div
+            className="transition-transform duration-150 group-hover:scale-105"
+            style={{
+              width: shouldUseMobileUI ? "24px" : "32px",
+              height: shouldUseMobileUI ? "24px" : "32px",
+              filter: "drop-shadow(0 3px 6px rgba(0, 0, 0, 0.55))",
+            }}
+          >
+            <ItemIcon
+              itemId={slot.item!.id}
+              size={shouldUseMobileUI ? 24 : 32}
+            />
+          </div>
         )}
       </div>
 
-      {/* Hover Glow Effect */}
       {!isEmpty && (
         <div
           className="absolute inset-0 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none"
@@ -331,9 +313,52 @@ function DroppableEquipmentSlot({
           }}
         />
       )}
+
+      {(slot.item?.quantity ?? 1) > 1 && (
+        <div
+          className="absolute bottom-1.5 right-1.5 min-w-[18px] rounded-full px-1 text-center font-bold"
+          style={{
+            fontSize: shouldUseMobileUI ? "8px" : "9px",
+            color: "#f2d08a",
+            background: "rgba(15, 12, 11, 0.78)",
+            border: "1px solid rgba(181, 145, 85, 0.4)",
+            textShadow: "0 1px 2px rgba(0, 0, 0, 0.9)",
+            lineHeight: shouldUseMobileUI ? "14px" : "15px",
+          }}
+        >
+          {slot.item!.quantity ?? 1}
+        </div>
+      )}
+
+      <div
+        className="absolute inset-[2px] rounded-[12px] pointer-events-none opacity-0 group-focus-visible:opacity-100 transition-opacity duration-150"
+        style={{
+          border: `1px solid ${theme.colors.accent.primary}aa`,
+          boxShadow: `0 0 0 1px ${theme.colors.accent.primary}22`,
+        }}
+      />
     </button>
   );
 }
+
+interface PaperdollSlotPlacement {
+  area: string;
+  key: string;
+}
+
+const PAPERDOLL_PLACEMENTS: PaperdollSlotPlacement[] = [
+  { area: "cape", key: EquipmentSlotName.CAPE },
+  { area: "head", key: EquipmentSlotName.HELMET },
+  { area: "body", key: EquipmentSlotName.BODY },
+  { area: "legs", key: EquipmentSlotName.LEGS },
+  { area: "boots", key: EquipmentSlotName.BOOTS },
+  { area: "ammo", key: EquipmentSlotName.ARROWS },
+  { area: "amulet", key: EquipmentSlotName.AMULET },
+  { area: "ring", key: EquipmentSlotName.RING },
+  { area: "gloves", key: EquipmentSlotName.GLOVES },
+  { area: "weapon", key: EquipmentSlotName.WEAPON },
+  { area: "shield", key: EquipmentSlotName.SHIELD },
+];
 
 export const EquipmentPanel = React.memo(function EquipmentPanel({
   equipment,
@@ -542,11 +567,28 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   // Helper to find slot by key
   const getSlot = (key: string) => slots.find((s) => s.key === key) || null;
 
-  // Unified slot cell renderer for both mobile and desktop
-  const renderSlotCell = (slotName: string, isMobile: boolean) => (
+  const equipmentSignature = useMemo(
+    () =>
+      slots
+        .map((slot) =>
+          slot.item
+            ? `${slot.key}:${slot.item.id}:${slot.item.quantity ?? 1}`
+            : `${slot.key}:empty`,
+        )
+        .join("|"),
+    [slots],
+  );
+
+  const renderSlotCell = (
+    slotName: string,
+    isMobile: boolean,
+    area?: string,
+  ) => (
     <div
+      key={slotName}
       className={isMobile ? undefined : "w-full h-full"}
       style={{
+        gridArea: area,
         height: isMobile ? MOBILE_EQUIPMENT.slotHeight : undefined,
         containerType: "size",
       }}
@@ -562,46 +604,57 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
     </div>
   );
 
-  // OSRS Paperdoll Grid Layout - 3 columns, 4 rows
-  // Both mobile and desktop share the same slot order, only styling differs
-  const renderEquipmentGrid = (isMobile: boolean) => (
-    <div
-      className={isMobile ? "grid" : "relative grid h-full"}
-      style={
-        isMobile
-          ? {
-              gridTemplateColumns: `repeat(${MOBILE_EQUIPMENT.columns}, 1fr)`,
-              gap: `${MOBILE_EQUIPMENT.gap}px`,
-              padding: `${MOBILE_EQUIPMENT.padding}px`,
-            }
-          : {
-              gridTemplateColumns: "1fr 1.2fr 1fr",
-              gridTemplateRows: "1fr 1.2fr 1fr 1fr",
-              gap: `${theme.spacing.xs}px`,
-            }
-      }
-    >
-      {/* Row 1: Cape, Head, Amulet */}
-      {renderSlotCell(EquipmentSlotName.CAPE, isMobile)}
-      {renderSlotCell(EquipmentSlotName.HELMET, isMobile)}
-      {renderSlotCell(EquipmentSlotName.AMULET, isMobile)}
+  const renderEquipmentGrid = (isMobile: boolean) => {
+    const slotSize = isMobile ? MOBILE_EQUIPMENT.slotHeight : 72;
+    const gap = isMobile ? MOBILE_EQUIPMENT.gap : 8;
+    const padding = isMobile ? MOBILE_EQUIPMENT.padding : 10;
+    const portraitMin = isMobile ? 96 : 128;
 
-      {/* Row 2: Weapon, Body, Shield */}
-      {renderSlotCell(EquipmentSlotName.WEAPON, isMobile)}
-      {renderSlotCell(EquipmentSlotName.BODY, isMobile)}
-      {renderSlotCell(EquipmentSlotName.SHIELD, isMobile)}
+    return (
+      <div
+        data-equipment-grid="paperdoll"
+        className="grid h-full"
+        style={{
+          gridTemplateColumns: `${slotSize}px minmax(0, 1fr) minmax(0, 1fr) ${slotSize}px`,
+          gridTemplateRows: `repeat(5, ${slotSize}px)`,
+          gridTemplateAreas: `
+          "cape portrait portrait ammo"
+          "head portrait portrait amulet"
+          "body portrait portrait ring"
+          "legs portrait portrait gloves"
+          "boots weapon shield empty"
+        `,
+          gap,
+          padding,
+          alignItems: "stretch",
+        }}
+      >
+        <div
+          data-equipment-center="portrait"
+          style={{
+            gridArea: "portrait",
+            minWidth: 0,
+            minHeight: isMobile
+              ? slotSize * 4 + gap * 3
+              : slotSize * 4 + gap * 3,
+          }}
+        >
+          <EquipmentPaperdollPortrait
+            world={world}
+            equipmentSignature={equipmentSignature}
+            compact={isMobile}
+            className="h-full w-full"
+          />
+        </div>
 
-      {/* Row 3: Ring, Legs, Gloves */}
-      {renderSlotCell(EquipmentSlotName.RING, isMobile)}
-      {renderSlotCell(EquipmentSlotName.LEGS, isMobile)}
-      {renderSlotCell(EquipmentSlotName.GLOVES, isMobile)}
+        {PAPERDOLL_PLACEMENTS.map((placement) =>
+          renderSlotCell(placement.key, isMobile, placement.area),
+        )}
 
-      {/* Row 4: Boots, empty, Ammo */}
-      {renderSlotCell(EquipmentSlotName.BOOTS, isMobile)}
-      <div />
-      {renderSlotCell(EquipmentSlotName.ARROWS, isMobile)}
-    </div>
-  );
+        <div style={{ gridArea: "empty" }} />
+      </div>
+    );
+  };
 
   return (
     <>
@@ -616,50 +669,28 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
           boxShadow: "none",
         }}
       >
-        {/* Equipment Grid Container */}
         <div
           className="flex-1 relative overflow-hidden"
           style={{
-            background: `linear-gradient(180deg, ${theme.colors.background.panelSecondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
-            border: `1px solid ${theme.colors.border.default}66`,
-            borderRadius: `${theme.borderRadius.md}px`,
+            background:
+              "linear-gradient(180deg, rgba(38, 31, 29, 0.98) 0%, rgba(20, 17, 18, 0.99) 100%)",
+            border: `1px solid ${theme.colors.border.default}70`,
+            borderRadius: `${theme.borderRadius.lg}px`,
             padding: shouldUseMobileUI ? 0 : `${theme.spacing.sm}px`,
-            // Embossed container
-            boxShadow: `${theme.shadows.sm}, inset 2px 2px 4px rgba(0, 0, 0, 0.4), inset -1px -1px 3px rgba(60, 60, 68, 0.1)`,
+            boxShadow:
+              "0 12px 30px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.24)",
           }}
         >
           {renderEquipmentGrid(shouldUseMobileUI)}
         </div>
 
-        {/* Bottom section: Utility Buttons */}
         {shouldUseMobileUI ? (
-          <div
-            className="flex items-center justify-center gap-2 px-3 py-1.5"
-            style={{
-              background: `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
-              borderRadius: `${theme.borderRadius.sm}px`,
-              border: `1px solid ${theme.colors.border.default}66`,
-              boxShadow: `${theme.shadows.sm}, inset 1px 1px 3px rgba(0, 0, 0, 0.3)`,
-            }}
-          >
-            <UtilityButton
-              icon={<StatsIcon className="w-full h-full" />}
-              label="Stats"
-              onClick={handleOpenStats}
-            />
-            <UtilityButton
-              icon={<DeathIcon className="w-full h-full" />}
-              label="Death"
-              onClick={handleOpenDeath}
-            />
-          </div>
-        ) : (
           <>
-            {/* Equipment Bonuses Summary - Desktop */}
             <div
-              className="flex justify-center gap-4 py-1"
+              className="flex justify-center gap-4 py-1.5"
               style={{
-                background: `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
+                background:
+                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
                 fontSize: "11px",
@@ -677,11 +708,57 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
               </span>
             </div>
 
-            {/* Utility Buttons (RS3-style) - Desktop */}
+            <div
+              className="flex items-center justify-center gap-2 px-3 py-1.5"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
+                borderRadius: `${theme.borderRadius.sm}px`,
+                border: `1px solid ${theme.colors.border.default}66`,
+                boxShadow: `${theme.shadows.sm}, inset 1px 1px 3px rgba(0, 0, 0, 0.3)`,
+              }}
+            >
+              <UtilityButton
+                icon={<StatsIcon className="w-full h-full" />}
+                label="Stats"
+                onClick={handleOpenStats}
+              />
+              <UtilityButton
+                icon={<DeathIcon className="w-full h-full" />}
+                label="Death"
+                onClick={handleOpenDeath}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div
+              className="flex justify-center gap-4 py-1"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
+                borderRadius: `${theme.borderRadius.md}px`,
+                border: `1px solid ${theme.colors.border.default}66`,
+                fontSize: "11px",
+                boxShadow: theme.shadows.sm,
+              }}
+            >
+              <span style={{ color: theme.colors.state.danger }}>
+                ⚔️ {totalBonuses.attack}
+              </span>
+              <span style={{ color: theme.colors.state.success }}>
+                🛡️ {totalBonuses.defense}
+              </span>
+              <span style={{ color: theme.colors.state.warning }}>
+                💪 {totalBonuses.strength}
+              </span>
+            </div>
+
             <div
               className="flex justify-between px-1 py-1.5"
               style={{
-                background: `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
+                background:
+                  "linear-gradient(180deg, rgba(46, 39, 37, 0.98) 0%, rgba(24, 20, 21, 0.98) 100%)",
                 borderRadius: `${theme.borderRadius.md}px`,
                 border: `1px solid ${theme.colors.border.default}66`,
                 boxShadow: theme.shadows.sm,

--- a/packages/client/src/game/panels/InventoryPanel.tsx
+++ b/packages/client/src/game/panels/InventoryPanel.tsx
@@ -20,10 +20,10 @@ import {
 } from "@dnd-kit/core";
 import {
   useDragStore,
-  calculateCursorTooltipPosition,
   TOOLTIP_SIZE_ESTIMATES,
   useThemeStore,
   useMobileLayout,
+  CursorTooltip,
 } from "@/ui";
 import {
   getInteractiveTileStyle,
@@ -683,28 +683,13 @@ function renderItemHoverTooltip(
       (bonuses.defense !== undefined && bonuses.defense !== 0) ||
       (bonuses.strength !== undefined && bonuses.strength !== 0));
 
-  // Use shared tooltip positioning for consistent edge detection
-  // Offset of 4px keeps tooltip close to cursor while avoiding overlap
-  const { left, top } = calculateCursorTooltipPosition(
-    itemHover.position,
-    TOOLTIP_SIZE_ESTIMATES.medium, // Use shared size estimate
-    4, // cursorOffset - keep tooltip close to cursor
-    8, // margin from screen edges
-  );
-
-  return createPortal(
-    <div
-      className="pointer-events-none"
+  return (
+    <CursorTooltip
+      visible={true}
+      position={itemHover.position}
+      estimatedSize={TOOLTIP_SIZE_ESTIMATES.medium}
       style={{
-        position: "fixed",
-        left,
-        top,
         zIndex: zIndex.tooltip,
-        background: `linear-gradient(135deg, ${theme.colors.background.primary} 0%, ${theme.colors.background.secondary} 100%)`,
-        border: `2px solid ${theme.colors.accent.secondary}80`,
-        borderRadius: "4px",
-        padding: "8px 12px",
-        boxShadow: theme.shadows.lg,
         minWidth: "120px",
         maxWidth: "220px",
       }}
@@ -761,8 +746,7 @@ function renderItemHoverTooltip(
           )}
         </div>
       )}
-    </div>,
-    document.body,
+    </CursorTooltip>
   );
 }
 

--- a/packages/client/src/game/panels/PrayerPanel.tsx
+++ b/packages/client/src/game/panels/PrayerPanel.tsx
@@ -22,17 +22,26 @@ import React, {
 import { createPortal } from "react-dom";
 import { useDraggable } from "@dnd-kit/core";
 import {
-  calculateCursorTooltipPosition,
   useThemeStore,
   useMobileLayout,
+  CursorTooltip,
+  TOOLTIP_SIZE_ESTIMATES,
 } from "@/ui";
 import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
 } from "@/ui/theme/themes";
-import { zIndex, MOBILE_PRAYER } from "../../constants";
-import { useTooltipSize } from "../../hooks";
+import {
+  zIndex,
+  MOBILE_PRAYER,
+  PANEL_ICON_SIZE,
+  PANEL_GRID_GAP,
+  PANEL_PADDING,
+  PANEL_GRID_PADDING,
+  PANEL_MOBILE_PADDING,
+  PANEL_SLOT_RADIUS,
+} from "../../constants";
 import type { PlayerStats, ClientWorld } from "../../types";
 import {
   EventType,
@@ -66,11 +75,12 @@ function isPrayerToggledPayload(data: unknown): data is PrayerToggledEvent {
   );
 }
 
-// Prayer panel layout constants - compact sizing
-const PRAYER_ICON_SIZE = 36; // Compact icon size
-const PRAYER_GAP = 2; // Tight gap
-const PANEL_PADDING = 3; // Minimal container padding
-const GRID_PADDING = 3; // Minimal grid padding
+// Prayer panel layout constants — use shared sizing tokens from panelLayout.ts
+// to ensure consistency across Prayer, Spells, Skills, and Inventory panels.
+const PRAYER_ICON_SIZE = PANEL_ICON_SIZE; // 36px desktop icon size
+const PRAYER_GAP = PANEL_GRID_GAP; // 3px gap between slots
+// PANEL_PADDING and GRID_PADDING come directly from the shared constants barrel
+const GRID_PADDING = PANEL_GRID_PADDING; // alias for local use
 const HEADER_HEIGHT = 44; // Compact prayer points header + bar
 const FOOTER_HEIGHT = 28; // Compact active prayers footer
 const PRAYER_DATA_POLL_INTERVAL_MS = 250;
@@ -291,20 +301,33 @@ function PrayerIcon({
     [onClick, isUnlocked],
   );
 
+  const [isHovered, setIsHovered] = React.useState(false);
+
   // Memoize button style to prevent recreation on every render
   const buttonStyle = useMemo(
     (): React.CSSProperties => ({
       width: iconSize,
       height: iconSize,
       padding: 0,
+      background:
+        isHovered && isUnlocked
+          ? "rgba(183, 140, 76, 0.08)"
+          : "var(--color-slot-empty)",
       ...getInteractiveTileStyle(theme, {
         active: isActive,
         dragging: isDragging,
+        hovered: isHovered,
         disabled: !isUnlocked,
-        radius: isMobile ? 6 : 4,
+        radius: 4, // Square matching equipment/inventory UI
         accentColor: theme.colors.accent.secondary,
       }),
-      borderRadius: isMobile ? 4 : 2,
+      borderColor: isActive
+        ? theme.colors.accent.secondary
+        : isHovered && isUnlocked
+          ? "rgba(183, 140, 76, 0.4)" // RS3/OSRS gold tint on hover
+          : "rgba(8, 8, 10, 0.6)",
+      borderWidth: "1px",
+      borderRadius: 4, // Square slots
       cursor: isUnlocked ? (isDragging ? "grabbing" : "grab") : "not-allowed",
       display: "flex",
       alignItems: "center",
@@ -312,12 +335,14 @@ function PrayerIcon({
       position: "relative",
       overflow: "hidden",
       boxShadow: isActive
-        ? `0 0 ${isMobile ? 12 : 8}px ${theme.colors.accent.secondary}80, inset 0 0 ${isMobile ? 16 : 10}px ${theme.colors.accent.secondary}33`
-        : "inset 0 1px 2px rgba(0, 0, 0, 0.4)",
+        ? `0 0 ${isMobile ? 12 : 8}px ${theme.colors.accent.secondary}80, inset 0 0 ${isMobile ? 16 : 10}px ${theme.colors.accent.secondary}33, inset 2px 2px 4px rgba(0, 0, 0, 0.34)`
+        : isHovered && isUnlocked
+          ? "inset 2px 2px 4px rgba(0, 0, 0, 0.5), inset -1px -1px 2px rgba(183, 140, 76, 0.15)"
+          : "inset 2px 2px 4px rgba(0, 0, 0, 0.42), inset -1px -1px 2px rgba(88, 74, 56, 0.12)",
       opacity: isDragging ? 0.5 : 1,
       touchAction: "none",
     }),
-    [isActive, isUnlocked, isDragging, theme, iconSize, isMobile],
+    [isActive, isUnlocked, isDragging, isHovered, theme, iconSize, isMobile],
   );
 
   return (
@@ -325,9 +350,15 @@ function PrayerIcon({
       ref={setNodeRef}
       onClick={handleClick}
       onContextMenu={onContextMenu}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={(e) => {
+        setIsHovered(true);
+        onMouseEnter(e);
+      }}
       onMouseMove={onMouseMove}
-      onMouseLeave={onMouseLeave}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        onMouseLeave();
+      }}
       disabled={!isUnlocked}
       aria-label={`${prayer.name}${isActive ? " (Active)" : ""}${!isUnlocked ? " (Locked)" : ""}`}
       className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
@@ -421,18 +452,12 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
     y: 0,
     prayer: null,
   });
-  const prayerTooltipRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
   // Use prayer points directly from stats prop (same pattern as StatusBars)
   // This ensures a single source of truth - no local state that can get out of sync
   const prayerPoints = stats?.prayerPoints ?? { current: 0, max: 1 };
-
-  const prayerTooltipSize = useTooltipSize(hoveredPrayer, prayerTooltipRef, {
-    width: 200,
-    height: 100,
-  });
 
   const playerPrayerLevel = stats?.skills?.prayer?.level ?? 1;
 
@@ -688,21 +713,21 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
       className="flex flex-col h-full"
       style={{
         ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-        padding: shouldUseMobileUI ? 4 : 3,
+        padding: shouldUseMobileUI ? PANEL_MOBILE_PADDING : PANEL_PADDING,
       }}
     >
       {/* Prayer Points Header - Compact */}
       <div
         style={{
+          ...getPanelInsetStyle(theme, {
+            emphasis: "normal",
+            radius: 4,
+          }),
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
           marginBottom: 4,
-          ...getPanelInsetStyle(theme, {
-            emphasis: "normal",
-            radius: theme.borderRadius.md,
-          }),
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
@@ -718,70 +743,75 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
             >
               Prayer Points
             </div>
-            <div
-              style={{
-                fontSize: shouldUseMobileUI ? 13 : 11,
-                fontWeight: 600,
-                color: theme.colors.status.prayer,
-              }}
-            >
-              {prayerPoints.current} / {prayerPoints.max}
-            </div>
           </div>
         </div>
 
-        {/* Drain indicator */}
-        {totalDrain > 0 && (
-          <div style={{ textAlign: "right" }}>
+        {/* Prayer points + bar on the right — matches spell panel's autocast indicator */}
+        <div
+          style={{
+            textAlign: "right",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: 2,
+          }}
+        >
+          <div
+            style={{
+              fontSize: shouldUseMobileUI ? 13 : 11,
+              fontWeight: 600,
+              color:
+                prayerPct < 25
+                  ? theme.colors.state.danger
+                  : prayerPct < 50
+                    ? theme.colors.state.warning
+                    : theme.colors.status.prayer,
+            }}
+          >
+            {prayerPoints.current} / {prayerPoints.max}
+          </div>
+          {/* Inline mini-bar */}
+          <div
+            style={{
+              width: 48,
+              height: 3,
+              background: theme.colors.slot.empty,
+              borderRadius: 2,
+              overflow: "hidden",
+              border: `1px solid ${theme.colors.border.default}25`,
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${prayerPct}%`,
+                background:
+                  prayerPct < 25
+                    ? theme.colors.state.danger
+                    : prayerPct < 50
+                      ? `linear-gradient(90deg, ${theme.colors.state.warning} 0%, ${theme.colors.status.prayer} 100%)`
+                      : `linear-gradient(90deg, ${theme.colors.status.prayer} 0%, ${theme.colors.state.info} 100%)`,
+                borderRadius: 2,
+                transition: "width 0.3s ease",
+                boxShadow:
+                  totalDrain > 0
+                    ? `0 0 4px ${theme.colors.status.prayer}80`
+                    : "none",
+              }}
+            />
+          </div>
+          {totalDrain > 0 && (
             <div
               style={{
                 fontSize: 8,
                 color: theme.colors.state.danger,
-                textTransform: "uppercase",
-                opacity: 0.7,
-              }}
-            >
-              Drain
-            </div>
-            <div
-              style={{
-                fontSize: 10,
-                color: theme.colors.state.danger,
-                fontWeight: 600,
+                opacity: 0.8,
               }}
             >
               -{totalDrain}/min
             </div>
-          </div>
-        )}
-      </div>
-
-      {/* Prayer Points Bar - Compact */}
-      <div
-        style={{
-          height: shouldUseMobileUI ? 10 : 4,
-          background: theme.colors.slot.empty,
-          borderRadius: shouldUseMobileUI
-            ? theme.borderRadius.md
-            : theme.borderRadius.sm,
-          marginBottom: 4,
-          overflow: "hidden",
-          border: `1px solid ${theme.colors.border.default}35`,
-        }}
-      >
-        <div
-          style={{
-            height: "100%",
-            width: `${prayerPct}%`,
-            background: `linear-gradient(90deg, ${theme.colors.status.prayer} 0%, ${theme.colors.state.info} 100%)`,
-            borderRadius: theme.borderRadius.sm,
-            transition: "width 0.3s ease",
-            boxShadow:
-              totalDrain > 0
-                ? `0 0 6px ${theme.colors.status.prayer}80`
-                : "none",
-          }}
-        />
+          )}
+        </div>
       </div>
 
       {/* Prayer Grid - adaptive columns based on panel width */}
@@ -796,17 +826,17 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
       >
         <div
           style={{
+            ...getPanelInsetStyle(theme, {
+              emphasis: "strong",
+              radius: 4,
+            }),
             display: "grid",
             // Mobile: larger icons (48px) with more gap, Desktop: compact
             gridTemplateColumns: shouldUseMobileUI
               ? `repeat(${gridColumns}, ${MOBILE_PRAYER.iconSize}px)`
               : `repeat(${gridColumns}, ${PRAYER_ICON_SIZE}px)`,
             gap: shouldUseMobileUI ? MOBILE_PRAYER.gap : PRAYER_GAP,
-            padding: GRID_PADDING,
-            ...getPanelInsetStyle(theme, {
-              emphasis: "strong",
-              radius: theme.borderRadius.md,
-            }),
+            padding: "8px 4px",
             justifyContent: "center",
           }}
         >
@@ -832,12 +862,12 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
       {/* Quick Prayers Toggle - Compact */}
       <div
         style={{
-          marginTop: 4,
-          padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
           ...getPanelInsetStyle(theme, {
             emphasis: "normal",
-            radius: theme.borderRadius.md,
+            radius: 4,
           }),
+          marginTop: 4,
+          padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
@@ -863,7 +893,7 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
                 ? `linear-gradient(180deg, ${theme.colors.state.danger}26 0%, rgba(39, 15, 15, 0.28) 100%)`
                 : theme.colors.slot.disabled,
             border: `1px solid ${activePrayers.size > 0 ? theme.colors.state.danger : theme.colors.border.default}40`,
-            borderRadius: theme.borderRadius.sm,
+            borderRadius: 4,
             color:
               activePrayers.size > 0
                 ? theme.colors.state.danger
@@ -878,134 +908,115 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
 
       {/* Prayer Tooltip */}
       {hoveredPrayer &&
-        createPortal(
-          (() => {
-            const tooltipSize = {
-              width: prayerTooltipSize.width || 200,
-              height: prayerTooltipSize.height || 100,
-            };
-            const { left, top } = calculateCursorTooltipPosition(
-              mousePos,
-              tooltipSize,
-            );
-            const isUnlocked = playerPrayerLevel >= hoveredPrayer.level;
+        (() => {
+          const isUnlocked = playerPrayerLevel >= hoveredPrayer.level;
 
-            return (
+          return (
+            <CursorTooltip
+              visible={true}
+              position={mousePos}
+              estimatedSize={{ width: 200, height: 100 }}
+              style={{
+                zIndex: zIndex.tooltip,
+                border: `1px solid ${getCategoryColor(hoveredPrayer.category)}50`,
+                minWidth: 180,
+              }}
+            >
+              {/* Header */}
               <div
-                ref={prayerTooltipRef}
-                className="fixed pointer-events-none"
                 style={{
-                  left,
-                  top,
-                  zIndex: zIndex.tooltip,
-                  background:
-                    theme.name === "hyperscape"
-                      ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
-                      : `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.primary} 100%)`,
-                  border: `1px solid ${getCategoryColor(hoveredPrayer.category)}50`,
-                  borderRadius: theme.borderRadius.md,
-                  padding: "10px 12px",
-                  boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255,255,255,0.04)`,
-                  minWidth: 180,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  marginBottom: 6,
                 }}
               >
-                {/* Header */}
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                    marginBottom: 6,
-                  }}
-                >
-                  <span style={{ fontSize: 22 }}>
-                    {getPrayerDisplayIcon(hoveredPrayer.icon)}
-                  </span>
-                  <div>
-                    <div
-                      style={{
-                        fontSize: 14,
-                        fontWeight: 700,
-                        color: getCategoryColor(hoveredPrayer.category),
-                      }}
-                    >
-                      {hoveredPrayer.name}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 10,
-                        color: theme.colors.text.muted,
-                      }}
-                    >
-                      Level {hoveredPrayer.level} Prayer
-                    </div>
-                  </div>
-                </div>
-
-                {/* Description */}
-                <div
-                  style={{
-                    fontSize: 11,
-                    color: theme.colors.text.secondary,
-                    marginBottom: 8,
-                    lineHeight: 1.4,
-                  }}
-                >
-                  {hoveredPrayer.description}
-                </div>
-
-                {/* Drain rate */}
-                <div
-                  style={{
-                    fontSize: 10,
-                    color: theme.colors.text.muted,
-                    display: "flex",
-                    justifyContent: "space-between",
-                  }}
-                >
-                  <span>Drain rate:</span>
-                  <span style={{ color: theme.colors.accent.secondary }}>
-                    {hoveredPrayer.drainRate} points/min
-                  </span>
-                </div>
-
-                {/* Status */}
-                {!isUnlocked && (
+                <span style={{ fontSize: 22 }}>
+                  {getPrayerDisplayIcon(hoveredPrayer.icon)}
+                </span>
+                <div>
                   <div
                     style={{
-                      marginTop: 8,
-                      padding: "4px 8px",
-                      background: `${theme.colors.state.danger}26`,
-                      borderRadius: theme.borderRadius.sm,
-                      fontSize: 10,
-                      color: theme.colors.state.danger,
-                      textAlign: "center",
+                      fontSize: 14,
+                      fontWeight: 700,
+                      color: getCategoryColor(hoveredPrayer.category),
                     }}
                   >
-                    Requires level {hoveredPrayer.level} Prayer
+                    {hoveredPrayer.name}
                   </div>
-                )}
-                {hoveredPrayer.active && (
                   <div
                     style={{
-                      marginTop: 8,
-                      padding: "4px 8px",
-                      background: `${theme.colors.state.success}26`,
-                      borderRadius: theme.borderRadius.sm,
                       fontSize: 10,
-                      color: theme.colors.state.success,
-                      textAlign: "center",
-                      fontWeight: 600,
+                      color: theme.colors.text.muted,
                     }}
                   >
-                    Currently Active
+                    Level {hoveredPrayer.level} Prayer
                   </div>
-                )}
+                </div>
               </div>
-            );
-          })(),
-          document.body,
-        )}
+
+              {/* Description */}
+              <div
+                style={{
+                  fontSize: 11,
+                  color: theme.colors.text.secondary,
+                  marginBottom: 8,
+                  lineHeight: 1.4,
+                }}
+              >
+                {hoveredPrayer.description}
+              </div>
+
+              {/* Drain rate */}
+              <div
+                style={{
+                  fontSize: 10,
+                  color: theme.colors.text.muted,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>Drain rate:</span>
+                <span style={{ color: theme.colors.accent.secondary }}>
+                  {hoveredPrayer.drainRate} points/min
+                </span>
+              </div>
+
+              {/* Status */}
+              {!isUnlocked && (
+                <div
+                  style={{
+                    marginTop: 8,
+                    padding: "4px 8px",
+                    background: `${theme.colors.state.danger}26`,
+                    borderRadius: 4,
+                    fontSize: 10,
+                    color: theme.colors.state.danger,
+                    textAlign: "center",
+                  }}
+                >
+                  Requires level {hoveredPrayer.level} Prayer
+                </div>
+              )}
+              {hoveredPrayer.active && (
+                <div
+                  style={{
+                    marginTop: 8,
+                    padding: "4px 8px",
+                    background: `${theme.colors.state.success}26`,
+                    borderRadius: 4,
+                    fontSize: 10,
+                    color: theme.colors.state.success,
+                    textAlign: "center",
+                    fontWeight: 600,
+                  }}
+                >
+                  Currently Active
+                </div>
+              )}
+            </CursorTooltip>
+          );
+        })()}
 
       {/* Prayer Context Menu */}
       {contextMenu.visible &&
@@ -1039,7 +1050,7 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
                         ? "linear-gradient(180deg, rgba(44, 36, 24, 0.98) 0%, rgba(18, 15, 11, 0.98) 100%)"
                         : theme.colors.background.secondary,
                     border: `1px solid ${theme.colors.border.default}`,
-                    borderRadius: theme.borderRadius.md,
+                    borderRadius: 4,
                     boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255,255,255,0.04)`,
                     overflow: "hidden",
                     minWidth: 100,

--- a/packages/client/src/game/panels/QuestsPanel.tsx
+++ b/packages/client/src/game/panels/QuestsPanel.tsx
@@ -3,7 +3,7 @@
  *
  * Connects the QuestLog component to the server's quest system via network.
  * Displays available, active, and completed quests with filtering and sorting.
- * Uses COLORS constants for consistent styling with other panels.
+ * Uses theme utilities for consistent styling with other panels.
  *
  * Desktop: When a quest is clicked, it opens the QuestDetailPanel in a separate window.
  * Mobile: Quest details are shown inline with a back button to return to the list.
@@ -18,7 +18,11 @@ import {
   useMobileLayout,
   useTheme,
 } from "@/ui";
-import { getPanelSurfaceStyle } from "@/ui/theme/themes";
+import { getPanelSurfaceStyle, getPanelInsetStyle } from "@/ui/theme/themes";
+import {
+  PANEL_MOBILE_PADDING,
+  PANEL_SLOT_RADIUS,
+} from "../../constants/panelLayout";
 import { QuestLog } from "@/game/components/quest";
 import {
   type Quest,
@@ -30,8 +34,8 @@ import {
   filterQuests,
   calculateQuestProgress,
   CATEGORY_CONFIG,
+  STATE_CONFIG,
 } from "@/game/systems";
-import { COLORS, spacing, typography } from "../../constants";
 import { parseJSONWithDefault } from "../../utils/validation";
 import type { ClientWorld } from "../../types";
 
@@ -108,12 +112,16 @@ function saveLastViewedQuest(questId: string | null): void {
   }
 }
 
-// OSRS-style status colors for mobile detail view
-const STATUS_COLORS: Record<string, string> = {
-  available: COLORS.ERROR,
-  active: COLORS.WARNING,
-  completed: COLORS.SUCCESS,
-  failed: COLORS.TEXT_MUTED,
+function getStateColor(state: QuestState): string {
+  return STATE_CONFIG[state].color;
+}
+
+const CATEGORY_ICONS: Record<string, string> = {
+  crown: "\u{1F451}",
+  scroll: "\u{1F4DC}",
+  sun: "\u2600\uFE0F",
+  calendar: "\u{1F4C5}",
+  star: "\u2B50",
 };
 
 /** Server quest list item structure */
@@ -281,24 +289,26 @@ function MobileQuestDetail({
 }: MobileQuestDetailProps) {
   const progress = calculateQuestProgress(quest);
   const categoryConfig = CATEGORY_CONFIG[quest.category];
+  const categoryIcon =
+    CATEGORY_ICONS[categoryConfig.icon] || categoryConfig.icon;
   const canAccept = quest.state === "available";
   const canComplete = quest.state === "active" && progress === 100;
 
   const containerStyle: React.CSSProperties = {
+    ...getPanelSurfaceStyle(theme),
     height: "100%",
     display: "flex",
     flexDirection: "column",
-    background: theme.colors.background.panelSecondary,
     overflow: "hidden",
   };
 
   const headerStyle: React.CSSProperties = {
+    ...getPanelInsetStyle(theme, { radius: 0 }),
     display: "flex",
     alignItems: "center",
-    gap: spacing.sm,
-    padding: `${spacing.sm} ${spacing.sm}`,
+    gap: theme.spacing.sm,
+    padding: `${PANEL_MOBILE_PADDING * 2 + 2}px`,
     borderBottom: `1px solid ${theme.colors.border.default}`,
-    background: theme.colors.background.panelSecondary,
     minHeight: "48px",
   };
 
@@ -310,17 +320,17 @@ function MobileQuestDetail({
     height: "36px",
     background: "transparent",
     border: "none",
-    color: COLORS.TEXT_SECONDARY,
+    color: theme.colors.text.secondary,
     cursor: "pointer",
     padding: 0,
-    borderRadius: "6px",
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
   };
 
   const titleStyle: React.CSSProperties = {
     flex: 1,
-    color: STATUS_COLORS[quest.state] || COLORS.TEXT_PRIMARY,
-    fontSize: typography.fontSize.lg,
-    fontWeight: typography.fontWeight.semibold,
+    color: getStateColor(quest.state),
+    fontSize: theme.typography.fontSize.lg,
+    fontWeight: theme.typography.fontWeight.semibold,
     margin: 0,
     overflow: "hidden",
     textOverflow: "ellipsis",
@@ -330,40 +340,38 @@ function MobileQuestDetail({
   const contentStyle: React.CSSProperties = {
     flex: 1,
     overflowY: "auto",
-    padding: spacing.sm,
+    padding: `${PANEL_MOBILE_PADDING * 2 + 2}px`,
     WebkitOverflowScrolling: "touch",
   };
 
   const sectionStyle: React.CSSProperties = {
-    marginBottom: spacing.sm,
+    marginBottom: theme.spacing.sm,
   };
 
   const sectionTitleStyle: React.CSSProperties = {
-    color: COLORS.ACCENT,
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.semibold,
+    color: theme.colors.accent.primary,
+    fontSize: theme.typography.fontSize.sm,
+    fontWeight: theme.typography.fontWeight.semibold,
     textTransform: "uppercase",
     letterSpacing: "0.5px",
-    marginBottom: spacing.xs,
+    marginBottom: theme.spacing.xs,
   };
 
   const descriptionStyle: React.CSSProperties = {
-    color: COLORS.TEXT_SECONDARY,
-    fontSize: typography.fontSize.base,
-    lineHeight: "1.5",
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.fontSize.base,
+    lineHeight: theme.typography.lineHeight.normal,
     margin: 0,
   };
 
   const metaRowStyle: React.CSSProperties = {
+    ...getPanelInsetStyle(theme, { radius: PANEL_SLOT_RADIUS }),
     display: "flex",
     flexWrap: "wrap",
-    gap: spacing.sm,
-    marginBottom: spacing.sm,
-    padding: spacing.sm,
-    background: theme.colors.background.tertiary,
-    borderRadius: "6px",
-    border: `1px solid ${theme.colors.border.default}`,
-    fontSize: typography.fontSize.base,
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+    padding: theme.spacing.sm,
+    fontSize: theme.typography.fontSize.base,
   };
 
   const metaItemStyle: React.CSSProperties = {
@@ -374,39 +382,42 @@ function MobileQuestDetail({
   };
 
   const metaLabelStyle: React.CSSProperties = {
-    color: COLORS.TEXT_MUTED,
-    fontSize: typography.fontSize.sm,
+    color: theme.colors.text.muted,
+    fontSize: theme.typography.fontSize.sm,
     textTransform: "uppercase",
   };
 
   const metaValueStyle: React.CSSProperties = {
-    color: COLORS.TEXT_PRIMARY,
-    fontWeight: typography.fontWeight.medium,
+    color: theme.colors.text.primary,
+    fontWeight: theme.typography.fontWeight.medium,
   };
 
   const progressBarContainerStyle: React.CSSProperties = {
     height: "6px",
-    backgroundColor: COLORS.BG_TERTIARY,
-    borderRadius: "2px",
+    backgroundColor: theme.colors.background.tertiary,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
     overflow: "hidden",
-    marginTop: spacing.xs,
-    marginBottom: spacing.sm,
+    marginTop: theme.spacing.xs,
+    marginBottom: theme.spacing.sm,
   };
 
   const progressBarFillStyle: React.CSSProperties = {
     height: "100%",
     width: `${progress}%`,
-    backgroundColor: progress === 100 ? COLORS.SUCCESS : COLORS.ACCENT,
+    backgroundColor:
+      progress === 100
+        ? theme.colors.state.success
+        : theme.colors.accent.primary,
     transition: "width 0.3s ease",
   };
 
   const objectiveStyle = (completed: boolean): React.CSSProperties => ({
     display: "flex",
     alignItems: "flex-start",
-    gap: spacing.xs,
-    padding: `${spacing.xs} 0`,
-    color: completed ? COLORS.SUCCESS : COLORS.TEXT_SECONDARY,
-    fontSize: typography.fontSize.base,
+    gap: theme.spacing.xs,
+    padding: `${theme.spacing.xs}px 0`,
+    color: completed ? theme.colors.state.success : theme.colors.text.secondary,
+    fontSize: theme.typography.fontSize.base,
     textDecoration: completed ? "line-through" : "none",
     opacity: completed ? 0.7 : 1,
   });
@@ -414,34 +425,34 @@ function MobileQuestDetail({
   const actionsStyle: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
-    gap: spacing.sm,
-    padding: spacing.sm,
+    gap: theme.spacing.sm,
+    padding: `${PANEL_MOBILE_PADDING * 2 + 2}px`,
     borderTop: `1px solid ${theme.colors.border.default}`,
-    background: theme.colors.background.panelSecondary,
+    background: theme.colors.background.secondary,
   };
 
   const buttonBaseStyle: React.CSSProperties = {
-    padding: `${spacing.md} ${spacing.md}`,
+    padding: `${theme.spacing.md}px`,
     border: "none",
-    borderRadius: "6px",
-    fontSize: typography.fontSize.base,
-    fontWeight: typography.fontWeight.medium,
+    borderRadius: `${PANEL_SLOT_RADIUS}px`,
+    fontSize: theme.typography.fontSize.base,
+    fontWeight: theme.typography.fontWeight.medium,
     cursor: "pointer",
-    transition: "all 0.15s ease",
+    transition: theme.transitions.fast,
     minHeight: "44px",
   };
 
   const primaryButtonStyle: React.CSSProperties = {
     ...buttonBaseStyle,
-    background: COLORS.ACCENT,
-    color: COLORS.BG_PRIMARY,
+    background: theme.colors.accent.primary,
+    color: theme.colors.background.primary,
   };
 
   const secondaryButtonStyle: React.CSSProperties = {
     ...buttonBaseStyle,
-    background: COLORS.BG_TERTIARY,
-    color: COLORS.TEXT_PRIMARY,
-    border: `1px solid ${COLORS.BORDER_PRIMARY}`,
+    background: theme.colors.background.tertiary,
+    color: theme.colors.text.primary,
+    border: `1px solid ${theme.colors.border.default}`,
   };
 
   return (
@@ -467,7 +478,7 @@ function MobileQuestDetail({
         <h3 style={titleStyle}>
           {quest.pinned && (
             <span
-              style={{ color: "#ffd700", marginRight: "6px" }}
+              style={{ color: theme.colors.accent.gold, marginRight: "6px" }}
               title="Pinned"
             >
               ★
@@ -484,7 +495,7 @@ function MobileQuestDetail({
           <div style={metaItemStyle}>
             <span style={metaLabelStyle}>Category</span>
             <span style={{ ...metaValueStyle, color: categoryConfig.color }}>
-              {categoryConfig.icon} {categoryConfig.label}
+              {categoryIcon} {categoryConfig.label}
             </span>
           </div>
           <div style={metaItemStyle}>
@@ -496,7 +507,7 @@ function MobileQuestDetail({
             <span
               style={{
                 ...metaValueStyle,
-                color: STATUS_COLORS[quest.state],
+                color: getStateColor(quest.state),
               }}
             >
               {quest.state.charAt(0).toUpperCase() + quest.state.slice(1)}
@@ -552,10 +563,10 @@ function MobileQuestDetail({
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: spacing.xs,
-                  padding: `${spacing.xs} 0`,
-                  color: COLORS.TEXT_SECONDARY,
-                  fontSize: typography.fontSize.base,
+                  gap: theme.spacing.xs,
+                  padding: `${theme.spacing.xs}px 0`,
+                  color: theme.colors.text.secondary,
+                  fontSize: theme.typography.fontSize.base,
                 }}
               >
                 <span>{reward.icon || "•"}</span>
@@ -575,7 +586,7 @@ function MobileQuestDetail({
             <div style={descriptionStyle}>
               {quest.questGiver}
               {quest.questGiverLocation && (
-                <span style={{ color: COLORS.TEXT_MUTED }}>
+                <span style={{ color: theme.colors.text.muted }}>
                   {" "}
                   - {quest.questGiverLocation}
                 </span>

--- a/packages/client/src/game/panels/SkillsPanel.tsx
+++ b/packages/client/src/game/panels/SkillsPanel.tsx
@@ -9,18 +9,19 @@
 import React, { useState, useRef, useMemo, useCallback, memo } from "react";
 import { createPortal } from "react-dom";
 import { useDraggable } from "@dnd-kit/core";
-import {
-  calculateCursorTooltipPosition,
-  useThemeStore,
-  useMobileLayout,
-} from "@/ui";
+import { CursorTooltip, useThemeStore, useMobileLayout } from "@/ui";
 import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
 } from "@/ui/theme/themes";
 import { zIndex, MOBILE_SKILLS } from "../../constants";
-import { useTooltipSize } from "../../hooks";
+import {
+  PANEL_PADDING,
+  PANEL_MOBILE_PADDING,
+  PANEL_GRID_GAP,
+  PANEL_SLOT_RADIUS,
+} from "../../constants/panelLayout";
 import type { PlayerStats, Skills } from "../../types";
 import {
   SKILL_DEFINITIONS,
@@ -124,8 +125,8 @@ const DraggableSkillCard = memo(function DraggableSkillCard({
         hovered: isHovered,
         radius: 4,
       }),
-      padding: isMobile ? "4px 6px" : "3px 6px",
-      minHeight: isMobile ? MOBILE_SKILLS.cardHeight : 28,
+      padding: isMobile ? "4px 6px" : `${PANEL_PADDING - 2}px 4px`,
+      minHeight: isMobile ? MOBILE_SKILLS.cardHeight : 24,
       cursor: isDragging ? "grabbing" : "grab",
       display: "flex",
       alignItems: "center",
@@ -153,20 +154,20 @@ const DraggableSkillCard = memo(function DraggableSkillCard({
       <div className="flex items-center justify-center gap-1 w-full">
         <span
           style={{
-            fontSize: isMobile ? "14px" : "13px",
+            fontSize: isMobile ? "14px" : "11px",
             filter: "drop-shadow(1px 1px 1px rgba(0,0,0,0.4))",
             lineHeight: 1,
           }}
         >
           {skill.icon}
         </span>
-        {/* RuneScape-style slanted level display: current↗/↘base */}
+        {/* OSRS-style slanted level display: current↗/↘base */}
         <div
           style={{
             display: "flex",
             alignItems: "center",
             position: "relative",
-            height: "16px",
+            height: "13px",
           }}
         >
           {/* Current level - shifted up */}
@@ -189,7 +190,7 @@ const DraggableSkillCard = memo(function DraggableSkillCard({
           {/* Slanted separator */}
           <span
             style={{
-              fontSize: isMobile ? "10px" : "9px",
+              fontSize: isMobile ? "10px" : "8px",
               fontWeight: 400,
               color: theme.colors.text.disabled,
               lineHeight: 1,
@@ -230,22 +231,6 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
   const [hoveredTotalLevel, setHoveredTotalLevel] = useState(false);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
   const [guideSkill, setGuideSkill] = useState<Skill | null>(null);
-  const skillTooltipRef = useRef<HTMLDivElement>(null);
-  const totalLevelTooltipRef = useRef<HTMLDivElement>(null);
-
-  const skillTooltipSize = useTooltipSize(hoveredSkill, skillTooltipRef, {
-    width: 180,
-    height: 90,
-  });
-
-  const totalLevelTooltipSize = useTooltipSize(
-    hoveredTotalLevel,
-    totalLevelTooltipRef,
-    {
-      width: 140,
-      height: 50,
-    },
-  );
 
   const s: Partial<Skills> = stats?.skills ?? {};
 
@@ -271,119 +256,105 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
       className="flex flex-col h-full overflow-hidden"
       style={{
         ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-        padding: shouldUseMobileUI ? "4px" : "3px",
+        padding: shouldUseMobileUI ? PANEL_MOBILE_PADDING : PANEL_PADDING,
       }}
     >
-      {/* Content */}
+      {/* Compact header — matches Prayer/Spell panel pattern */}
       <div
-        className="flex flex-col flex-1 overflow-hidden"
         style={{
-          background: "transparent",
-          padding: shouldUseMobileUI ? "4px" : "3px",
+          ...getPanelInsetStyle(theme, { emphasis: "normal", radius: 4 }),
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
+          marginBottom: 4,
+          flexShrink: 0,
         }}
       >
-        {/* Skills Grid - Mobile: 2 columns with names, Desktop: 3 columns compact */}
-        <div
-          className="grid flex-1"
-          style={{
-            ...getPanelInsetStyle(theme, {
-              emphasis: "strong",
-              radius: theme.borderRadius.md,
-            }),
-            padding: shouldUseMobileUI ? "4px" : "3px",
-            gridTemplateColumns: shouldUseMobileUI
-              ? `repeat(${MOBILE_SKILLS.columns}, 1fr)`
-              : "repeat(3, 1fr)",
-            gap: shouldUseMobileUI ? `${MOBILE_SKILLS.gap}px` : "3px",
-          }}
-        >
-          {skills.map((skill) => (
-            <DraggableSkillCard
-              key={skill.key}
-              skill={skill}
-              isHovered={hoveredSkill?.key === skill.key}
-              isMobile={shouldUseMobileUI}
-              onClick={setGuideSkill}
-              onMouseEnter={(e) => {
-                setHoveredSkill(skill);
-                setMousePos({ x: e.clientX, y: e.clientY });
-              }}
-              onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
-              onMouseLeave={() => {
-                setHoveredSkill(null);
-              }}
-            />
-          ))}
+        {/* Left: icon + label */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: shouldUseMobileUI ? 16 : 14 }}>⚔️</span>
+          <div
+            style={{
+              fontSize: shouldUseMobileUI ? 9 : 8,
+              color: theme.colors.text.muted,
+              textTransform: "uppercase",
+              letterSpacing: 0.5,
+            }}
+          >
+            Skills
+          </div>
         </div>
 
-        {/* Total Level & Combat Level - Compact */}
+        {/* Right: Total / Combat with OSRS-style angled split */}
         <div
-          className="flex justify-between"
-          style={{
-            marginTop: shouldUseMobileUI ? "4px" : "3px",
-            ...getPanelInsetStyle(theme, {
-              emphasis: "normal",
-              radius: theme.borderRadius.md,
-            }),
-            padding: shouldUseMobileUI ? "6px 8px" : "4px 6px",
-            flexShrink: 0,
+          style={{ textAlign: "center", cursor: "default" }}
+          onMouseEnter={(e) => {
+            setHoveredTotalLevel(true);
+            setMousePos({ x: e.clientX, y: e.clientY });
           }}
+          onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
+          onMouseLeave={() => setHoveredTotalLevel(false)}
         >
           <div
-            className="text-center flex-1"
-            style={{ cursor: "default" }}
-            onMouseEnter={(e) => {
-              setHoveredTotalLevel(true);
-              setMousePos({ x: e.clientX, y: e.clientY });
+            style={{
+              fontSize: 7,
+              color: theme.colors.text.muted,
+              textTransform: "uppercase",
+              letterSpacing: 0.5,
+              lineHeight: 1,
+              marginBottom: 2,
+              display: "flex",
+              gap: 6,
+              justifyContent: "center",
             }}
-            onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
-            onMouseLeave={() => setHoveredTotalLevel(false)}
           >
-            <div
-              style={{
-                fontSize: shouldUseMobileUI ? "8px" : "7px",
-                color: theme.colors.text.muted,
-                textTransform: "uppercase",
-                letterSpacing: "0.3px",
-                marginBottom: "1px",
-              }}
-            >
-              Total Level
-            </div>
+            <span>Total</span>
+            <span>Combat</span>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              position: "relative",
+              height: 14,
+            }}
+          >
             <span
               style={{
-                fontSize: shouldUseMobileUI ? "14px" : "12px",
-                fontWeight: 600,
+                fontSize: shouldUseMobileUI ? 12 : 10,
+                fontWeight: 700,
                 color: theme.colors.text.accent,
+                lineHeight: 1,
+                position: "relative",
+                top: -2,
+                textShadow: "1px 1px 1px rgba(0,0,0,0.5)",
               }}
             >
               {totalLevel}
             </span>
-          </div>
-          <div
-            style={{
-              width: "1px",
-              background: `${theme.colors.border.default}30`,
-              margin: "0 4px",
-            }}
-          />
-          <div className="text-center flex-1">
-            <div
-              style={{
-                fontSize: shouldUseMobileUI ? "8px" : "7px",
-                color: theme.colors.text.muted,
-                textTransform: "uppercase",
-                letterSpacing: "0.3px",
-                marginBottom: "1px",
-              }}
-            >
-              Combat Level
-            </div>
             <span
               style={{
-                fontSize: shouldUseMobileUI ? "14px" : "12px",
-                fontWeight: 600,
+                fontSize: shouldUseMobileUI ? 10 : 9,
+                fontWeight: 400,
+                color: theme.colors.text.disabled,
+                lineHeight: 1,
+                margin: "0 2px",
+                transform: "rotate(-20deg)",
+                display: "inline-block",
+              }}
+            >
+              /
+            </span>
+            <span
+              style={{
+                fontSize: shouldUseMobileUI ? 12 : 10,
+                fontWeight: 700,
                 color: theme.colors.state.danger,
+                lineHeight: 1,
+                position: "relative",
+                top: 2,
+                textShadow: "1px 1px 1px rgba(0,0,0,0.5)",
               }}
             >
               {combatLevel}
@@ -392,180 +363,171 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
         </div>
       </div>
 
+      {/* Skills Grid - Mobile: 2 columns with names, Desktop: 3 columns compact */}
+      <div
+        className="grid flex-1 overflow-hidden"
+        style={{
+          ...getPanelInsetStyle(theme, {
+            emphasis: "strong",
+            radius: 4,
+          }),
+          padding: shouldUseMobileUI ? MOBILE_SKILLS.gap : PANEL_PADDING,
+          gridTemplateColumns: shouldUseMobileUI
+            ? `repeat(${MOBILE_SKILLS.columns}, 1fr)`
+            : "repeat(3, 1fr)",
+          gap: shouldUseMobileUI
+            ? `${MOBILE_SKILLS.gap}px`
+            : `${PANEL_GRID_GAP}px`,
+        }}
+      >
+        {skills.map((skill) => (
+          <DraggableSkillCard
+            key={skill.key}
+            skill={skill}
+            isHovered={hoveredSkill?.key === skill.key}
+            isMobile={shouldUseMobileUI}
+            onClick={setGuideSkill}
+            onMouseEnter={(e) => {
+              setHoveredSkill(skill);
+              setMousePos({ x: e.clientX, y: e.clientY });
+            }}
+            onMouseMove={(e) => setMousePos({ x: e.clientX, y: e.clientY })}
+            onMouseLeave={() => {
+              setHoveredSkill(null);
+            }}
+          />
+        ))}
+      </div>
+
       {/* Skill Tooltip */}
       {hoveredSkill &&
-        createPortal(
-          (() => {
-            const currentLevelXP = calculateXPForLevel(hoveredSkill.level);
-            const nextLevelXP = calculateXPForLevel(hoveredSkill.level + 1);
-            const xpRemaining = nextLevelXP - hoveredSkill.xp;
-            const xpIntoLevel = hoveredSkill.xp - currentLevelXP;
-            const xpForThisLevel = nextLevelXP - currentLevelXP;
-            const progress = Math.min(
-              100,
-              Math.max(0, (xpIntoLevel / xpForThisLevel) * 100),
-            );
+        (() => {
+          const currentLevelXP = calculateXPForLevel(hoveredSkill.level);
+          const nextLevelXP = calculateXPForLevel(hoveredSkill.level + 1);
+          const xpRemaining = nextLevelXP - hoveredSkill.xp;
+          const xpIntoLevel = hoveredSkill.xp - currentLevelXP;
+          const xpForThisLevel = nextLevelXP - currentLevelXP;
+          const progress = Math.min(
+            100,
+            Math.max(0, (xpIntoLevel / xpForThisLevel) * 100),
+          );
 
-            const tooltipSize = {
-              width: skillTooltipSize.width || 180,
-              height: skillTooltipSize.height || 90,
-            };
-            const { left, top } = calculateCursorTooltipPosition(
-              mousePos,
-              tooltipSize,
-            );
-
-            return (
-              <div
-                ref={skillTooltipRef}
-                className="fixed pointer-events-none"
-                style={{
-                  left,
-                  top,
-                  zIndex: zIndex.tooltip,
-                  background:
-                    theme.name === "hyperscape"
-                      ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
-                      : theme.colors.slot.filled,
-                  border: `1px solid ${theme.colors.border.default}50`,
-                  borderRadius: theme.borderRadius.md,
-                  padding: "6px 8px",
-                  minWidth: "140px",
-                  boxShadow: `${theme.shadows.md}, inset 0 1px 0 rgba(255,255,255,0.04)`,
-                }}
-              >
-                {/* Header */}
-                <div className="flex items-center gap-1.5 mb-1.5">
-                  <span style={{ fontSize: "14px" }}>{hoveredSkill.icon}</span>
-                  <span
-                    style={{
-                      fontSize: "11px",
-                      fontWeight: 600,
-                      color: theme.colors.text.accent,
-                    }}
-                  >
-                    {hoveredSkill.label}
-                  </span>
-                  <span
-                    style={{
-                      marginLeft: "auto",
-                      fontSize: "10px",
-                      fontWeight: 600,
-                      color:
-                        hoveredSkill.level >= 99
-                          ? theme.colors.state.success
-                          : theme.colors.text.accent,
-                    }}
-                  >
-                    Lvl {hoveredSkill.level}
-                  </span>
-                </div>
-
-                {/* XP Info */}
-                <div
-                  style={{
-                    fontSize: "9px",
-                    color: theme.colors.text.secondary,
-                    marginBottom: "2px",
-                  }}
-                >
-                  XP: {hoveredSkill.xp.toLocaleString()}
-                </div>
-                <div
-                  style={{
-                    fontSize: "9px",
-                    color: theme.colors.text.muted,
-                    marginBottom: "4px",
-                  }}
-                >
-                  {hoveredSkill.level >= 99
-                    ? "Max level reached!"
-                    : `${xpRemaining.toLocaleString()} XP to level ${hoveredSkill.level + 1}`}
-                </div>
-
-                {/* Progress bar */}
-                {hoveredSkill.level < 99 && (
-                  <div
-                    style={{
-                      height: "3px",
-                      background: theme.colors.slot.empty,
-                      borderRadius: theme.borderRadius.sm,
-                      overflow: "hidden",
-                    }}
-                  >
-                    <div
-                      style={{
-                        height: "100%",
-                        width: `${progress}%`,
-                        background: theme.colors.accent.secondary,
-                        borderRadius: theme.borderRadius.sm,
-                      }}
-                    />
-                  </div>
-                )}
-              </div>
-            );
-          })(),
-          document.body,
-        )}
-
-      {/* Total Level XP Tooltip */}
-      {hoveredTotalLevel &&
-        createPortal(
-          (() => {
-            const tooltipSize = {
-              width: totalLevelTooltipSize.width || 140,
-              height: totalLevelTooltipSize.height || 50,
-            };
-            const { left, top } = calculateCursorTooltipPosition(
-              mousePos,
-              tooltipSize,
-            );
-
-            return (
-              <div
-                ref={totalLevelTooltipRef}
-                className="fixed pointer-events-none"
-                style={{
-                  left,
-                  top,
-                  zIndex: zIndex.tooltip,
-                  background:
-                    theme.name === "hyperscape"
-                      ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
-                      : theme.colors.slot.filled,
-                  border: `1px solid ${theme.colors.border.default}50`,
-                  borderRadius: theme.borderRadius.md,
-                  padding: "6px 8px",
-                  minWidth: "120px",
-                  boxShadow: `${theme.shadows.md}, inset 0 1px 0 rgba(255,255,255,0.04)`,
-                }}
-              >
-                <div
-                  style={{
-                    fontSize: "9px",
-                    color: theme.colors.text.muted,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.3px",
-                    marginBottom: "2px",
-                  }}
-                >
-                  Total XP
-                </div>
-                <div
+          return (
+            <CursorTooltip
+              visible={!!hoveredSkill}
+              position={mousePos}
+              estimatedSize={{ width: 140, height: 90 }}
+              style={{
+                minWidth: "140px",
+                zIndex: zIndex.tooltip,
+              }}
+            >
+              {/* Header */}
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <span style={{ fontSize: "14px" }}>{hoveredSkill.icon}</span>
+                <span
                   style={{
                     fontSize: "11px",
                     fontWeight: 600,
                     color: theme.colors.text.accent,
                   }}
                 >
-                  {totalXP.toLocaleString()}
-                </div>
+                  {hoveredSkill.label}
+                </span>
+                <span
+                  style={{
+                    marginLeft: "auto",
+                    fontSize: "10px",
+                    fontWeight: 600,
+                    color:
+                      hoveredSkill.level >= 99
+                        ? theme.colors.state.success
+                        : theme.colors.text.accent,
+                  }}
+                >
+                  Lvl {hoveredSkill.level}
+                </span>
               </div>
-            );
-          })(),
-          document.body,
-        )}
+
+              {/* XP Info */}
+              <div
+                style={{
+                  fontSize: "9px",
+                  color: theme.colors.text.secondary,
+                  marginBottom: "2px",
+                }}
+              >
+                XP: {hoveredSkill.xp.toLocaleString()}
+              </div>
+              <div
+                style={{
+                  fontSize: "9px",
+                  color: theme.colors.text.muted,
+                  marginBottom: "4px",
+                }}
+              >
+                {hoveredSkill.level >= 99
+                  ? "Max level reached!"
+                  : `${xpRemaining.toLocaleString()} XP to level ${hoveredSkill.level + 1}`}
+              </div>
+
+              {/* Progress bar */}
+              {hoveredSkill.level < 99 && (
+                <div
+                  style={{
+                    height: "3px",
+                    background: theme.colors.slot.empty,
+                    borderRadius: theme.borderRadius.sm,
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      height: "100%",
+                      width: `${progress}%`,
+                      background: theme.colors.accent.secondary,
+                      borderRadius: theme.borderRadius.sm,
+                    }}
+                  />
+                </div>
+              )}
+            </CursorTooltip>
+          );
+        })()}
+
+      {/* Total Level XP Tooltip */}
+      {hoveredTotalLevel && (
+        <CursorTooltip
+          visible={true}
+          position={mousePos}
+          estimatedSize={{ width: 120, height: 50 }}
+          style={{
+            minWidth: "120px",
+            zIndex: zIndex.tooltip,
+          }}
+        >
+          <div
+            style={{
+              fontSize: "9px",
+              color: theme.colors.text.muted,
+              textTransform: "uppercase",
+              letterSpacing: "0.3px",
+              marginBottom: "2px",
+            }}
+          >
+            Total XP
+          </div>
+          <div
+            style={{
+              fontSize: "11px",
+              fontWeight: 600,
+              color: theme.colors.text.accent,
+            }}
+          >
+            {totalXP.toLocaleString()}
+          </div>
+        </CursorTooltip>
+      )}
 
       {/* Skill Guide Modal — portaled to body so it renders center-screen */}
       {guideSkill &&

--- a/packages/client/src/game/panels/SpellsPanel.tsx
+++ b/packages/client/src/game/panels/SpellsPanel.tsx
@@ -15,30 +15,36 @@ import React, {
   useMemo,
 } from "react";
 import { createPortal } from "react-dom";
-import {
-  calculateCursorTooltipPosition,
-  useThemeStore,
-  useMobileLayout,
-} from "@/ui";
+import { useThemeStore, useMobileLayout, CursorTooltip } from "@/ui";
 import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
 } from "@/ui/theme/themes";
 import { zIndex } from "../../constants";
-import { useTooltipSize } from "../../hooks";
+import {
+  PANEL_ICON_SIZE,
+  PANEL_GRID_GAP,
+  PANEL_PADDING,
+  PANEL_GRID_PADDING,
+  PANEL_MOBILE_PADDING,
+  PANEL_MOBILE_ICON_SIZE,
+  PANEL_MOBILE_GRID_GAP,
+  PANEL_SLOT_RADIUS,
+} from "../../constants/panelLayout";
 import type { PlayerStats, ClientWorld } from "../../types";
 import { spellService, EventType, type Spell } from "@hyperscape/shared";
 
-// Spell panel layout constants
-const SPELL_ICON_SIZE = 40;
-const SPELL_GAP = 4;
-const PANEL_PADDING = 8;
-const GRID_PADDING = 6;
+// Spell panel layout constants — use shared sizing tokens from panelLayout.ts
+// to ensure consistency across Prayer, Spells, Skills, and Inventory panels.
+const SPELL_ICON_SIZE = PANEL_ICON_SIZE; // 36px desktop icon size
+const SPELL_GAP = PANEL_GRID_GAP; // 3px gap between slots
+// PANEL_PADDING re-exported from constants barrel
+const GRID_PADDING = PANEL_GRID_PADDING; // alias for local use
 
-// Mobile constants
-const MOBILE_SPELL_ICON_SIZE = 52;
-const MOBILE_SPELL_GAP = 6;
+// Mobile constants – use shared mobile icon size token
+const MOBILE_SPELL_ICON_SIZE = PANEL_MOBILE_ICON_SIZE; // 48px (touch target)
+const MOBILE_SPELL_GAP = PANEL_MOBILE_GRID_GAP; // 6px
 
 /**
  * Calculate number of columns based on container width
@@ -49,7 +55,8 @@ function calculateColumns(containerWidth: number, isMobile: boolean): number {
   const availableWidth = containerWidth - PANEL_PADDING * 2 - GRID_PADDING * 2;
   const colWidth = iconSize + gap;
   const maxCols = Math.floor((availableWidth + gap) / colWidth);
-  return Math.max(2, Math.min(4, maxCols));
+  // 5 columns by default (matches PrayerPanel), adapt for narrower windows
+  return Math.max(2, Math.min(5, maxCols));
 }
 
 /** Export dimensions for window configuration */
@@ -129,6 +136,8 @@ function SpellIcon({
   const isUnlocked = playerLevel >= spell.level;
   const isSelected = spell.isSelected;
 
+  const [isHovered, setIsHovered] = React.useState(false);
+
   const iconSize = isMobile ? MOBILE_SPELL_ICON_SIZE : SPELL_ICON_SIZE;
 
   const buttonStyle = useMemo(
@@ -136,16 +145,24 @@ function SpellIcon({
       width: iconSize,
       height: iconSize,
       padding: 0,
+      background:
+        isHovered && isUnlocked
+          ? "rgba(183, 140, 76, 0.08)"
+          : "var(--color-slot-empty)",
       ...getInteractiveTileStyle(theme, {
         active: isSelected,
+        hovered: isHovered,
         disabled: !isUnlocked,
-        radius: isMobile ? 6 : 4,
-        accentColor: getElementColor(spell.element),
+        radius: 4, // Square matching equipment/inventory UI
+        accentColor: getElementColor(spell.element), // Keep logic
       }),
-      border: isSelected
-        ? `2px solid ${getElementColor(spell.element)}B3`
-        : `1px solid ${theme.colors.border.default}40`,
-      borderRadius: isMobile ? 6 : 4,
+      borderColor: isSelected
+        ? `${getElementColor(spell.element)}B3`
+        : isHovered && isUnlocked
+          ? "rgba(183, 140, 76, 0.4)"
+          : "rgba(8, 8, 10, 0.6)",
+      borderWidth: "1px",
+      borderRadius: 4,
       cursor: isUnlocked ? "pointer" : "not-allowed",
       display: "flex",
       alignItems: "center",
@@ -153,20 +170,36 @@ function SpellIcon({
       position: "relative",
       overflow: "hidden",
       boxShadow: isSelected
-        ? `0 0 ${isMobile ? 14 : 10}px ${getElementColor(spell.element)}80, inset 0 0 ${isMobile ? 18 : 12}px ${getElementColor(spell.element)}33`
-        : "inset 0 1px 2px rgba(0, 0, 0, 0.4)",
+        ? `0 0 ${isMobile ? 12 : 8}px ${getElementColor(spell.element)}80, inset 0 0 ${isMobile ? 16 : 10}px ${getElementColor(spell.element)}33, inset 2px 2px 4px rgba(0, 0, 0, 0.34)`
+        : isHovered && isUnlocked
+          ? "inset 2px 2px 4px rgba(0, 0, 0, 0.5), inset -1px -1px 2px rgba(183, 140, 76, 0.15)"
+          : "inset 2px 2px 4px rgba(0, 0, 0, 0.42), inset -1px -1px 2px rgba(88, 74, 56, 0.12)",
       opacity: isUnlocked ? 1 : 0.5,
     }),
-    [isSelected, isUnlocked, theme, iconSize, isMobile, spell.element],
+    [
+      isSelected,
+      isUnlocked,
+      isHovered,
+      theme,
+      iconSize,
+      isMobile,
+      spell.element,
+    ],
   );
 
   return (
     <button
       onClick={isUnlocked ? onClick : undefined}
       onContextMenu={onContextMenu}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={(e) => {
+        setIsHovered(true);
+        onMouseEnter(e);
+      }}
       onMouseMove={onMouseMove}
-      onMouseLeave={onMouseLeave}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        onMouseLeave();
+      }}
       disabled={!isUnlocked}
       aria-label={`${spell.name}${isSelected ? " (Selected)" : ""}${!isUnlocked ? " (Locked)" : ""}`}
       className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
@@ -252,16 +285,10 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
     y: 0,
     spell: null,
   });
-  const spellTooltipRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
   const playerMagicLevel = stats?.skills?.magic?.level ?? 1;
-
-  const spellTooltipSize = useTooltipSize(hoveredSpell, spellTooltipRef, {
-    width: 220,
-    height: 150,
-  });
 
   // Track container width for adaptive layout
   useEffect(() => {
@@ -383,91 +410,75 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
       className="flex flex-col h-full"
       style={{
         ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-        padding: PANEL_PADDING,
+        padding: shouldUseMobileUI ? PANEL_MOBILE_PADDING : PANEL_PADDING,
       }}
     >
-      {/* Header */}
+      {/* Magic Level Header — mirrors Prayer's prayer-points header */}
       <div
         style={{
+          ...getPanelInsetStyle(theme, { emphasis: "normal", radius: 4 }),
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          padding: shouldUseMobileUI ? "6px 8px" : "4px 8px",
-          marginBottom: 6,
-          ...getPanelInsetStyle(theme, {
-            emphasis: "normal",
-            radius: theme.borderRadius.md,
-          }),
+          padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
+          marginBottom: 4,
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontSize: shouldUseMobileUI ? 18 : 16 }}>🔮</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: shouldUseMobileUI ? 16 : 14 }}>🔮</span>
           <div>
             <div
               style={{
-                fontSize: shouldUseMobileUI ? 10 : 9,
+                fontSize: shouldUseMobileUI ? 9 : 8,
                 color: theme.colors.text.muted,
                 textTransform: "uppercase",
                 letterSpacing: 0.5,
               }}
             >
-              Spellbook
-            </div>
-            <div
-              style={{
-                fontSize: shouldUseMobileUI ? 14 : 12,
-                fontWeight: 600,
-                color: theme.colors.text.primary,
-              }}
-            >
-              Magic Level: {playerMagicLevel}
+              Magic Level
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Selected spell indicator */}
-      {selectedSpellId && (
+        {/* Magic level value on the right — always visible, matches prayer panel pattern */}
         <div
           style={{
-            padding: shouldUseMobileUI ? "6px 8px" : "4px 8px",
-            marginBottom: 6,
-            ...getPanelInsetStyle(theme, {
-              emphasis: "normal",
-              radius: theme.borderRadius.md,
-            }),
-            background: `${getElementColor(spells.find((s) => s.id === selectedSpellId)?.element || "air")}1f`,
-            border: `1px solid ${getElementColor(spells.find((s) => s.id === selectedSpellId)?.element || "air")}40`,
-            fontSize: shouldUseMobileUI ? 11 : 10,
-            color: theme.colors.text.secondary,
+            textAlign: "right",
             display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: 2,
           }}
         >
-          <span>
-            Autocast:{" "}
-            <span style={{ color: theme.colors.text.primary, fontWeight: 600 }}>
-              {spells.find((s) => s.id === selectedSpellId)?.name}
-            </span>
-          </span>
-          <button
-            onClick={() => selectSpell(selectedSpellId)}
+          <div
             style={{
-              background: "transparent",
-              border: "none",
-              color: theme.colors.state.danger,
-              cursor: "pointer",
-              fontSize: shouldUseMobileUI ? 11 : 10,
-              padding: "2px 6px",
+              fontSize: shouldUseMobileUI ? 13 : 11,
+              fontWeight: 600,
+              color: theme.colors.accent.secondary,
             }}
           >
-            Clear
-          </button>
+            {playerMagicLevel}
+          </div>
+          {selectedSpellId && (
+            <div
+              style={{
+                fontSize: 8,
+                color: theme.colors.state.success,
+                textTransform: "uppercase",
+                opacity: 0.8,
+                maxWidth: 64,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              ✓ {spells.find((s) => s.id === selectedSpellId)?.name ?? ""}
+            </div>
+          )}
         </div>
-      )}
+      </div>
 
-      {/* Spell Grid */}
+      {/* Spell Grid — mirrors PrayerPanel grid exactly */}
       <div
         className="scrollbar-thin"
         style={{
@@ -479,14 +490,13 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
       >
         <div
           style={{
+            ...getPanelInsetStyle(theme, { emphasis: "strong", radius: 4 }),
             display: "grid",
-            gridTemplateColumns: `repeat(${gridColumns}, ${iconSize}px)`,
-            gap: gap,
-            padding: GRID_PADDING,
-            ...getPanelInsetStyle(theme, {
-              emphasis: "strong",
-              radius: theme.borderRadius.md,
-            }),
+            gridTemplateColumns: shouldUseMobileUI
+              ? `repeat(${gridColumns}, ${MOBILE_SPELL_ICON_SIZE}px)`
+              : `repeat(${gridColumns}, ${SPELL_ICON_SIZE}px)`,
+            gap: shouldUseMobileUI ? MOBILE_SPELL_GAP : SPELL_GAP,
+            padding: "8px 4px",
             justifyContent: "center",
           }}
         >
@@ -515,160 +525,180 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
         </div>
       </div>
 
-      {/* Spell Tooltip */}
-      {hoveredSpell &&
-        createPortal(
-          (() => {
-            const tooltipSize = {
-              width: spellTooltipSize.width || 220,
-              height: spellTooltipSize.height || 150,
-            };
-            const { left, top } = calculateCursorTooltipPosition(
-              mousePos,
-              tooltipSize,
-            );
-            const isUnlocked = playerMagicLevel >= hoveredSpell.level;
+      {/* Footer — mirrors Prayer's "Active: X / Deactivate All" row */}
+      <div
+        style={{
+          ...getPanelInsetStyle(theme, { emphasis: "normal", radius: 4 }),
+          marginTop: 4,
+          padding: shouldUseMobileUI ? "4px 6px" : "3px 6px",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <span
+          style={{
+            fontSize: shouldUseMobileUI ? 10 : 9,
+            color: theme.colors.text.muted,
+          }}
+        >
+          {selectedSpellId
+            ? `Autocast: ${spells.find((s) => s.id === selectedSpellId)?.name ?? ""}`
+            : "No autocast set"}
+        </span>
+        <button
+          onClick={() => selectedSpellId && selectSpell(selectedSpellId)}
+          disabled={!selectedSpellId}
+          className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+          style={{
+            padding: shouldUseMobileUI ? "3px 8px" : "2px 6px",
+            fontSize: shouldUseMobileUI ? 10 : 9,
+            background: selectedSpellId
+              ? `linear-gradient(180deg, ${theme.colors.state.danger}26 0%, rgba(39, 15, 15, 0.28) 100%)`
+              : theme.colors.slot.disabled,
+            border: `1px solid ${
+              selectedSpellId
+                ? theme.colors.state.danger
+                : theme.colors.border.default
+            }40`,
+            borderRadius: 4,
+            color: selectedSpellId
+              ? theme.colors.state.danger
+              : theme.colors.text.disabled,
+            cursor: selectedSpellId ? "pointer" : "default",
+          }}
+        >
+          Clear
+        </button>
+      </div>
 
-            return (
+      {/* Spell Tooltip */}
+      <CursorTooltip
+        visible={!!hoveredSpell && !contextMenu.visible}
+        position={mousePos}
+      >
+        {hoveredSpell && (
+          <div
+            style={{
+              background:
+                theme.name === "hyperscape"
+                  ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
+                  : `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.primary} 100%)`,
+              border: `1px solid ${getElementColor(hoveredSpell.element)}50`,
+              borderRadius: theme.borderRadius.md,
+              padding: "12px 14px",
+              boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255,255,255,0.04)`,
+              minWidth: 200,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                marginBottom: 8,
+              }}
+            >
+              <span style={{ fontSize: 28 }}>
+                {ELEMENT_ICONS[hoveredSpell.element] || "✨"}
+              </span>
+              <div>
+                <div
+                  style={{
+                    fontSize: 15,
+                    fontWeight: 700,
+                    color: getElementColor(hoveredSpell.element),
+                  }}
+                >
+                  {hoveredSpell.name}
+                </div>
+                <div style={{ fontSize: 11, color: theme.colors.text.muted }}>
+                  Level {hoveredSpell.level} Magic
+                </div>
+              </div>
+            </div>
+
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 6,
+                fontSize: 11,
+                marginBottom: 10,
+              }}
+            >
+              <div style={{ color: theme.colors.text.muted }}>
+                Max Hit:{" "}
+                <span style={{ color: theme.colors.state.danger }}>
+                  {hoveredSpell.baseMaxHit}
+                </span>
+              </div>
+              <div style={{ color: theme.colors.text.muted }}>
+                XP:{" "}
+                <span style={{ color: theme.colors.state.success }}>
+                  {hoveredSpell.baseXp}
+                </span>
+              </div>
+            </div>
+
+            <div
+              style={{
+                fontSize: 10,
+                color: theme.colors.text.muted,
+                marginBottom: 8,
+              }}
+            >
+              <div style={{ marginBottom: 4, fontWeight: 600 }}>Rune Cost:</div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {hoveredSpell.runes.map((rune, idx) => (
+                  <span
+                    key={idx}
+                    style={{
+                      background: theme.colors.slot.filled,
+                      padding: "2px 6px",
+                      borderRadius: theme.borderRadius.sm,
+                      color: theme.colors.text.secondary,
+                    }}
+                  >
+                    {rune.quantity}x{" "}
+                    {rune.runeId.replace("_rune", "").replace("_", " ")}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {playerMagicLevel < hoveredSpell.level && (
               <div
-                ref={spellTooltipRef}
-                className="fixed pointer-events-none"
                 style={{
-                  left,
-                  top,
-                  zIndex: zIndex.tooltip,
-                  background:
-                    theme.name === "hyperscape"
-                      ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
-                      : `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.primary} 100%)`,
-                  border: `1px solid ${getElementColor(hoveredSpell.element)}50`,
-                  borderRadius: theme.borderRadius.md,
-                  padding: "12px 14px",
-                  boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255,255,255,0.04)`,
-                  minWidth: 200,
+                  padding: "5px 10px",
+                  background: `${theme.colors.state.danger}26`,
+                  borderRadius: theme.borderRadius.sm,
+                  fontSize: 11,
+                  color: theme.colors.state.danger,
+                  textAlign: "center",
                 }}
               >
-                {/* Header */}
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 10,
-                    marginBottom: 8,
-                  }}
-                >
-                  <span style={{ fontSize: 28 }}>
-                    {ELEMENT_ICONS[hoveredSpell.element] || "✨"}
-                  </span>
-                  <div>
-                    <div
-                      style={{
-                        fontSize: 15,
-                        fontWeight: 700,
-                        color: getElementColor(hoveredSpell.element),
-                      }}
-                    >
-                      {hoveredSpell.name}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 11,
-                        color: theme.colors.text.muted,
-                      }}
-                    >
-                      Level {hoveredSpell.level} Magic
-                    </div>
-                  </div>
-                </div>
-
-                {/* Stats */}
-                <div
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 1fr",
-                    gap: 6,
-                    fontSize: 11,
-                    marginBottom: 10,
-                  }}
-                >
-                  <div style={{ color: theme.colors.text.muted }}>
-                    Max Hit:{" "}
-                    <span style={{ color: theme.colors.state.danger }}>
-                      {hoveredSpell.baseMaxHit}
-                    </span>
-                  </div>
-                  <div style={{ color: theme.colors.text.muted }}>
-                    XP:{" "}
-                    <span style={{ color: theme.colors.state.success }}>
-                      {hoveredSpell.baseXp}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Rune cost */}
-                <div
-                  style={{
-                    fontSize: 10,
-                    color: theme.colors.text.muted,
-                    marginBottom: 8,
-                  }}
-                >
-                  <div style={{ marginBottom: 4, fontWeight: 600 }}>
-                    Rune Cost:
-                  </div>
-                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                    {hoveredSpell.runes.map((rune, idx) => (
-                      <span
-                        key={idx}
-                        style={{
-                          background: theme.colors.slot.filled,
-                          padding: "2px 6px",
-                          borderRadius: theme.borderRadius.sm,
-                          color: theme.colors.text.secondary,
-                        }}
-                      >
-                        {rune.quantity}x{" "}
-                        {rune.runeId.replace("_rune", "").replace("_", " ")}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Status */}
-                {!isUnlocked && (
-                  <div
-                    style={{
-                      padding: "5px 10px",
-                      background: `${theme.colors.state.danger}26`,
-                      borderRadius: theme.borderRadius.sm,
-                      fontSize: 11,
-                      color: theme.colors.state.danger,
-                      textAlign: "center",
-                    }}
-                  >
-                    Requires level {hoveredSpell.level} Magic
-                  </div>
-                )}
-                {hoveredSpell.isSelected && (
-                  <div
-                    style={{
-                      padding: "5px 10px",
-                      background: `${theme.colors.state.success}26`,
-                      borderRadius: theme.borderRadius.sm,
-                      fontSize: 11,
-                      color: theme.colors.state.success,
-                      textAlign: "center",
-                      fontWeight: 600,
-                    }}
-                  >
-                    Currently Selected for Autocast
-                  </div>
-                )}
+                Requires level {hoveredSpell.level} Magic
               </div>
-            );
-          })(),
-          document.body,
+            )}
+            {hoveredSpell.isSelected && (
+              <div
+                style={{
+                  padding: "5px 10px",
+                  background: `${theme.colors.state.success}26`,
+                  borderRadius: theme.borderRadius.sm,
+                  fontSize: 11,
+                  color: theme.colors.state.success,
+                  textAlign: "center",
+                  fontWeight: 600,
+                }}
+              >
+                Currently Selected for Autocast
+              </div>
+            )}
+          </div>
         )}
+      </CursorTooltip>
 
       {/* Context Menu */}
       {contextMenu.visible &&
@@ -692,7 +722,6 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
               overflow: "hidden",
             }}
           >
-            {/* Menu Header */}
             <div
               style={{
                 padding: "6px 10px",
@@ -706,7 +735,6 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
               {contextMenu.spell.name}
             </div>
 
-            {/* Autocast option */}
             {playerMagicLevel >= contextMenu.spell.level && (
               <button
                 onClick={() => {
@@ -742,7 +770,6 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
               </button>
             )}
 
-            {/* Locked message */}
             {playerMagicLevel < contextMenu.spell.level && (
               <div
                 style={{
@@ -756,11 +783,10 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
               </div>
             )}
 
-            {/* Cancel option */}
             <button
-              onClick={() => {
-                setContextMenu((prev) => ({ ...prev, visible: false }));
-              }}
+              onClick={() =>
+                setContextMenu((prev) => ({ ...prev, visible: false }))
+              }
               className="w-full text-left transition-colors duration-75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-amber-400/60"
               style={{
                 padding: "6px 10px",
@@ -785,7 +811,6 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
           document.body,
         )}
 
-      {/* CSS for pulse animation */}
       <style>{`
         @keyframes pulse {
           0%, 100% { opacity: 1; }

--- a/packages/client/src/game/panels/equipment/EquipmentIcons.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentIcons.tsx
@@ -1,221 +1,113 @@
 import React from "react";
 
 // ============================================================================
-// SVG Icons for Equipment Slots (Clean monochrome design)
+// SVG Icons for Equipment Slots (Solid Geometric Silhouette Design)
 // ============================================================================
 
-/** Helmet/Head slot icon */
 export function HelmetIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M12 2C7 2 4 6 4 10v4c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-4c0-4-3-8-8-8z" />
-      <path d="M4 12h16" />
-      <path d="M8 16v2M16 16v2" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 5l6-3 6 3v6l-2 8H8l-2-8V5zm6 3H9v5h2v2h2v-2h2V8h-3z"
+      />
     </svg>
   );
 }
 
-/** Weapon slot icon (crossed swords) */
 export function WeaponIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M14.5 17.5L3 6V3h3l11.5 11.5" />
-      <path d="M13 19l6-6" />
-      <path d="M16 16l4 4" />
-      <path d="M19 21l2-2" />
-      <path d="M9.5 6.5L21 18V21h-3L6.5 9.5" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M15 3h6v6l-2-2-6 6 3 3-2 2-4-4-4 4-2-2 4-4-4-4 2-2 3 3 6-6-2-2z" />
     </svg>
   );
 }
 
-/** Body/Chest armor slot icon */
 export function BodyIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M6 4l-2 2v12l2 2h12l2-2V6l-2-2" />
-      <path d="M6 4h12" />
-      <path d="M9 4v3c0 1.7 1.3 3 3 3s3-1.3 3-3V4" />
-      <path d="M4 8h2M18 8h2" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 3h12l4 6-3 3v9H5v-9L2 9l4-6zm3 4v3h6V7H9z"
+      />
     </svg>
   );
 }
 
-/** Shield slot icon */
 export function ShieldIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M3 4h18v7l-9 11L3 11V4z" />
     </svg>
   );
 }
 
-/** Legs slot icon */
 export function LegsIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M6 4h12v4l-1 12H7L6 8V4z" />
-      <path d="M12 4v16" />
-      <path d="M6 8h12" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M5 3h14v8l-3 2v8H9v-8L6 11V3zM9 5H7v5l2 1V5zm6 0h-2v6l2-1V5z" />
     </svg>
   );
 }
 
-/** Arrows/Ammo slot icon */
 export function ArrowsIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      {/* Arrow shaft */}
-      <path d="M5 19L19 5" />
-      {/* Arrow head */}
-      <path d="M15 5h4v4" />
-      {/* Arrow fletching */}
-      <path d="M5 19l3-1M5 19l1-3" />
-      {/* Second arrow (stacked) */}
-      <path d="M8 16L18 6" strokeOpacity="0.5" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M15 3h6v6l-1-1-8 8-4-4 8-8-1-1zm-6 8l-5 5 2 2 5-5-2-2zm5 5l-5 5 2 2 5-5-2-2z" />
     </svg>
   );
 }
 
-/** Boots slot icon */
 export function BootsIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M7 3v8l-3 4v5h6l1-3h2l1 3h6v-5l-3-4V3" />
-      <path d="M7 11h10" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M7 4h10v9l4 4v4H5v-5l2-3V4z" />
     </svg>
   );
 }
 
-/** Gloves slot icon */
 export function GlovesIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M6 14V8a2 2 0 0 1 4 0v1a2 2 0 0 1 4 0v-1a2 2 0 0 1 4 0v6" />
-      <path d="M6 14c0 4 2 7 6 7s6-3 6-7" />
-      <path d="M10 9V6a2 2 0 0 0-4 0v2" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M5 4h14v7l2 4-3 5H6l-3-5 2-4V4z" />
     </svg>
   );
 }
 
-/** Cape slot icon */
 export function CapeIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M8 3h8v2l1 14-5 3-5-3 1-14V3z" />
-      <path d="M8 3c-1 0-2 1-2 2M16 3c1 0 2 1 2 2" />
-      <path d="M9 7h6" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 3h12l3 18H3L6 3zm2 4v4h8V7H8z"
+      />
     </svg>
   );
 }
 
-/** Amulet/Necklace slot icon */
 export function AmuletIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M7 4c0 3 2 6 5 8 3-2 5-5 5-8" />
-      <circle cx="12" cy="15" r="3" />
-      <path d="M12 18v1" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 3h12v4l-4 5v-2L10 8v2L6 7V3zm2 3h8v1L12 9l-4-2V6zm3 7h2v5l-1 2-1-2v-5z"
+      />
     </svg>
   );
 }
 
-/** Ring slot icon */
 export function RingIcon({ className }: { className?: string }) {
   return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <ellipse cx="12" cy="14" rx="6" ry="4" />
-      <ellipse cx="12" cy="14" rx="3.5" ry="2" />
-      <path d="M10 7l2-4 2 4" />
-      <path d="M10 7h4" />
-      <path d="M12 7v3" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 10l3-5h6l3 5v4l-3 5H9l-3-5v-4zm3-.5L10.5 7h3l1.5 2.5V13l-1.5 2.5h-3L9 13V9.5z"
+      />
     </svg>
   );
 }
@@ -224,7 +116,6 @@ export function RingIcon({ className }: { className?: string }) {
 // Utility Button Icons
 // ============================================================================
 
-/** Stats icon (bar chart) */
 export function StatsIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -232,8 +123,7 @@ export function StatsIcon({ className }: { className?: string }) {
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      strokeLinecap="square"
       className={className}
     >
       <path d="M18 20V10M12 20V4M6 20v-6" />
@@ -241,7 +131,6 @@ export function StatsIcon({ className }: { className?: string }) {
   );
 }
 
-/** Death/Skull icon */
 export function DeathIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -249,13 +138,12 @@ export function DeathIcon({ className }: { className?: string }) {
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      strokeLinecap="square"
       className={className}
     >
       <circle cx="12" cy="10" r="7" />
-      <circle cx="9" cy="9" r="1.5" fill="currentColor" />
-      <circle cx="15" cy="9" r="1.5" fill="currentColor" />
+      <circle cx="9" cy="9" r="1.5" fill="currentColor" stroke="none" />
+      <circle cx="15" cy="9" r="1.5" fill="currentColor" stroke="none" />
       <path d="M8 17v4M12 17v4M16 17v4" />
       <path d="M9 14c.8.7 1.9 1 3 1s2.2-.3 3-1" />
     </svg>

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -2,7 +2,9 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { EventType, THREE, createRenderer } from "@hyperscape/shared";
 import type { WebGPURenderer } from "@hyperscape/shared";
 import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
+import { MeshStandardNodeMaterial } from "three/webgpu";
 import { useThemeStore } from "@/ui";
+import { getPanelInsetStyle } from "@/ui/theme/themes";
 import type { ClientWorld } from "../../../types";
 
 type PortraitMode = "loading" | "live" | "fallback";
@@ -23,6 +25,7 @@ interface AvatarCarrier {
 }
 
 interface PlayerWithLiveAvatar {
+  id?: string;
   _avatar?: AvatarCarrier;
   avatar?: AvatarCarrier;
 }
@@ -32,25 +35,111 @@ type MaterialCarrier = THREE.Object3D & {
   frustumCulled?: boolean;
 };
 
+type StandardLikeMaterial = THREE.Material & {
+  color?: THREE.Color;
+  emissive?: THREE.Color;
+  emissiveIntensity?: number;
+  roughness?: number;
+  metalness?: number;
+  envMapIntensity?: number;
+  opacity?: number;
+  transparent?: boolean;
+  alphaTest?: number;
+  side?: THREE.Side;
+  shadowSide?: THREE.Side | null;
+  map?: THREE.Texture | null;
+  normalMap?: THREE.Texture | null;
+  emissiveMap?: THREE.Texture | null;
+  aoMap?: THREE.Texture | null;
+  roughnessMap?: THREE.Texture | null;
+  metalnessMap?: THREE.Texture | null;
+  alphaMap?: THREE.Texture | null;
+  depthTest?: boolean;
+  depthWrite?: boolean;
+  toneMapped?: boolean;
+  vertexColors?: boolean;
+  wireframe?: boolean;
+  fog?: boolean;
+};
+
 function getLiveAvatarScene(world?: ClientWorld): THREE.Object3D | null {
-  const player = world?.getPlayer() as PlayerWithLiveAvatar | null;
+  const scenePlayer = world?.entities?.player as PlayerWithLiveAvatar | null;
+  const player = (scenePlayer ??
+    world?.getPlayer()) as PlayerWithLiveAvatar | null;
   if (!player) return null;
 
+  const localEntity = (
+    player.id ? world?.entities?.get?.(player.id) : null
+  ) as PlayerWithLiveAvatar | null;
+
+  const candidate = localEntity ?? player;
+
   return (
+    candidate._avatar?.instance?.raw?.scene ??
+    candidate.avatar?.instance?.raw?.scene ??
     player._avatar?.instance?.raw?.scene ??
     player.avatar?.instance?.raw?.scene ??
     null
   );
 }
 
-function cloneMaterial(
+function createFreshPortraitMaterial(source: THREE.Material): THREE.Material {
+  const standardSource = source as StandardLikeMaterial;
+  const material = new MeshStandardNodeMaterial();
+
+  material.color = standardSource.color?.clone() ?? new THREE.Color(0xffffff);
+  material.emissive =
+    standardSource.emissive?.clone() ?? new THREE.Color(0x000000);
+  material.emissiveIntensity = standardSource.emissiveIntensity ?? 0;
+  material.roughness = standardSource.roughness ?? 1;
+  material.metalness = standardSource.metalness ?? 0;
+  material.envMapIntensity = standardSource.envMapIntensity ?? 1;
+  material.opacity = standardSource.opacity ?? 1;
+  material.transparent = standardSource.transparent ?? false;
+  material.alphaTest = standardSource.alphaTest ?? 0;
+  material.side = standardSource.side ?? THREE.FrontSide;
+  material.shadowSide = standardSource.shadowSide;
+  material.depthTest = standardSource.depthTest ?? true;
+  material.depthWrite = standardSource.depthWrite ?? true;
+  material.toneMapped = standardSource.toneMapped ?? true;
+  material.vertexColors = standardSource.vertexColors ?? false;
+  material.wireframe = standardSource.wireframe ?? false;
+  material.fog = standardSource.fog ?? true;
+
+  if (standardSource.map) material.map = standardSource.map;
+  if (standardSource.normalMap) material.normalMap = standardSource.normalMap;
+  if (standardSource.emissiveMap) {
+    material.emissiveMap = standardSource.emissiveMap;
+  }
+  if (standardSource.aoMap) material.aoMap = standardSource.aoMap;
+  if (standardSource.roughnessMap) {
+    material.roughnessMap = standardSource.roughnessMap;
+  }
+  if (standardSource.metalnessMap) {
+    material.metalnessMap = standardSource.metalnessMap;
+  }
+  if (standardSource.alphaMap) material.alphaMap = standardSource.alphaMap;
+
+  material.name = source.name;
+  material.blending = source.blending;
+  material.blendSrc = source.blendSrc;
+  material.blendDst = source.blendDst;
+  material.blendEquation = source.blendEquation;
+  material.premultipliedAlpha = source.premultipliedAlpha;
+  material.visible = source.visible;
+  material.userData = { ...source.userData };
+
+  return material;
+}
+
+function clonePortraitMaterial(
   material: THREE.Material | THREE.Material[],
 ): THREE.Material | THREE.Material[] {
   if (Array.isArray(material)) {
-    return material.map((entry) => entry.clone());
+    return material.map((entry) => createFreshPortraitMaterial(entry));
   }
 
-  return material.clone();
+  return createFreshPortraitMaterial(material);
 }
 
 function disposePortraitClone(root: THREE.Object3D | null): void {
@@ -72,6 +161,8 @@ function disposePortraitClone(root: THREE.Object3D | null): void {
 
 function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
   const clone = SkeletonUtils.clone(sourceScene) as THREE.Object3D;
+  clone.scale.copy(sourceScene.scale);
+  clone.visible = true;
   const silhouettes: THREE.Object3D[] = [];
 
   clone.traverse((child) => {
@@ -84,9 +175,17 @@ function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
 
     const materialCarrier = child as MaterialCarrier;
     if (materialCarrier.material) {
-      materialCarrier.material = cloneMaterial(materialCarrier.material);
+      materialCarrier.material = clonePortraitMaterial(
+        materialCarrier.material,
+      );
       materialCarrier.frustumCulled = false;
     }
+
+    if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
+      child.visible = true;
+    }
+
+    child.layers.enableAll();
   });
 
   silhouettes.forEach((node) => node.parent?.remove(node));
@@ -145,6 +244,7 @@ function PortraitFallback({
   mode: PortraitMode;
 }) {
   const theme = useThemeStore((s) => s.theme);
+  const isLoading = mode === "loading";
 
   return (
     <div
@@ -161,8 +261,15 @@ function PortraitFallback({
           width: compact ? "86%" : "82%",
           height: compact ? "92%" : "94%",
           borderRadius: compact ? 16 : 20,
+          ...getPanelInsetStyle(theme, {
+            emphasis: "strong",
+            radius: compact ? 16 : 20,
+          }),
+          padding: 0,
           background:
-            "radial-gradient(circle at 50% 18%, rgba(223, 186, 112, 0.16), rgba(22, 18, 17, 0.02) 52%, rgba(0, 0, 0, 0) 74%)",
+            theme.name === "hyperscape"
+              ? "radial-gradient(circle at 50% 16%, rgba(190, 165, 123, 0.12), transparent 58%), linear-gradient(180deg, rgba(30, 35, 42, 0.95) 0%, rgba(18, 21, 26, 0.98) 100%)"
+              : undefined,
         }}
       >
         <div
@@ -170,98 +277,119 @@ function PortraitFallback({
           style={{
             borderRadius: compact ? 16 : 22,
             border: `1px solid ${theme.colors.border.default}55`,
-            background:
-              "linear-gradient(180deg, rgba(34, 28, 26, 0.14) 0%, rgba(14, 11, 10, 0.04) 100%)",
+            background: isLoading
+              ? "linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(0,0,0,0.08) 100%)"
+              : "linear-gradient(180deg, rgba(255,255,255,0.035) 0%, rgba(0,0,0,0.12) 100%)",
             boxShadow:
               "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -16px 24px rgba(0,0,0,0.18)",
           }}
         />
 
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: compact ? 34 : 42,
-            height: compact ? 34 : 42,
-            top: compact ? "10%" : "8%",
-            background:
-              "linear-gradient(180deg, rgba(224, 197, 143, 0.95), rgba(154, 118, 71, 0.95))",
-            boxShadow: "0 10px 18px rgba(0,0,0,0.22)",
-          }}
-        />
+        {isLoading ? (
+          <>
+            <div
+              className="absolute inset-x-[24%] top-[18%] h-[18%] rounded-full"
+              style={{
+                background: `radial-gradient(circle at center, ${theme.colors.accent.primary}18 0%, transparent 72%)`,
+              }}
+            />
+            <div
+              className="absolute inset-x-[18%] bottom-[16%] top-[28%] rounded-[22px]"
+              style={{
+                border: `1px dashed ${theme.colors.border.hover}`,
+                opacity: 0.55,
+              }}
+            />
+          </>
+        ) : (
+          <>
+            <div
+              className="absolute rounded-full"
+              style={{
+                width: compact ? 34 : 42,
+                height: compact ? 34 : 42,
+                top: compact ? "10%" : "8%",
+                background:
+                  "linear-gradient(180deg, rgba(224, 197, 143, 0.95), rgba(154, 118, 71, 0.95))",
+                boxShadow: "0 10px 18px rgba(0,0,0,0.22)",
+              }}
+            />
 
-        <div
-          className="absolute rounded-[24px]"
-          style={{
-            width: compact ? 46 : 56,
-            height: compact ? 78 : 98,
-            top: compact ? "24%" : "22%",
-            background:
-              "linear-gradient(180deg, rgba(72, 105, 63, 0.95), rgba(44, 68, 42, 0.98))",
-            boxShadow: "0 12px 20px rgba(0,0,0,0.22)",
-          }}
-        />
+            <div
+              className="absolute rounded-[24px]"
+              style={{
+                width: compact ? 46 : 56,
+                height: compact ? 78 : 98,
+                top: compact ? "24%" : "22%",
+                background:
+                  "linear-gradient(180deg, rgba(72, 105, 63, 0.95), rgba(44, 68, 42, 0.98))",
+                boxShadow: "0 12px 20px rgba(0,0,0,0.22)",
+              }}
+            />
 
-        <div
-          className="absolute rounded-[14px]"
-          style={{
-            width: compact ? 82 : 102,
-            height: compact ? 16 : 18,
-            top: compact ? "39%" : "38%",
-            background:
-              "linear-gradient(90deg, rgba(213, 171, 97, 0) 0%, rgba(213, 171, 97, 0.75) 24%, rgba(213, 171, 97, 0.75) 76%, rgba(213, 171, 97, 0) 100%)",
-            opacity: 0.32,
-          }}
-        />
+            <div
+              className="absolute rounded-[14px]"
+              style={{
+                width: compact ? 82 : 102,
+                height: compact ? 16 : 18,
+                top: compact ? "39%" : "38%",
+                background:
+                  "linear-gradient(90deg, rgba(213, 171, 97, 0) 0%, rgba(213, 171, 97, 0.75) 24%, rgba(213, 171, 97, 0.75) 76%, rgba(213, 171, 97, 0) 100%)",
+                opacity: 0.32,
+              }}
+            />
 
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: compact ? 14 : 18,
-            height: compact ? 62 : 78,
-            left: compact ? "26%" : "24%",
-            top: compact ? "28%" : "27%",
-            transform: "rotate(10deg)",
-            background:
-              "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
-          }}
-        />
+            <div
+              className="absolute rounded-full"
+              style={{
+                width: compact ? 14 : 18,
+                height: compact ? 62 : 78,
+                left: compact ? "26%" : "24%",
+                top: compact ? "28%" : "27%",
+                transform: "rotate(10deg)",
+                background:
+                  "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
+              }}
+            />
 
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: compact ? 14 : 18,
-            height: compact ? 62 : 78,
-            right: compact ? "26%" : "24%",
-            top: compact ? "28%" : "27%",
-            transform: "rotate(-10deg)",
-            background:
-              "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
-          }}
-        />
+            <div
+              className="absolute rounded-full"
+              style={{
+                width: compact ? 14 : 18,
+                height: compact ? 62 : 78,
+                right: compact ? "26%" : "24%",
+                top: compact ? "28%" : "27%",
+                transform: "rotate(-10deg)",
+                background:
+                  "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
+              }}
+            />
 
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: compact ? 16 : 20,
-            height: compact ? 90 : 112,
-            left: compact ? "41%" : "40%",
-            bottom: compact ? "8%" : "6%",
-            background:
-              "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
-          }}
-        />
+            <div
+              className="absolute rounded-full"
+              style={{
+                width: compact ? 16 : 20,
+                height: compact ? 90 : 112,
+                left: compact ? "41%" : "40%",
+                bottom: compact ? "8%" : "6%",
+                background:
+                  "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
+              }}
+            />
 
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: compact ? 16 : 20,
-            height: compact ? 90 : 112,
-            right: compact ? "41%" : "40%",
-            bottom: compact ? "8%" : "6%",
-            background:
-              "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
-          }}
-        />
+            <div
+              className="absolute rounded-full"
+              style={{
+                width: compact ? 16 : 20,
+                height: compact ? 90 : 112,
+                right: compact ? "41%" : "40%",
+                bottom: compact ? "8%" : "6%",
+                background:
+                  "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
+              }}
+            />
+          </>
+        )}
 
         <div
           className="absolute"
@@ -342,6 +470,7 @@ export const EquipmentPaperdollPortrait = React.memo(
       sceneRef.current = scene;
 
       const camera = new THREE.PerspectiveCamera(28, 1, 0.1, 20);
+      camera.layers.enableAll();
       cameraRef.current = camera;
 
       const ambient = new THREE.AmbientLight(0xf5e8cf, 1.35);
@@ -453,6 +582,12 @@ export const EquipmentPaperdollPortrait = React.memo(
 
       try {
         const portraitClone = buildPortraitClone(sourceScene);
+        const bounds = new THREE.Box3().setFromObject(portraitClone);
+        if (bounds.isEmpty()) {
+          setMode("loading");
+          return;
+        }
+
         sceneRef.current.add(portraitClone);
         avatarRootRef.current = portraitClone;
         framePortraitAvatar(portraitClone, cameraRef.current);
@@ -474,8 +609,15 @@ export const EquipmentPaperdollPortrait = React.memo(
         className={`relative overflow-hidden ${className}`}
         style={{
           borderRadius: compact ? 14 : 18,
-          border: `1px solid ${theme.colors.border.default}66`,
-          background: `radial-gradient(circle at 50% 10%, ${theme.colors.accent.primary}18 0%, rgba(24, 18, 15, 0.08) 38%, rgba(10, 9, 10, 0.16) 100%)`,
+          ...getPanelInsetStyle(theme, {
+            emphasis: "strong",
+            radius: compact ? 14 : 18,
+          }),
+          padding: 0,
+          background:
+            theme.name === "hyperscape"
+              ? `radial-gradient(circle at 50% 8%, ${theme.colors.accent.primary}14 0%, rgba(15, 18, 22, 0) 42%), linear-gradient(180deg, rgba(31, 35, 42, 0.98) 0%, rgba(18, 21, 26, 0.99) 100%)`
+              : undefined,
           boxShadow:
             "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -14px 20px rgba(0,0,0,0.16)",
         }}

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -1,0 +1,462 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { EventType, THREE, createRenderer } from "@hyperscape/shared";
+import type { WebGPURenderer } from "@hyperscape/shared";
+import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
+import { useThemeStore } from "@/ui";
+import type { ClientWorld } from "../../../types";
+
+type PortraitMode = "loading" | "live" | "fallback";
+
+interface EquipmentPaperdollPortraitProps {
+  world?: ClientWorld;
+  className?: string;
+  equipmentSignature?: string;
+  compact?: boolean;
+}
+
+interface AvatarCarrier {
+  instance?: {
+    raw?: {
+      scene?: THREE.Object3D;
+    };
+  } | null;
+}
+
+interface PlayerWithLiveAvatar {
+  _avatar?: AvatarCarrier;
+  avatar?: AvatarCarrier;
+}
+
+function getLiveAvatarScene(world?: ClientWorld): THREE.Object3D | null {
+  const player = world?.getPlayer() as PlayerWithLiveAvatar | null;
+  if (!player) return null;
+
+  return (
+    player._avatar?.instance?.raw?.scene ??
+    player.avatar?.instance?.raw?.scene ??
+    null
+  );
+}
+
+function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
+  const clone = SkeletonUtils.clone(sourceScene) as THREE.Object3D;
+  const silhouettes: THREE.Object3D[] = [];
+
+  clone.traverse((child) => {
+    if (child.name.startsWith("Silhouette_")) {
+      silhouettes.push(child);
+    }
+
+    child.castShadow = false;
+    child.receiveShadow = false;
+  });
+
+  silhouettes.forEach((node) => node.parent?.remove(node));
+
+  clone.position.set(0, 0, 0);
+  clone.quaternion.identity();
+  clone.rotation.set(0, 0, 0);
+  clone.updateMatrixWorld(true);
+
+  const initialBox = new THREE.Box3().setFromObject(clone);
+  if (initialBox.isEmpty()) {
+    return clone;
+  }
+
+  const center = initialBox.getCenter(new THREE.Vector3());
+  clone.position.x -= center.x;
+  clone.position.z -= center.z;
+  clone.position.y -= initialBox.min.y;
+  clone.updateMatrixWorld(true);
+
+  return clone;
+}
+
+function framePortraitAvatar(
+  avatarRoot: THREE.Object3D,
+  camera: THREE.PerspectiveCamera,
+) {
+  avatarRoot.updateMatrixWorld(true);
+
+  const box = new THREE.Box3().setFromObject(avatarRoot);
+  if (box.isEmpty()) {
+    camera.position.set(0, 1.25, 2.8);
+    camera.lookAt(0, 1.1, 0);
+    return;
+  }
+
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  const height = Math.max(size.y, 1.5);
+  const width = Math.max(size.x, 0.8);
+  const distance = Math.max(2.2, height * 1.08, width * 1.9);
+  const lookY = center.y + height * 0.08;
+
+  camera.position.set(0, lookY, distance);
+  camera.lookAt(0, lookY, 0);
+  camera.near = 0.1;
+  camera.far = Math.max(12, distance + height * 3);
+  camera.updateProjectionMatrix();
+}
+
+function PortraitFallback({
+  compact,
+  mode,
+}: {
+  compact: boolean;
+  mode: PortraitMode;
+}) {
+  const theme = useThemeStore((s) => s.theme);
+
+  return (
+    <div
+      data-portrait-fallback="true"
+      className="absolute inset-0 flex items-center justify-center"
+      style={{
+        opacity: mode === "loading" ? 0.7 : 1,
+        transition: "opacity 160ms ease",
+      }}
+    >
+      <div
+        className="relative flex items-center justify-center"
+        style={{
+          width: compact ? "84%" : "78%",
+          height: compact ? "90%" : "92%",
+          borderRadius: compact ? 18 : 26,
+          background:
+            "radial-gradient(circle at 50% 18%, rgba(223, 186, 112, 0.16), rgba(22, 18, 17, 0.02) 52%, rgba(0, 0, 0, 0) 74%)",
+        }}
+      >
+        <div
+          className="absolute inset-x-[12%] bottom-[10%] top-[7%]"
+          style={{
+            borderRadius: compact ? 16 : 22,
+            border: `1px solid ${theme.colors.border.default}55`,
+            background:
+              "linear-gradient(180deg, rgba(34, 28, 26, 0.14) 0%, rgba(14, 11, 10, 0.04) 100%)",
+            boxShadow:
+              "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -16px 24px rgba(0,0,0,0.18)",
+          }}
+        />
+
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: compact ? 34 : 42,
+            height: compact ? 34 : 42,
+            top: compact ? "10%" : "8%",
+            background:
+              "linear-gradient(180deg, rgba(224, 197, 143, 0.95), rgba(154, 118, 71, 0.95))",
+            boxShadow: "0 10px 18px rgba(0,0,0,0.22)",
+          }}
+        />
+
+        <div
+          className="absolute rounded-[24px]"
+          style={{
+            width: compact ? 46 : 56,
+            height: compact ? 78 : 98,
+            top: compact ? "24%" : "22%",
+            background:
+              "linear-gradient(180deg, rgba(72, 105, 63, 0.95), rgba(44, 68, 42, 0.98))",
+            boxShadow: "0 12px 20px rgba(0,0,0,0.22)",
+          }}
+        />
+
+        <div
+          className="absolute rounded-[14px]"
+          style={{
+            width: compact ? 82 : 102,
+            height: compact ? 16 : 18,
+            top: compact ? "39%" : "38%",
+            background:
+              "linear-gradient(90deg, rgba(213, 171, 97, 0) 0%, rgba(213, 171, 97, 0.75) 24%, rgba(213, 171, 97, 0.75) 76%, rgba(213, 171, 97, 0) 100%)",
+            opacity: 0.32,
+          }}
+        />
+
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: compact ? 14 : 18,
+            height: compact ? 62 : 78,
+            left: compact ? "26%" : "24%",
+            top: compact ? "28%" : "27%",
+            transform: "rotate(10deg)",
+            background:
+              "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
+          }}
+        />
+
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: compact ? 14 : 18,
+            height: compact ? 62 : 78,
+            right: compact ? "26%" : "24%",
+            top: compact ? "28%" : "27%",
+            transform: "rotate(-10deg)",
+            background:
+              "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
+          }}
+        />
+
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: compact ? 16 : 20,
+            height: compact ? 90 : 112,
+            left: compact ? "41%" : "40%",
+            bottom: compact ? "8%" : "6%",
+            background:
+              "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
+          }}
+        />
+
+        <div
+          className="absolute rounded-full"
+          style={{
+            width: compact ? 16 : 20,
+            height: compact ? 90 : 112,
+            right: compact ? "41%" : "40%",
+            bottom: compact ? "8%" : "6%",
+            background:
+              "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
+          }}
+        />
+
+        <div
+          className="absolute"
+          style={{
+            inset: 0,
+            borderRadius: compact ? 18 : 26,
+            background:
+              "radial-gradient(circle at 50% 12%, rgba(255,255,255,0.16), rgba(255,255,255,0) 34%)",
+            pointerEvents: "none",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const EquipmentPaperdollPortrait = React.memo(
+  function EquipmentPaperdollPortrait({
+    world,
+    className = "",
+    equipmentSignature = "",
+    compact = false,
+  }: EquipmentPaperdollPortraitProps) {
+    const theme = useThemeStore((s) => s.theme);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const rendererRef = useRef<WebGPURenderer | null>(null);
+    const sceneRef = useRef<THREE.Scene | null>(null);
+    const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+    const avatarRootRef = useRef<THREE.Object3D | null>(null);
+    const frameRef = useRef<number>(0);
+    const [rendererReady, setRendererReady] = useState(false);
+    const [mode, setMode] = useState<PortraitMode>("fallback");
+    const [refreshNonce, setRefreshNonce] = useState(0);
+
+    const signature = useMemo(
+      () => `${equipmentSignature}|${compact ? "compact" : "full"}`,
+      [compact, equipmentSignature],
+    );
+
+    useEffect(() => {
+      if (!world) {
+        setMode("fallback");
+        return;
+      }
+
+      const triggerRefresh = () => setRefreshNonce((current) => current + 1);
+      triggerRefresh();
+
+      const timers = [120, 420, 1100].map((delay) =>
+        window.setTimeout(triggerRefresh, delay),
+      );
+
+      const handleAvatarReady = () => triggerRefresh();
+
+      world.on(EventType.AVATAR_LOAD_COMPLETE, handleAvatarReady, undefined);
+
+      return () => {
+        timers.forEach((timerId) => window.clearTimeout(timerId));
+        world.off(
+          EventType.AVATAR_LOAD_COMPLETE,
+          handleAvatarReady,
+          undefined,
+          undefined,
+        );
+      };
+    }, [signature, world]);
+
+    useEffect(() => {
+      if (!world || !canvasRef.current || !containerRef.current) {
+        return;
+      }
+
+      let cancelled = false;
+
+      const scene = new THREE.Scene();
+      sceneRef.current = scene;
+
+      const camera = new THREE.PerspectiveCamera(28, 1, 0.1, 20);
+      cameraRef.current = camera;
+
+      const ambient = new THREE.AmbientLight(0xf5e8cf, 1.35);
+      const key = new THREE.DirectionalLight(0xfff2d1, 1.45);
+      key.position.set(1.3, 2.2, 3.2);
+      const fill = new THREE.DirectionalLight(0x9ab7ff, 0.35);
+      fill.position.set(-1.8, 1.4, 2.4);
+      const rim = new THREE.DirectionalLight(0xf0c98b, 0.6);
+      rim.position.set(0.5, 2.6, -1.8);
+
+      scene.add(ambient, key, fill, rim);
+
+      const resize = () => {
+        if (
+          !containerRef.current ||
+          !rendererRef.current ||
+          !cameraRef.current
+        ) {
+          return;
+        }
+
+        const bounds = containerRef.current.getBoundingClientRect();
+        const width = Math.max(1, Math.floor(bounds.width));
+        const height = Math.max(1, Math.floor(bounds.height));
+
+        rendererRef.current.setSize(width, height);
+        cameraRef.current.aspect = width / height;
+        cameraRef.current.updateProjectionMatrix();
+      };
+
+      const renderFrame = () => {
+        if (!rendererRef.current || !sceneRef.current || !cameraRef.current) {
+          return;
+        }
+
+        rendererRef.current.render(sceneRef.current, cameraRef.current);
+        frameRef.current = window.requestAnimationFrame(renderFrame);
+      };
+
+      createRenderer({
+        canvas: canvasRef.current,
+        alpha: true,
+        antialias: true,
+      })
+        .then((renderer) => {
+          if (cancelled) {
+            renderer.dispose();
+            return;
+          }
+
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+          rendererRef.current = renderer;
+          setRendererReady(true);
+          resize();
+          frameRef.current = window.requestAnimationFrame(renderFrame);
+        })
+        .catch((error) => {
+          console.error(
+            "[EquipmentPaperdollPortrait] Failed to create renderer:",
+            error,
+          );
+          if (!cancelled) {
+            setRendererReady(false);
+            setMode("fallback");
+          }
+        });
+
+      let resizeObserver: ResizeObserver | null = null;
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(() => resize());
+        resizeObserver.observe(containerRef.current);
+      } else {
+        window.addEventListener("resize", resize);
+      }
+
+      return () => {
+        cancelled = true;
+        if (frameRef.current) {
+          window.cancelAnimationFrame(frameRef.current);
+        }
+        resizeObserver?.disconnect();
+        window.removeEventListener("resize", resize);
+        avatarRootRef.current?.parent?.remove(avatarRootRef.current);
+        avatarRootRef.current = null;
+        rendererRef.current?.dispose();
+        rendererRef.current = null;
+        sceneRef.current = null;
+        cameraRef.current = null;
+        setRendererReady(false);
+      };
+    }, [world]);
+
+    useEffect(() => {
+      if (!rendererReady || !sceneRef.current || !cameraRef.current) {
+        return;
+      }
+
+      avatarRootRef.current?.parent?.remove(avatarRootRef.current);
+      avatarRootRef.current = null;
+
+      const sourceScene = getLiveAvatarScene(world);
+      if (!sourceScene) {
+        setMode("fallback");
+        return;
+      }
+
+      try {
+        const portraitClone = buildPortraitClone(sourceScene);
+        sceneRef.current.add(portraitClone);
+        avatarRootRef.current = portraitClone;
+        framePortraitAvatar(portraitClone, cameraRef.current);
+        setMode("live");
+      } catch (error) {
+        console.error(
+          "[EquipmentPaperdollPortrait] Failed to build portrait clone:",
+          error,
+        );
+        setMode("fallback");
+      }
+    }, [refreshNonce, rendererReady, signature, world]);
+
+    return (
+      <div
+        ref={containerRef}
+        data-equipment-portrait="true"
+        data-portrait-mode={mode}
+        className={`relative overflow-hidden ${className}`}
+        style={{
+          borderRadius: compact ? 18 : 24,
+          border: `1px solid ${theme.colors.border.default}66`,
+          background: `radial-gradient(circle at 50% 12%, ${theme.colors.accent.primary}22 0%, rgba(24, 18, 15, 0.1) 42%, rgba(10, 9, 10, 0.18) 100%)`,
+          boxShadow:
+            "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 28px rgba(0,0,0,0.18)",
+        }}
+      >
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0) 24%, rgba(0,0,0,0.1) 100%)",
+          }}
+        />
+
+        <canvas
+          ref={canvasRef}
+          data-equipment-portrait-canvas="true"
+          className="absolute inset-0 h-full w-full"
+          style={{
+            display: mode === "live" ? "block" : "none",
+          }}
+        />
+
+        {mode !== "live" && <PortraitFallback compact={compact} mode={mode} />}
+      </div>
+    );
+  },
+);

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -89,8 +89,8 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.5);
   const width = Math.max(size.x, 0.8);
-  const distance = Math.max(2.2, height * 1.08, width * 1.9);
-  const lookY = center.y + height * 0.08;
+  const distance = Math.max(1.9, height * 0.94, width * 1.6);
+  const lookY = center.y + height * 0.03;
 
   camera.position.set(0, lookY, distance);
   camera.lookAt(0, lookY, 0);
@@ -120,9 +120,9 @@ function PortraitFallback({
       <div
         className="relative flex items-center justify-center"
         style={{
-          width: compact ? "84%" : "78%",
-          height: compact ? "90%" : "92%",
-          borderRadius: compact ? 18 : 26,
+          width: compact ? "86%" : "82%",
+          height: compact ? "92%" : "94%",
+          borderRadius: compact ? 16 : 20,
           background:
             "radial-gradient(circle at 50% 18%, rgba(223, 186, 112, 0.16), rgba(22, 18, 17, 0.02) 52%, rgba(0, 0, 0, 0) 74%)",
         }}
@@ -431,11 +431,11 @@ export const EquipmentPaperdollPortrait = React.memo(
         data-portrait-mode={mode}
         className={`relative overflow-hidden ${className}`}
         style={{
-          borderRadius: compact ? 18 : 24,
+          borderRadius: compact ? 14 : 18,
           border: `1px solid ${theme.colors.border.default}66`,
-          background: `radial-gradient(circle at 50% 12%, ${theme.colors.accent.primary}22 0%, rgba(24, 18, 15, 0.1) 42%, rgba(10, 9, 10, 0.18) 100%)`,
+          background: `radial-gradient(circle at 50% 10%, ${theme.colors.accent.primary}18 0%, rgba(24, 18, 15, 0.08) 38%, rgba(10, 9, 10, 0.16) 100%)`,
           boxShadow:
-            "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 28px rgba(0,0,0,0.18)",
+            "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -14px 20px rgba(0,0,0,0.16)",
         }}
       >
         <div

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -27,6 +27,11 @@ interface PlayerWithLiveAvatar {
   avatar?: AvatarCarrier;
 }
 
+type MaterialCarrier = THREE.Object3D & {
+  material?: THREE.Material | THREE.Material[];
+  frustumCulled?: boolean;
+};
+
 function getLiveAvatarScene(world?: ClientWorld): THREE.Object3D | null {
   const player = world?.getPlayer() as PlayerWithLiveAvatar | null;
   if (!player) return null;
@@ -36,6 +41,33 @@ function getLiveAvatarScene(world?: ClientWorld): THREE.Object3D | null {
     player.avatar?.instance?.raw?.scene ??
     null
   );
+}
+
+function cloneMaterial(
+  material: THREE.Material | THREE.Material[],
+): THREE.Material | THREE.Material[] {
+  if (Array.isArray(material)) {
+    return material.map((entry) => entry.clone());
+  }
+
+  return material.clone();
+}
+
+function disposePortraitClone(root: THREE.Object3D | null): void {
+  if (!root) return;
+
+  root.traverse((child) => {
+    const materialCarrier = child as MaterialCarrier;
+    const material = materialCarrier.material;
+    if (!material) return;
+
+    if (Array.isArray(material)) {
+      material.forEach((entry) => entry.dispose());
+      return;
+    }
+
+    material.dispose();
+  });
 }
 
 function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
@@ -49,6 +81,12 @@ function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
 
     child.castShadow = false;
     child.receiveShadow = false;
+
+    const materialCarrier = child as MaterialCarrier;
+    if (materialCarrier.material) {
+      materialCarrier.material = cloneMaterial(materialCarrier.material);
+      materialCarrier.frustumCulled = false;
+    }
   });
 
   silhouettes.forEach((node) => node.parent?.remove(node));
@@ -270,6 +308,7 @@ export const EquipmentPaperdollPortrait = React.memo(
         return;
       }
 
+      setMode("loading");
       const triggerRefresh = () => setRefreshNonce((current) => current + 1);
       triggerRefresh();
 
@@ -385,6 +424,7 @@ export const EquipmentPaperdollPortrait = React.memo(
         }
         resizeObserver?.disconnect();
         window.removeEventListener("resize", resize);
+        disposePortraitClone(avatarRootRef.current);
         avatarRootRef.current?.parent?.remove(avatarRootRef.current);
         avatarRootRef.current = null;
         rendererRef.current?.dispose();
@@ -400,6 +440,8 @@ export const EquipmentPaperdollPortrait = React.memo(
         return;
       }
 
+      setMode("loading");
+      disposePortraitClone(avatarRootRef.current);
       avatarRootRef.current?.parent?.remove(avatarRootRef.current);
       avatarRootRef.current = null;
 

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -141,7 +141,22 @@ function clearPreviewVisuals(visuals: EquipmentVisualStore): void {
 function framePortraitAvatar(
   avatarRoot: THREE.Object3D,
   camera: THREE.PerspectiveCamera,
+  zoomMultiplier = 1.0,
+  baseStateRef?: React.MutableRefObject<{
+    camY: number;
+    lookY: number;
+    distance: number;
+    center: THREE.Vector3;
+  } | null>,
 ) {
+  if (baseStateRef?.current) {
+    const { camY, lookY, distance, center } = baseStateRef.current;
+    const currentDistance = distance / Math.max(0.1, zoomMultiplier);
+    camera.position.set(center.x, camY, -currentDistance);
+    camera.lookAt(center.x, lookY, center.z);
+    return;
+  }
+
   avatarRoot.updateMatrixWorld(true);
 
   const box = new THREE.Box3().setFromObject(avatarRoot);
@@ -155,13 +170,26 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(2.5, height * 1.24, width * 2.08);
-  const lookY = center.y - height * 0.08;
 
-  camera.position.set(center.x, lookY, -distance);
+  // Zoom out enough so the full avatar fits within the portrait container
+  const distance = Math.max(3.2, height * 2.1, width * 1.6);
+
+  // Look slightly higher to push the avatar down in the viewport
+  const lookY = center.y + height * 0.02;
+
+  // Keep camera vertically offset relatively the same angle
+  const camY = lookY + height * 0.6;
+
+  if (baseStateRef) {
+    baseStateRef.current = { camY, lookY, distance, center: center.clone() };
+  }
+
+  const currentDistance = distance / Math.max(0.1, zoomMultiplier);
+
+  camera.position.set(center.x, camY, -currentDistance);
   camera.lookAt(center.x, lookY, center.z);
   camera.near = 0.1;
-  camera.far = Math.max(12, distance + height * 3);
+  camera.far = Math.max(12, currentDistance + height * 3);
   camera.updateProjectionMatrix();
 }
 
@@ -398,6 +426,19 @@ export const EquipmentPaperdollPortrait = React.memo(
     const [mode, setMode] = useState<PortraitMode>("loading");
     const [refreshNonce, setRefreshNonce] = useState(0);
 
+    const isDraggingRef = useRef(false);
+    const lastMousePosRef = useRef({ x: 0, y: 0 });
+    const targetRotationRef = useRef(Math.PI * 0.08);
+    const currentRotationRef = useRef(Math.PI * 0.08);
+    const targetZoomRef = useRef(1);
+    const currentZoomRef = useRef(1);
+    const baseCameraStateRef = useRef<{
+      camY: number;
+      lookY: number;
+      distance: number;
+      center: THREE.Vector3;
+    } | null>(null);
+
     const avatarUrl = useMemo(
       () => resolvePlayerAvatarUrl(world),
       [world, refreshNonce],
@@ -429,6 +470,7 @@ export const EquipmentPaperdollPortrait = React.memo(
 
       avatarSceneRef.current = null;
       avatarNodeRef.current = null;
+      baseCameraStateRef.current = null;
     };
 
     useEffect(() => {
@@ -457,6 +499,29 @@ export const EquipmentPaperdollPortrait = React.memo(
           viewportRef.current = viewport;
           viewport.start((delta) => {
             avatarNodeRef.current?.instance?.update(delta);
+
+            const rDiff =
+              targetRotationRef.current - currentRotationRef.current;
+            const zDiff = targetZoomRef.current - currentZoomRef.current;
+
+            if (Math.abs(rDiff) > 0.001 || Math.abs(zDiff) > 0.001) {
+              currentRotationRef.current += rDiff * Math.min(1.0, delta * 15);
+              currentZoomRef.current += zDiff * Math.min(1.0, delta * 15);
+
+              const vrm = getPreviewVRM(
+                avatarNodeRef.current?.instance ?? null,
+              );
+              if (vrm && avatarSceneRef.current) {
+                avatarSceneRef.current.rotation.y = currentRotationRef.current;
+                vrm.scene.rotation.y = currentRotationRef.current;
+                framePortraitAvatar(
+                  avatarSceneRef.current,
+                  viewport.camera,
+                  currentZoomRef.current,
+                  baseCameraStateRef,
+                );
+              }
+            }
           });
           setRendererReady(true);
 
@@ -586,8 +651,8 @@ export const EquipmentPaperdollPortrait = React.memo(
 
           avatarNode.visible = false;
           avatarScene.visible = false;
-          avatarScene.rotation.y = 0;
-          vrm.scene.rotation.y = 0;
+          avatarScene.rotation.y = currentRotationRef.current;
+          vrm.scene.rotation.y = currentRotationRef.current;
 
           if (avatarInstance.setEmoteAndWait) {
             await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);
@@ -614,7 +679,12 @@ export const EquipmentPaperdollPortrait = React.memo(
           avatarNode.visible = true;
           avatarScene.visible = true;
           viewport.resize();
-          framePortraitAvatar(avatarScene, viewport.camera);
+          framePortraitAvatar(
+            avatarScene,
+            viewport.camera,
+            currentZoomRef.current,
+            baseCameraStateRef,
+          );
           setMode("live");
         } catch (error) {
           console.error(
@@ -640,29 +710,42 @@ export const EquipmentPaperdollPortrait = React.memo(
         ref={containerRef}
         data-equipment-portrait="true"
         data-portrait-mode={mode}
-        className={`relative overflow-hidden ${className}`}
+        className={`relative overflow-hidden touch-none select-none ${className}`}
+        onPointerDown={(e) => {
+          isDraggingRef.current = true;
+          lastMousePosRef.current = { x: e.clientX, y: e.clientY };
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }}
+        onPointerMove={(e) => {
+          if (!isDraggingRef.current) return;
+          const deltaX = e.clientX - lastMousePosRef.current.x;
+          targetRotationRef.current += deltaX * 0.01;
+          lastMousePosRef.current = { x: e.clientX, y: e.clientY };
+        }}
+        onPointerUp={(e) => {
+          isDraggingRef.current = false;
+          e.currentTarget.releasePointerCapture(e.pointerId);
+        }}
+        onWheel={(e) => {
+          const zoomDelta = e.deltaY > 0 ? 0.1 : -0.1;
+          targetZoomRef.current = Math.max(
+            0.4,
+            Math.min(1.15, targetZoomRef.current + zoomDelta),
+          );
+        }}
         style={{
-          borderRadius: compact ? 16 : 20,
+          borderRadius: 4,
           ...getPanelInsetStyle(theme, {
             emphasis: "strong",
-            radius: compact ? 16 : 20,
+            radius: 4,
           }),
           padding: 0,
-          background:
-            theme.name === "hyperscape"
-              ? `radial-gradient(circle at 50% 8%, ${theme.colors.accent.primary}14 0%, rgba(15, 18, 22, 0) 42%), linear-gradient(180deg, rgba(31, 35, 42, 0.98) 0%, rgba(18, 21, 26, 0.99) 100%)`
-              : undefined,
-          boxShadow:
-            "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -14px 20px rgba(0,0,0,0.16)",
+          border: "none",
+          background: "transparent",
+          boxShadow: "none",
         }}
       >
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background:
-              "linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0) 24%, rgba(0,0,0,0.1) 100%)",
-          }}
-        />
+        <div className="absolute inset-0 pointer-events-none" />
 
         <canvas
           ref={canvasRef}

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -155,8 +155,8 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(2.28, height * 1.12, width * 1.92);
-  const lookY = center.y - height * 0.05;
+  const distance = Math.max(2.18, height * 1.08, width * 1.84);
+  const lookY = center.y - height * 0.08;
 
   camera.position.set(center.x, lookY, -distance);
   camera.lookAt(center.x, lookY, center.z);
@@ -446,6 +446,7 @@ export const EquipmentPaperdollPortrait = React.memo(
         container,
         canvas,
         cameraPosition: new THREE.Vector3(0, 1.32, 2.95),
+        adjustCameraDepth: false,
       })
         .then((viewport) => {
           if (cancelled) {
@@ -612,8 +613,8 @@ export const EquipmentPaperdollPortrait = React.memo(
 
           avatarNode.visible = true;
           avatarScene.visible = true;
-          framePortraitAvatar(avatarScene, viewport.camera);
           viewport.resize();
+          framePortraitAvatar(avatarScene, viewport.camera);
           setMode("live");
         } catch (error) {
           console.error(

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -156,10 +156,10 @@ function framePortraitAvatar(
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
   const distance = Math.max(1.85, height * 0.9, width * 1.45);
-  const lookY = center.y + height * 0.05;
+  const lookY = center.y + height * 0.04;
 
-  camera.position.set(0, lookY, distance);
-  camera.lookAt(0, lookY, 0);
+  camera.position.set(center.x, lookY, distance);
+  camera.lookAt(center.x, lookY, center.z);
   camera.near = 0.1;
   camera.far = Math.max(12, distance + height * 3);
   camera.updateProjectionMatrix();
@@ -395,7 +395,7 @@ export const EquipmentPaperdollPortrait = React.memo(
     const avatarSceneRef = useRef<THREE.Object3D | null>(null);
     const previewVisualsRef = useRef<EquipmentVisualStore>({});
     const [rendererReady, setRendererReady] = useState(false);
-    const [mode, setMode] = useState<PortraitMode>("fallback");
+    const [mode, setMode] = useState<PortraitMode>("loading");
     const [refreshNonce, setRefreshNonce] = useState(0);
 
     const avatarUrl = useMemo(
@@ -492,7 +492,7 @@ export const EquipmentPaperdollPortrait = React.memo(
 
     useEffect(() => {
       if (!world) {
-        setMode("fallback");
+        setMode("loading");
         return;
       }
 
@@ -523,8 +523,13 @@ export const EquipmentPaperdollPortrait = React.memo(
         setMode("loading");
         clearPreviewAvatar();
 
-        if (!world.loader || !avatarUrl || !viewport) {
+        if (!avatarUrl) {
           setMode("fallback");
+          return;
+        }
+
+        if (!world.loader || !viewport) {
+          setMode("loading");
           return;
         }
 
@@ -580,6 +585,7 @@ export const EquipmentPaperdollPortrait = React.memo(
 
           avatarNode.visible = false;
           avatarScene.visible = false;
+          avatarScene.rotation.y = Math.PI;
 
           if (avatarInstance.setEmoteAndWait) {
             await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -155,7 +155,7 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(2.18, height * 1.08, width * 1.84);
+  const distance = Math.max(2.5, height * 1.24, width * 2.08);
   const lookY = center.y - height * 0.08;
 
   camera.position.set(center.x, lookY, -distance);

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -1,212 +1,141 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { EventType, THREE, createRenderer } from "@hyperscape/shared";
-import type { WebGPURenderer } from "@hyperscape/shared";
-import * as SkeletonUtils from "three/examples/jsm/utils/SkeletonUtils.js";
-import { MeshStandardNodeMaterial } from "three/webgpu";
+import {
+  attachEquipmentVisualToVRM,
+  Emotes,
+  EventType,
+  resolveEquipmentVisualData,
+  resolveEquipmentVisualUrls,
+  removeEquipmentVisual,
+  type EquipmentVisualStore,
+  THREE,
+} from "@hyperscape/shared";
+import type { GLTF } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
+import type { VRM } from "@pixiv/three-vrm";
 import { useThemeStore } from "@/ui";
 import { getPanelInsetStyle } from "@/ui/theme/themes";
-import type { ClientWorld } from "../../../types";
+import { ThreeResourceManager } from "@/lib/ThreeResourceManager";
+import { createAvatarPreviewViewport } from "@/game/character/avatarPreviewViewport";
+import type { ClientWorld, PlayerEquipmentItems } from "../../../types";
 
 type PortraitMode = "loading" | "live" | "fallback";
 
 interface EquipmentPaperdollPortraitProps {
   world?: ClientWorld;
+  equipment?: PlayerEquipmentItems | null;
   className?: string;
   equipmentSignature?: string;
   compact?: boolean;
 }
 
-interface AvatarCarrier {
-  instance?: {
-    raw?: {
-      scene?: THREE.Object3D;
+interface PreviewAvatarScene {
+  scene?: THREE.Object3D & {
+    visible?: boolean;
+    userData?: {
+      vrm?: VRM;
     };
-  } | null;
+  };
+  userData?: {
+    vrm?: VRM;
+  };
 }
 
-interface PlayerWithLiveAvatar {
-  id?: string;
-  _avatar?: AvatarCarrier;
-  avatar?: AvatarCarrier;
+interface PreviewAvatarInstance {
+  destroy(): void;
+  update(delta: number): void;
+  raw: PreviewAvatarScene;
+  disableRateCheck?: () => void;
+  setEmote?: (emote: string) => void;
+  setEmoteAndWait?: (emote: string, timeoutMs?: number) => Promise<void>;
 }
 
-type MaterialCarrier = THREE.Object3D & {
-  material?: THREE.Material | THREE.Material[];
-  frustumCulled?: boolean;
-};
-
-type StandardLikeMaterial = THREE.Material & {
-  color?: THREE.Color;
-  emissive?: THREE.Color;
-  emissiveIntensity?: number;
-  roughness?: number;
-  metalness?: number;
-  envMapIntensity?: number;
-  opacity?: number;
-  transparent?: boolean;
-  alphaTest?: number;
-  side?: THREE.Side;
-  shadowSide?: THREE.Side | null;
-  map?: THREE.Texture | null;
-  normalMap?: THREE.Texture | null;
-  emissiveMap?: THREE.Texture | null;
-  aoMap?: THREE.Texture | null;
-  roughnessMap?: THREE.Texture | null;
-  metalnessMap?: THREE.Texture | null;
-  alphaMap?: THREE.Texture | null;
-  depthTest?: boolean;
-  depthWrite?: boolean;
-  toneMapped?: boolean;
-  vertexColors?: boolean;
-  wireframe?: boolean;
-  fog?: boolean;
-};
-
-function getLiveAvatarScene(world?: ClientWorld): THREE.Object3D | null {
-  const scenePlayer = world?.entities?.player as PlayerWithLiveAvatar | null;
-  const player = (scenePlayer ??
-    world?.getPlayer()) as PlayerWithLiveAvatar | null;
-  if (!player) return null;
-
-  const localEntity = (
-    player.id ? world?.entities?.get?.(player.id) : null
-  ) as PlayerWithLiveAvatar | null;
-
-  const candidate = localEntity ?? player;
-
-  return (
-    candidate._avatar?.instance?.raw?.scene ??
-    candidate.avatar?.instance?.raw?.scene ??
-    player._avatar?.instance?.raw?.scene ??
-    player.avatar?.instance?.raw?.scene ??
-    null
-  );
+interface PreviewAvatarNode {
+  instance: PreviewAvatarInstance | null;
+  mount?: () => Promise<void>;
+  position: THREE.Vector3;
+  visible: boolean;
+  parent: { matrixWorld: THREE.Matrix4 };
+  activate(ctx: ClientWorld): void;
+  deactivate?: () => void;
 }
 
-function createFreshPortraitMaterial(source: THREE.Material): THREE.Material {
-  const standardSource = source as StandardLikeMaterial;
-  const material = new MeshStandardNodeMaterial();
-
-  material.color = standardSource.color?.clone() ?? new THREE.Color(0xffffff);
-  material.emissive =
-    standardSource.emissive?.clone() ?? new THREE.Color(0x000000);
-  material.emissiveIntensity = standardSource.emissiveIntensity ?? 0;
-  material.roughness = standardSource.roughness ?? 1;
-  material.metalness = standardSource.metalness ?? 0;
-  material.envMapIntensity = standardSource.envMapIntensity ?? 1;
-  material.opacity = standardSource.opacity ?? 1;
-  material.transparent = standardSource.transparent ?? false;
-  material.alphaTest = standardSource.alphaTest ?? 0;
-  material.side = standardSource.side ?? THREE.FrontSide;
-  material.shadowSide = standardSource.shadowSide;
-  material.depthTest = standardSource.depthTest ?? true;
-  material.depthWrite = standardSource.depthWrite ?? true;
-  material.toneMapped = standardSource.toneMapped ?? true;
-  material.vertexColors = standardSource.vertexColors ?? false;
-  material.wireframe = standardSource.wireframe ?? false;
-  material.fog = standardSource.fog ?? true;
-
-  if (standardSource.map) material.map = standardSource.map;
-  if (standardSource.normalMap) material.normalMap = standardSource.normalMap;
-  if (standardSource.emissiveMap) {
-    material.emissiveMap = standardSource.emissiveMap;
-  }
-  if (standardSource.aoMap) material.aoMap = standardSource.aoMap;
-  if (standardSource.roughnessMap) {
-    material.roughnessMap = standardSource.roughnessMap;
-  }
-  if (standardSource.metalnessMap) {
-    material.metalnessMap = standardSource.metalnessMap;
-  }
-  if (standardSource.alphaMap) material.alphaMap = standardSource.alphaMap;
-
-  material.name = source.name;
-  material.blending = source.blending;
-  material.blendSrc = source.blendSrc;
-  material.blendDst = source.blendDst;
-  material.blendEquation = source.blendEquation;
-  material.premultipliedAlpha = source.premultipliedAlpha;
-  material.visible = source.visible;
-  material.userData = { ...source.userData };
-
-  return material;
+interface PlayerWithAvatarUrl {
+  getAvatarUrl?: () => string;
+  data?: {
+    sessionAvatar?: unknown;
+    avatar?: unknown;
+  };
 }
 
-function clonePortraitMaterial(
-  material: THREE.Material | THREE.Material[],
-): THREE.Material | THREE.Material[] {
-  if (Array.isArray(material)) {
-    return material.map((entry) => createFreshPortraitMaterial(entry));
+const previewEquipmentParser = new GLTFLoader();
+previewEquipmentParser.setMeshoptDecoder(MeshoptDecoder);
+
+const previewEquipmentCache = new Map<string, GLTF>();
+
+const PREVIEW_EQUIPMENT_SLOTS: Array<{
+  slot: string;
+  item: keyof PlayerEquipmentItems;
+}> = [
+  { slot: "helmet", item: "helmet" },
+  { slot: "body", item: "body" },
+  { slot: "legs", item: "legs" },
+  { slot: "boots", item: "boots" },
+  { slot: "gloves", item: "gloves" },
+  { slot: "cape", item: "cape" },
+  { slot: "amulet", item: "amulet" },
+  { slot: "ring", item: "ring" },
+  { slot: "weapon", item: "weapon" },
+  { slot: "shield", item: "shield" },
+  { slot: "arrows", item: "arrows" },
+];
+
+function resolvePlayerAvatarUrl(world?: ClientWorld): string | null {
+  const player = (world?.entities?.player ??
+    world?.getPlayer?.()) as PlayerWithAvatarUrl | null;
+
+  if (!player) {
+    return null;
   }
 
-  return createFreshPortraitMaterial(material);
-}
-
-function disposePortraitClone(root: THREE.Object3D | null): void {
-  if (!root) return;
-
-  root.traverse((child) => {
-    const materialCarrier = child as MaterialCarrier;
-    const material = materialCarrier.material;
-    if (!material) return;
-
-    if (Array.isArray(material)) {
-      material.forEach((entry) => entry.dispose());
-      return;
-    }
-
-    material.dispose();
-  });
-}
-
-function buildPortraitClone(sourceScene: THREE.Object3D): THREE.Object3D {
-  const clone = SkeletonUtils.clone(sourceScene) as THREE.Object3D;
-  clone.scale.copy(sourceScene.scale);
-  clone.visible = true;
-  const silhouettes: THREE.Object3D[] = [];
-
-  clone.traverse((child) => {
-    if (child.name.startsWith("Silhouette_")) {
-      silhouettes.push(child);
-    }
-
-    child.castShadow = false;
-    child.receiveShadow = false;
-
-    const materialCarrier = child as MaterialCarrier;
-    if (materialCarrier.material) {
-      materialCarrier.material = clonePortraitMaterial(
-        materialCarrier.material,
-      );
-      materialCarrier.frustumCulled = false;
-    }
-
-    if ((child as THREE.SkinnedMesh).isSkinnedMesh) {
-      child.visible = true;
-    }
-
-    child.layers.enableAll();
-  });
-
-  silhouettes.forEach((node) => node.parent?.remove(node));
-
-  clone.position.set(0, 0, 0);
-  clone.quaternion.identity();
-  clone.rotation.set(0, 0, 0);
-  clone.updateMatrixWorld(true);
-
-  const initialBox = new THREE.Box3().setFromObject(clone);
-  if (initialBox.isEmpty()) {
-    return clone;
+  if (typeof player.getAvatarUrl === "function") {
+    return player.getAvatarUrl();
   }
 
-  const center = initialBox.getCenter(new THREE.Vector3());
-  clone.position.x -= center.x;
-  clone.position.z -= center.z;
-  clone.position.y -= initialBox.min.y;
-  clone.updateMatrixWorld(true);
+  const sessionAvatar = player.data?.sessionAvatar;
+  if (typeof sessionAvatar === "string" && sessionAvatar.length > 0) {
+    return sessionAvatar;
+  }
 
-  return clone;
+  const avatar = player.data?.avatar;
+  if (typeof avatar === "string" && avatar.length > 0) {
+    return avatar;
+  }
+
+  return null;
+}
+
+function getPreviewVRM(instance: PreviewAvatarInstance | null): VRM | null {
+  if (!instance?.raw) {
+    return null;
+  }
+
+  const rawScene = instance.raw.scene;
+  const fromUserData = rawScene?.userData?.vrm ?? instance.raw.userData?.vrm;
+  if (fromUserData?.scene && fromUserData.humanoid) {
+    return fromUserData;
+  }
+
+  const rawCandidate = instance.raw as unknown as VRM;
+  if (rawCandidate.scene && rawCandidate.humanoid) {
+    return rawCandidate;
+  }
+
+  return null;
+}
+
+function clearPreviewVisuals(visuals: EquipmentVisualStore): void {
+  Object.keys(visuals).forEach((slot) => removeEquipmentVisual(visuals, slot));
 }
 
 function framePortraitAvatar(
@@ -217,23 +146,94 @@ function framePortraitAvatar(
 
   const box = new THREE.Box3().setFromObject(avatarRoot);
   if (box.isEmpty()) {
-    camera.position.set(0, 1.25, 2.8);
-    camera.lookAt(0, 1.1, 0);
+    camera.position.set(0, 1.15, 2.7);
+    camera.lookAt(0, 1.05, 0);
     return;
   }
 
   const size = box.getSize(new THREE.Vector3());
   const center = box.getCenter(new THREE.Vector3());
-  const height = Math.max(size.y, 1.5);
-  const width = Math.max(size.x, 0.8);
-  const distance = Math.max(1.9, height * 0.94, width * 1.6);
-  const lookY = center.y + height * 0.03;
+  const height = Math.max(size.y, 1.6);
+  const width = Math.max(size.x, 0.7);
+  const distance = Math.max(1.85, height * 0.9, width * 1.45);
+  const lookY = center.y + height * 0.05;
 
   camera.position.set(0, lookY, distance);
   camera.lookAt(0, lookY, 0);
   camera.near = 0.1;
   camera.far = Math.max(12, distance + height * 3);
   camera.updateProjectionMatrix();
+}
+
+async function loadPreviewEquipmentVisuals(options: {
+  world: ClientWorld;
+  equipment: PlayerEquipmentItems | null | undefined;
+  vrm: VRM;
+  avatarRoot: THREE.Object3D;
+  visuals: EquipmentVisualStore;
+}): Promise<void> {
+  const { world, equipment, vrm, avatarRoot, visuals } = options;
+  const assetsUrl = world.assetsUrl?.replace(/\/$/, "") || "";
+
+  for (const entry of PREVIEW_EQUIPMENT_SLOTS) {
+    const equippedItem = equipment?.[entry.item];
+    if (!equippedItem?.id) {
+      continue;
+    }
+
+    const itemData = resolveEquipmentVisualData({
+      itemId: equippedItem.id,
+    });
+    const urls = resolveEquipmentVisualUrls({
+      assetsUrl,
+      itemId: equippedItem.id,
+      slot: entry.slot,
+      itemData,
+    });
+
+    if (!urls) {
+      continue;
+    }
+
+    let gltf = previewEquipmentCache.get(equippedItem.id);
+    if (!gltf) {
+      let file: File | undefined;
+
+      try {
+        file = world.loader
+          ? await world.loader.loadFile(urls.primaryUrl)
+          : undefined;
+      } catch (error) {
+        if (urls.fallbackUrl) {
+          file = world.loader
+            ? await world.loader.loadFile(urls.fallbackUrl)
+            : undefined;
+        } else {
+          throw error;
+        }
+      }
+
+      if (!file) {
+        continue;
+      }
+
+      const buffer = await file.arrayBuffer();
+      gltf = (await previewEquipmentParser.parseAsync(
+        buffer,
+        urls.primaryUrl,
+      )) as GLTF;
+      previewEquipmentCache.set(equippedItem.id, gltf);
+    }
+
+    const modelRoot = gltf.scene.clone(true);
+    attachEquipmentVisualToVRM({
+      slot: entry.slot,
+      modelRoot,
+      visuals,
+      vrm,
+      avatarRoot,
+    });
+  }
 }
 
 function PortraitFallback({
@@ -251,15 +251,15 @@ function PortraitFallback({
       data-portrait-fallback="true"
       className="absolute inset-0 flex items-center justify-center"
       style={{
-        opacity: mode === "loading" ? 0.7 : 1,
+        opacity: isLoading ? 0.9 : 1,
         transition: "opacity 160ms ease",
       }}
     >
       <div
         className="relative flex items-center justify-center"
         style={{
-          width: compact ? "86%" : "82%",
-          height: compact ? "92%" : "94%",
+          width: compact ? "84%" : "82%",
+          height: compact ? "96%" : "97%",
           borderRadius: compact ? 16 : 20,
           ...getPanelInsetStyle(theme, {
             emphasis: "strong",
@@ -268,18 +268,17 @@ function PortraitFallback({
           padding: 0,
           background:
             theme.name === "hyperscape"
-              ? "radial-gradient(circle at 50% 16%, rgba(190, 165, 123, 0.12), transparent 58%), linear-gradient(180deg, rgba(30, 35, 42, 0.95) 0%, rgba(18, 21, 26, 0.98) 100%)"
+              ? "radial-gradient(circle at 50% 12%, rgba(190, 165, 123, 0.12), transparent 54%), linear-gradient(180deg, rgba(30, 35, 42, 0.95) 0%, rgba(18, 21, 26, 0.98) 100%)"
               : undefined,
         }}
       >
         <div
-          className="absolute inset-x-[12%] bottom-[10%] top-[7%]"
+          className="absolute inset-x-[10%] bottom-[6%] top-[5%]"
           style={{
             borderRadius: compact ? 16 : 22,
             border: `1px solid ${theme.colors.border.default}55`,
-            background: isLoading
-              ? "linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(0,0,0,0.08) 100%)"
-              : "linear-gradient(180deg, rgba(255,255,255,0.035) 0%, rgba(0,0,0,0.12) 100%)",
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(0,0,0,0.12) 100%)",
             boxShadow:
               "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -16px 24px rgba(0,0,0,0.18)",
           }}
@@ -288,16 +287,16 @@ function PortraitFallback({
         {isLoading ? (
           <>
             <div
-              className="absolute inset-x-[24%] top-[18%] h-[18%] rounded-full"
+              className="absolute inset-x-[22%] top-[16%] h-[20%] rounded-full"
               style={{
-                background: `radial-gradient(circle at center, ${theme.colors.accent.primary}18 0%, transparent 72%)`,
+                background: `radial-gradient(circle at center, ${theme.colors.accent.primary}18 0%, transparent 74%)`,
               }}
             />
             <div
-              className="absolute inset-x-[18%] bottom-[16%] top-[28%] rounded-[22px]"
+              className="absolute inset-x-[18%] bottom-[12%] top-[24%] rounded-[20px]"
               style={{
                 border: `1px dashed ${theme.colors.border.hover}`,
-                opacity: 0.55,
+                opacity: 0.5,
               }}
             />
           </>
@@ -308,81 +307,64 @@ function PortraitFallback({
               style={{
                 width: compact ? 34 : 42,
                 height: compact ? 34 : 42,
-                top: compact ? "10%" : "8%",
+                top: compact ? "8%" : "7%",
                 background:
                   "linear-gradient(180deg, rgba(224, 197, 143, 0.95), rgba(154, 118, 71, 0.95))",
                 boxShadow: "0 10px 18px rgba(0,0,0,0.22)",
               }}
             />
-
             <div
               className="absolute rounded-[24px]"
               style={{
                 width: compact ? 46 : 56,
-                height: compact ? 78 : 98,
-                top: compact ? "24%" : "22%",
+                height: compact ? 82 : 106,
+                top: compact ? "20%" : "19%",
                 background:
                   "linear-gradient(180deg, rgba(72, 105, 63, 0.95), rgba(44, 68, 42, 0.98))",
                 boxShadow: "0 12px 20px rgba(0,0,0,0.22)",
               }}
             />
-
-            <div
-              className="absolute rounded-[14px]"
-              style={{
-                width: compact ? 82 : 102,
-                height: compact ? 16 : 18,
-                top: compact ? "39%" : "38%",
-                background:
-                  "linear-gradient(90deg, rgba(213, 171, 97, 0) 0%, rgba(213, 171, 97, 0.75) 24%, rgba(213, 171, 97, 0.75) 76%, rgba(213, 171, 97, 0) 100%)",
-                opacity: 0.32,
-              }}
-            />
-
             <div
               className="absolute rounded-full"
               style={{
                 width: compact ? 14 : 18,
-                height: compact ? 62 : 78,
-                left: compact ? "26%" : "24%",
-                top: compact ? "28%" : "27%",
+                height: compact ? 72 : 88,
+                left: compact ? "25%" : "24%",
+                top: compact ? "25%" : "24%",
                 transform: "rotate(10deg)",
                 background:
                   "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
               }}
             />
-
             <div
               className="absolute rounded-full"
               style={{
                 width: compact ? 14 : 18,
-                height: compact ? 62 : 78,
-                right: compact ? "26%" : "24%",
-                top: compact ? "28%" : "27%",
+                height: compact ? 72 : 88,
+                right: compact ? "25%" : "24%",
+                top: compact ? "25%" : "24%",
                 transform: "rotate(-10deg)",
                 background:
                   "linear-gradient(180deg, rgba(210, 171, 130, 0.9), rgba(154, 112, 83, 0.96))",
               }}
             />
-
             <div
               className="absolute rounded-full"
               style={{
                 width: compact ? 16 : 20,
-                height: compact ? 90 : 112,
-                left: compact ? "41%" : "40%",
+                height: compact ? 96 : 118,
+                left: compact ? "40%" : "39%",
                 bottom: compact ? "8%" : "6%",
                 background:
                   "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
               }}
             />
-
             <div
               className="absolute rounded-full"
               style={{
                 width: compact ? 16 : 20,
-                height: compact ? 90 : 112,
-                right: compact ? "41%" : "40%",
+                height: compact ? 96 : 118,
+                right: compact ? "40%" : "39%",
                 bottom: compact ? "8%" : "6%",
                 background:
                   "linear-gradient(180deg, rgba(44, 59, 85, 0.95), rgba(24, 34, 52, 0.98))",
@@ -390,17 +372,6 @@ function PortraitFallback({
             />
           </>
         )}
-
-        <div
-          className="absolute"
-          style={{
-            inset: 0,
-            borderRadius: compact ? 18 : 26,
-            background:
-              "radial-gradient(circle at 50% 12%, rgba(255,255,255,0.16), rgba(255,255,255,0) 34%)",
-            pointerEvents: "none",
-          }}
-        />
       </div>
     </div>
   );
@@ -409,6 +380,7 @@ function PortraitFallback({
 export const EquipmentPaperdollPortrait = React.memo(
   function EquipmentPaperdollPortrait({
     world,
+    equipment,
     className = "",
     equipmentSignature = "",
     compact = false,
@@ -416,19 +388,107 @@ export const EquipmentPaperdollPortrait = React.memo(
     const theme = useThemeStore((s) => s.theme);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    const rendererRef = useRef<WebGPURenderer | null>(null);
-    const sceneRef = useRef<THREE.Scene | null>(null);
-    const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
-    const avatarRootRef = useRef<THREE.Object3D | null>(null);
-    const frameRef = useRef<number>(0);
+    const viewportRef = useRef<Awaited<
+      ReturnType<typeof createAvatarPreviewViewport>
+    > | null>(null);
+    const avatarNodeRef = useRef<PreviewAvatarNode | null>(null);
+    const avatarSceneRef = useRef<THREE.Object3D | null>(null);
+    const previewVisualsRef = useRef<EquipmentVisualStore>({});
     const [rendererReady, setRendererReady] = useState(false);
     const [mode, setMode] = useState<PortraitMode>("fallback");
     const [refreshNonce, setRefreshNonce] = useState(0);
 
-    const signature = useMemo(
-      () => `${equipmentSignature}|${compact ? "compact" : "full"}`,
-      [compact, equipmentSignature],
+    const avatarUrl = useMemo(
+      () => resolvePlayerAvatarUrl(world),
+      [world, refreshNonce],
     );
+
+    const signature = useMemo(
+      () =>
+        `${avatarUrl ?? "no-avatar"}|${equipmentSignature}|${compact ? "compact" : "full"}`,
+      [avatarUrl, compact, equipmentSignature],
+    );
+
+    const clearPreviewAvatar = () => {
+      clearPreviewVisuals(previewVisualsRef.current);
+      previewVisualsRef.current = {};
+
+      const avatarScene = avatarSceneRef.current;
+      const avatarNode = avatarNodeRef.current;
+
+      avatarNode?.deactivate?.();
+
+      if (avatarScene) {
+        ThreeResourceManager.disposeObject(avatarScene, {
+          disposeGeometry: false,
+          disposeTextures: false,
+          disposeMaterial: true,
+          removeFromParent: false,
+        });
+      }
+
+      avatarSceneRef.current = null;
+      avatarNodeRef.current = null;
+    };
+
+    useEffect(() => {
+      const container = containerRef.current;
+      const canvas = canvasRef.current;
+
+      if (!container || !canvas) {
+        return;
+      }
+
+      let cancelled = false;
+      let resizeObserver: ResizeObserver | null = null;
+
+      createAvatarPreviewViewport({
+        container,
+        canvas,
+        cameraPosition: new THREE.Vector3(0, 1.32, 2.95),
+      })
+        .then((viewport) => {
+          if (cancelled) {
+            viewport.dispose();
+            return;
+          }
+
+          viewportRef.current = viewport;
+          viewport.start((delta) => {
+            avatarNodeRef.current?.instance?.update(delta);
+          });
+          setRendererReady(true);
+
+          if (typeof ResizeObserver !== "undefined") {
+            resizeObserver = new ResizeObserver(() => viewport.resize());
+            resizeObserver.observe(container);
+          } else {
+            window.addEventListener("resize", viewport.resize);
+          }
+        })
+        .catch((error) => {
+          console.error(
+            "[EquipmentPaperdollPortrait] Failed to initialize preview viewport:",
+            error,
+          );
+          if (!cancelled) {
+            setMode("fallback");
+            setRendererReady(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+        resizeObserver?.disconnect();
+        if (viewportRef.current) {
+          window.removeEventListener("resize", viewportRef.current.resize);
+        }
+        clearPreviewAvatar();
+        viewportRef.current?.dispose();
+        viewportRef.current = null;
+        setRendererReady(false);
+      };
+    }, []);
 
     useEffect(() => {
       if (!world) {
@@ -436,170 +496,136 @@ export const EquipmentPaperdollPortrait = React.memo(
         return;
       }
 
-      setMode("loading");
       const triggerRefresh = () => setRefreshNonce((current) => current + 1);
       triggerRefresh();
 
-      const timers = [120, 420, 1100].map((delay) =>
-        window.setTimeout(triggerRefresh, delay),
-      );
-
-      const handleAvatarReady = () => triggerRefresh();
-
-      world.on(EventType.AVATAR_LOAD_COMPLETE, handleAvatarReady, undefined);
+      world.on(EventType.AVATAR_LOAD_COMPLETE, triggerRefresh, undefined);
 
       return () => {
-        timers.forEach((timerId) => window.clearTimeout(timerId));
         world.off(
           EventType.AVATAR_LOAD_COMPLETE,
-          handleAvatarReady,
+          triggerRefresh,
           undefined,
           undefined,
         );
       };
-    }, [signature, world]);
+    }, [equipmentSignature, world]);
 
     useEffect(() => {
-      if (!world || !canvasRef.current || !containerRef.current) {
+      if (!world || !rendererReady || !viewportRef.current) {
         return;
       }
 
       let cancelled = false;
 
-      const scene = new THREE.Scene();
-      sceneRef.current = scene;
+      const buildPortrait = async () => {
+        const viewport = viewportRef.current;
+        setMode("loading");
+        clearPreviewAvatar();
 
-      const camera = new THREE.PerspectiveCamera(28, 1, 0.1, 20);
-      camera.layers.enableAll();
-      cameraRef.current = camera;
-
-      const ambient = new THREE.AmbientLight(0xf5e8cf, 1.35);
-      const key = new THREE.DirectionalLight(0xfff2d1, 1.45);
-      key.position.set(1.3, 2.2, 3.2);
-      const fill = new THREE.DirectionalLight(0x9ab7ff, 0.35);
-      fill.position.set(-1.8, 1.4, 2.4);
-      const rim = new THREE.DirectionalLight(0xf0c98b, 0.6);
-      rim.position.set(0.5, 2.6, -1.8);
-
-      scene.add(ambient, key, fill, rim);
-
-      const resize = () => {
-        if (
-          !containerRef.current ||
-          !rendererRef.current ||
-          !cameraRef.current
-        ) {
+        if (!world.loader || !avatarUrl || !viewport) {
+          setMode("fallback");
           return;
         }
 
-        const bounds = containerRef.current.getBoundingClientRect();
-        const width = Math.max(1, Math.floor(bounds.width));
-        const height = Math.max(1, Math.floor(bounds.height));
+        try {
+          const loadedAvatar = (await world.loader.load(
+            "avatar",
+            avatarUrl,
+          )) as {
+            toNodes: (
+              customHooks?: Record<string, unknown>,
+            ) => Map<string, unknown>;
+          };
 
-        rendererRef.current.setSize(width, height);
-        cameraRef.current.aspect = width / height;
-        cameraRef.current.updateProjectionMatrix();
-      };
-
-      const renderFrame = () => {
-        if (!rendererRef.current || !sceneRef.current || !cameraRef.current) {
-          return;
-        }
-
-        rendererRef.current.render(sceneRef.current, cameraRef.current);
-        frameRef.current = window.requestAnimationFrame(renderFrame);
-      };
-
-      createRenderer({
-        canvas: canvasRef.current,
-        alpha: true,
-        antialias: true,
-      })
-        .then((renderer) => {
           if (cancelled) {
-            renderer.dispose();
             return;
           }
 
-          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-          rendererRef.current = renderer;
-          setRendererReady(true);
-          resize();
-          frameRef.current = window.requestAnimationFrame(renderFrame);
-        })
-        .catch((error) => {
+          const avatarNode = loadedAvatar
+            .toNodes({
+              scene: viewport.scene,
+              loader: world.loader,
+            })
+            .get("avatar") as PreviewAvatarNode | undefined;
+
+          if (!avatarNode) {
+            setMode("fallback");
+            return;
+          }
+
+          avatarNode.parent = { matrixWorld: new THREE.Matrix4() };
+          avatarNode.position.set(0, 0, 0);
+          avatarNode.activate(world);
+          await avatarNode.mount?.();
+
+          if (cancelled) {
+            avatarNode.deactivate?.();
+            return;
+          }
+
+          const avatarInstance = avatarNode.instance;
+          const avatarScene = avatarInstance?.raw?.scene;
+          const vrm = getPreviewVRM(avatarInstance ?? null);
+
+          if (!avatarInstance || !avatarScene || !vrm) {
+            avatarNode.deactivate?.();
+            setMode("fallback");
+            return;
+          }
+
+          avatarNodeRef.current = avatarNode;
+          avatarSceneRef.current = avatarScene;
+          avatarInstance.disableRateCheck?.();
+
+          avatarNode.visible = false;
+          avatarScene.visible = false;
+
+          if (avatarInstance.setEmoteAndWait) {
+            await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);
+          } else {
+            avatarInstance.setEmote?.(Emotes.IDLE);
+          }
+
+          if (cancelled) {
+            return;
+          }
+
+          await loadPreviewEquipmentVisuals({
+            world,
+            equipment,
+            vrm,
+            avatarRoot: avatarScene,
+            visuals: previewVisualsRef.current,
+          });
+
+          if (cancelled) {
+            return;
+          }
+
+          avatarNode.visible = true;
+          avatarScene.visible = true;
+          framePortraitAvatar(avatarScene, viewport.camera);
+          viewport.resize();
+          setMode("live");
+        } catch (error) {
           console.error(
-            "[EquipmentPaperdollPortrait] Failed to create renderer:",
+            "[EquipmentPaperdollPortrait] Failed to build preview avatar:",
             error,
           );
           if (!cancelled) {
-            setRendererReady(false);
             setMode("fallback");
           }
-        });
+        }
+      };
 
-      let resizeObserver: ResizeObserver | null = null;
-      if (typeof ResizeObserver !== "undefined") {
-        resizeObserver = new ResizeObserver(() => resize());
-        resizeObserver.observe(containerRef.current);
-      } else {
-        window.addEventListener("resize", resize);
-      }
+      void buildPortrait();
 
       return () => {
         cancelled = true;
-        if (frameRef.current) {
-          window.cancelAnimationFrame(frameRef.current);
-        }
-        resizeObserver?.disconnect();
-        window.removeEventListener("resize", resize);
-        disposePortraitClone(avatarRootRef.current);
-        avatarRootRef.current?.parent?.remove(avatarRootRef.current);
-        avatarRootRef.current = null;
-        rendererRef.current?.dispose();
-        rendererRef.current = null;
-        sceneRef.current = null;
-        cameraRef.current = null;
-        setRendererReady(false);
+        clearPreviewAvatar();
       };
-    }, [world]);
-
-    useEffect(() => {
-      if (!rendererReady || !sceneRef.current || !cameraRef.current) {
-        return;
-      }
-
-      setMode("loading");
-      disposePortraitClone(avatarRootRef.current);
-      avatarRootRef.current?.parent?.remove(avatarRootRef.current);
-      avatarRootRef.current = null;
-
-      const sourceScene = getLiveAvatarScene(world);
-      if (!sourceScene) {
-        setMode("fallback");
-        return;
-      }
-
-      try {
-        const portraitClone = buildPortraitClone(sourceScene);
-        const bounds = new THREE.Box3().setFromObject(portraitClone);
-        if (bounds.isEmpty()) {
-          setMode("loading");
-          return;
-        }
-
-        sceneRef.current.add(portraitClone);
-        avatarRootRef.current = portraitClone;
-        framePortraitAvatar(portraitClone, cameraRef.current);
-        setMode("live");
-      } catch (error) {
-        console.error(
-          "[EquipmentPaperdollPortrait] Failed to build portrait clone:",
-          error,
-        );
-        setMode("fallback");
-      }
-    }, [refreshNonce, rendererReady, signature, world]);
+    }, [avatarUrl, equipment, rendererReady, signature, world]);
 
     return (
       <div
@@ -608,10 +634,10 @@ export const EquipmentPaperdollPortrait = React.memo(
         data-portrait-mode={mode}
         className={`relative overflow-hidden ${className}`}
         style={{
-          borderRadius: compact ? 14 : 18,
+          borderRadius: compact ? 16 : 20,
           ...getPanelInsetStyle(theme, {
             emphasis: "strong",
-            radius: compact ? 14 : 18,
+            radius: compact ? 16 : 20,
           }),
           padding: 0,
           background:

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -155,8 +155,8 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(1.85, height * 0.9, width * 1.45);
-  const lookY = center.y + height * 0.04;
+  const distance = Math.max(2.05, height * 1.02, width * 1.7);
+  const lookY = center.y + height * 0.03;
 
   camera.position.set(center.x, lookY, distance);
   camera.lookAt(center.x, lookY, center.z);
@@ -585,7 +585,7 @@ export const EquipmentPaperdollPortrait = React.memo(
 
           avatarNode.visible = false;
           avatarScene.visible = false;
-          avatarScene.rotation.y = Math.PI;
+          avatarScene.rotation.y = 0;
 
           if (avatarInstance.setEmoteAndWait) {
             await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -155,10 +155,10 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(2.18, height * 1.08, width * 1.82);
-  const lookY = center.y - height * 0.02;
+  const distance = Math.max(2.28, height * 1.12, width * 1.92);
+  const lookY = center.y - height * 0.05;
 
-  camera.position.set(center.x, lookY, distance);
+  camera.position.set(center.x, lookY, -distance);
   camera.lookAt(center.x, lookY, center.z);
   camera.near = 0.1;
   camera.far = Math.max(12, distance + height * 3);
@@ -586,7 +586,7 @@ export const EquipmentPaperdollPortrait = React.memo(
           avatarNode.visible = false;
           avatarScene.visible = false;
           avatarScene.rotation.y = 0;
-          vrm.scene.rotation.y = Math.PI;
+          vrm.scene.rotation.y = 0;
 
           if (avatarInstance.setEmoteAndWait) {
             await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -155,8 +155,8 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
-  const distance = Math.max(2.05, height * 1.02, width * 1.7);
-  const lookY = center.y + height * 0.03;
+  const distance = Math.max(2.18, height * 1.08, width * 1.82);
+  const lookY = center.y - height * 0.02;
 
   camera.position.set(center.x, lookY, distance);
   camera.lookAt(center.x, lookY, center.z);
@@ -586,6 +586,7 @@ export const EquipmentPaperdollPortrait = React.memo(
           avatarNode.visible = false;
           avatarScene.visible = false;
           avatarScene.rotation.y = 0;
+          vrm.scene.rotation.y = Math.PI;
 
           if (avatarInstance.setEmoteAndWait) {
             await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);

--- a/packages/client/src/game/panels/equipment/EquipmentTooltip.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentTooltip.tsx
@@ -1,10 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
 import { createPortal } from "react-dom";
-import {
-  calculateCursorTooltipPosition,
-  TOOLTIP_SIZE_ESTIMATES,
-  useThemeStore,
-} from "@/ui";
+import { useTooltipSize } from "@/hooks/useTooltipSize";
+import { TOOLTIP_SIZE_ESTIMATES, useThemeStore, CursorTooltip } from "@/ui";
 import { getItem } from "@hyperscape/shared";
 import type { Item } from "../../../types";
 
@@ -45,9 +42,24 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
   const theme = useThemeStore((s) => s.theme);
 
   if (!hoverState) return null;
-
   const item = hoverState.slot.item;
-  if (!item) return null;
+
+  if (!item) {
+    return (
+      <CursorTooltip
+        visible={true}
+        position={hoverState.position}
+        estimatedSize={{ width: 80, height: 32 }}
+        className="text-[10px] font-semibold tracking-wider uppercase whitespace-nowrap !p-[6px_10px]"
+        style={{
+          background: "rgba(18, 21, 25, 0.98)",
+          color: theme.colors.text.primary,
+        }}
+      >
+        {hoverState.slot.label}
+      </CursorTooltip>
+    );
+  }
 
   // Get full item data for additional info
   const itemData = getItem(item.id);
@@ -55,13 +67,6 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
   const equipSlot = itemData?.equipSlot || hoverState.slot.label;
 
   const rarityColor = RARITY_COLORS[rarity] || theme.colors.accent.primary;
-
-  // Use tooltip positioning with edge detection
-  const { left, top } = calculateCursorTooltipPosition(
-    { x: hoverState.position.x, y: hoverState.position.y },
-    TOOLTIP_SIZE_ESTIMATES.large,
-    8,
-  );
 
   const hasBonuses =
     item.bonuses &&
@@ -91,21 +96,15 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
     hasMagicBonuses ||
     hasRangedBonuses;
 
-  return createPortal(
-    <div
-      className="pointer-events-none"
+  return (
+    <CursorTooltip
+      visible={true}
+      position={hoverState.position}
+      estimatedSize={TOOLTIP_SIZE_ESTIMATES.xlarge}
       style={{
-        position: "fixed",
-        left,
-        top,
-        zIndex: theme.zIndex.tooltip,
-        background: `linear-gradient(180deg, ${theme.colors.background.primary} 0%, ${theme.colors.background.secondary} 100%)`,
-        border: `1px solid ${theme.colors.border.hover}`,
-        borderRadius: `${theme.borderRadius.md}px`,
-        padding: "10px 12px",
-        boxShadow: "0 4px 16px rgba(0,0,0,0.5)",
         minWidth: "160px",
         maxWidth: "240px",
+        zIndex: theme.zIndex.tooltip,
       }}
     >
       {/* Item name with rarity color */}
@@ -359,7 +358,6 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       >
         Click to unequip • Right-click for options
       </div>
-    </div>,
-    document.body,
+    </CursorTooltip>
   );
 });

--- a/packages/client/src/ui/components/Tab.tsx
+++ b/packages/client/src/ui/components/Tab.tsx
@@ -116,8 +116,8 @@ export const Tab = memo(function Tab({
   const containerStyle: React.CSSProperties = {
     ...getTabStyle(theme, { active: isActive, dragging: isDragging }),
     justifyContent: "center",
-    minWidth: hasVisualIcon ? 42 : 76,
-    maxWidth: hasVisualIcon ? 42 : 168,
+    minWidth: hasVisualIcon ? 34 : 70,
+    maxWidth: hasVisualIcon ? 42 : 140,
     ...style,
     ...(isUnlocked ? dragHandleProps.style : { cursor: "pointer" }),
   };

--- a/packages/client/src/ui/core/tooltip/CursorTooltip.tsx
+++ b/packages/client/src/ui/core/tooltip/CursorTooltip.tsx
@@ -1,0 +1,74 @@
+import React, { useRef } from "react";
+import { createPortal } from "react-dom";
+import { useTooltipSize } from "../../../hooks/useTooltipSize";
+import {
+  calculateCursorTooltipPosition,
+  type TooltipPositionOptions,
+} from "./useTooltipPosition";
+import { useThemeStore } from "@/ui";
+
+export interface CursorTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** If false, the tooltip is not rendered */
+  visible: boolean;
+  /** Current mouse position { x, y } */
+  position: { x: number; y: number };
+  /** Fallback size to use before actual measurement */
+  estimatedSize?: { width: number; height: number };
+  /** Offset from the cursor (default: 4) */
+  cursorOffset?: number;
+  /** Content to render */
+  children: React.ReactNode;
+}
+
+/**
+ * Reusable portal-based mouse-following tooltip.
+ * Automatically measures its own dimensions and flips orientation
+ * if it would clip off the edge of the screen.
+ * Standardizes the dark gradient theme across the game.
+ */
+export const CursorTooltip = React.memo(function CursorTooltip({
+  visible,
+  position,
+  estimatedSize = { width: 140, height: 60 },
+  cursorOffset = 4,
+  children,
+  className = "",
+  style,
+  ...props
+}: CursorTooltipProps) {
+  const theme = useThemeStore((s) => s.theme);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  // Measure the actual rendered dimension for precise alignment
+  const actualSize = useTooltipSize(visible, tooltipRef, estimatedSize);
+
+  if (!visible) return null;
+
+  // Calculate safe bounding-box positioning
+  const { left, top } = calculateCursorTooltipPosition(
+    position,
+    actualSize,
+    cursorOffset,
+  );
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      className={`fixed pointer-events-none z-[100000] animate-in fade-in zoom-in-95 duration-100 ${className}`}
+      style={{
+        left,
+        top,
+        background: `linear-gradient(180deg, ${theme.colors.background.primary} 0%, ${theme.colors.background.secondary} 100%)`,
+        border: `1px solid ${theme.colors.border.hover}`,
+        borderRadius: `4px`, // Squared off look matching the design rules
+        padding: "8px 10px",
+        boxShadow: "0 4px 16px rgba(0,0,0,0.5)",
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+});

--- a/packages/client/src/ui/core/tooltip/index.ts
+++ b/packages/client/src/ui/core/tooltip/index.ts
@@ -23,3 +23,5 @@ export {
   type TooltipPositionOptions,
   type TooltipPositionResult,
 } from "./useTooltipPosition";
+
+export * from "./CursorTooltip";

--- a/packages/client/src/ui/stores/windowStore.ts
+++ b/packages/client/src/ui/stores/windowStore.ts
@@ -203,8 +203,9 @@ const STORAGE_KEY = "hyperscape-window-layout";
  * - 14: New flush layout with proportional scaling (Minimap→Quests→Skills→Inventory→Menubar right column, Chat left, Action bar bottom center)
  * - 15: Improved flush layout with proper height distribution - right column fills entire viewport height
  * - 16: UI theme and layout improvements - taller chat, action bar bottom anchoring fix
+ * - 17: Add SpellsPanel to the default layout alongside Prayer
  */
-const SCHEMA_VERSION = 16;
+const SCHEMA_VERSION = 17;
 
 /** Panel ID to icon mapping for tab display migration */
 const PANEL_ICONS: Record<string, string> = {
@@ -214,6 +215,7 @@ const PANEL_ICONS: Record<string, string> = {
   stats: "📊",
   skills: "⭐",
   prayer: "✨",
+  spells: "🪄",
   combat: "🗡️",
   account: "👤",
   settings: "⚙️",
@@ -608,6 +610,14 @@ const migrations: Record<number, MigrationFn> = {
   16: () => {
     debugLog(
       "[WindowStore Migration v16] Clearing all windows - UI theme and layout improvements",
+    );
+    return new Map<string, WindowState>();
+  },
+
+  // v17: Add spells tab
+  17: () => {
+    debugLog(
+      "[WindowStore Migration v17] Clearing all windows to include spellbook in default layout",
     );
     return new Map<string, WindowState>();
   },

--- a/packages/client/src/ui/theme/themes.ts
+++ b/packages/client/src/ui/theme/themes.ts
@@ -671,8 +671,8 @@ export function getTabStyle(
     display: "flex",
     alignItems: "center",
     gap: theme.spacing.xs,
-    minHeight: 34,
-    padding: `0 ${theme.spacing.sm + 1}px`,
+    minHeight: 32,
+    padding: `0 6px`,
     ...getTabChromeStyle(theme, {
       isActive: active,
       isDragging: dragging,

--- a/packages/client/tests/e2e/panels.spec.ts
+++ b/packages/client/tests/e2e/panels.spec.ts
@@ -421,18 +421,71 @@ test.describe("Equipment Panel", () => {
     await page.waitForTimeout(500);
 
     const equipmentPanel = page.locator('[data-panel="equipment"]');
+    const portrait = equipmentPanel.locator('[data-equipment-portrait="true"]');
 
-    // Equipment panel should have slot elements
-    const slots = equipmentPanel.locator(
-      "[data-slot], [data-equipment-slot], .equipment-slot",
-    );
-    const slotCount = await slots.count();
+    await expect(portrait).toBeVisible();
 
-    // Should have at least some equipment slots (head, body, legs, weapon, etc.)
-    // Standard RPG has ~11 equipment slots, but at minimum we expect 1
-    expect(slotCount).toBeGreaterThanOrEqual(1);
+    const slots = equipmentPanel.locator("[data-equipment-slot]");
+    await expect(slots).toHaveCount(11);
 
     await takeGameScreenshot(page, "equipment-slots");
+  });
+
+  test("should render the paperdoll layout on a mobile viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    await waitForGameLoad(page);
+    await waitForPlayerSpawn(page);
+
+    await openPanel(page, "equipment");
+    await page.waitForTimeout(500);
+
+    const equipmentPanel = page.locator('[data-panel="equipment"]');
+    await expect(
+      equipmentPanel.locator('[data-equipment-grid="paperdoll"]'),
+    ).toBeVisible();
+    await expect(
+      equipmentPanel.locator('[data-equipment-portrait="true"]'),
+    ).toBeVisible();
+    await expect(equipmentPanel.locator("[data-equipment-slot]")).toHaveCount(
+      11,
+    );
+
+    await takeGameScreenshot(page, "equipment-mobile-paperdoll");
+  });
+
+  test("should keep the portrait stable during equipment interactions", async ({
+    page,
+  }) => {
+    await openPanel(page, "equipment");
+    await page.waitForTimeout(500);
+
+    const equipmentPanel = page.locator('[data-panel="equipment"]');
+    const portrait = equipmentPanel.locator('[data-equipment-portrait="true"]');
+    await expect(portrait).toBeVisible();
+
+    const occupiedSlots = equipmentPanel.locator(
+      '[data-equipment-slot][data-slot-empty="false"]',
+    );
+    const beforeCount = await occupiedSlots.count();
+
+    if (beforeCount > 0) {
+      await occupiedSlots.first().click();
+      await page.waitForTimeout(600);
+
+      const afterCount = await equipmentPanel
+        .locator('[data-equipment-slot][data-slot-empty="false"]')
+        .count();
+
+      expect(afterCount).toBeLessThanOrEqual(beforeCount);
+      await expect(portrait).toBeVisible();
+    }
+
+    await expect(equipmentPanel.locator("[data-equipment-slot]")).toHaveCount(
+      11,
+    );
   });
 });
 

--- a/packages/client/tests/unit/EquipmentPanel.test.tsx
+++ b/packages/client/tests/unit/EquipmentPanel.test.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EquipmentSlotName,
+  ITEMS,
+  type Item,
+  type PlayerEquipmentItems,
+} from "@hyperscape/shared";
+import { EquipmentPanel } from "../../src/game/panels/EquipmentPanel";
+
+let mockShouldUseMobileUI = false;
+
+vi.mock("@/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/ui")>("@/ui");
+
+  return {
+    ...actual,
+    useDroppable: vi.fn(() => ({
+      isOver: false,
+      setNodeRef: vi.fn(),
+    })),
+    useDragStore: vi.fn(
+      (selector: (state: { item: null; isDragging: boolean }) => unknown) =>
+        selector({
+          item: null,
+          isDragging: false,
+        }),
+    ),
+    useMobileLayout: vi.fn(() => ({
+      isMobile: mockShouldUseMobileUI,
+      isTablet: false,
+      isDesktop: !mockShouldUseMobileUI,
+      orientation: mockShouldUseMobileUI ? "portrait" : "landscape",
+      isPortrait: mockShouldUseMobileUI,
+      isLandscape: !mockShouldUseMobileUI,
+      shouldUseMobileUI: mockShouldUseMobileUI,
+      touchTargetSize: mockShouldUseMobileUI ? 48 : 40,
+      safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewport: {
+        width: mockShouldUseMobileUI ? 390 : 1280,
+        height: mockShouldUseMobileUI ? 844 : 720,
+      },
+    })),
+  };
+});
+
+function createMockItem(
+  id: string,
+  name: string,
+  equipSlot?: Item["equipSlot"],
+  quantity = 1,
+): Item {
+  return {
+    id,
+    name,
+    type: "weapon" as Item["type"],
+    description: `A ${name}`,
+    examine: `Examine ${name}`,
+    tradeable: true,
+    rarity: "common" as Item["rarity"],
+    modelPath: null,
+    iconPath: `/items/${id}.png`,
+    equipSlot,
+    quantity,
+    stackable: quantity > 1,
+    maxStackSize: quantity > 1 ? 1000 : 1,
+  };
+}
+
+describe("EquipmentPanel", () => {
+  const emptyEquipment: PlayerEquipmentItems = {
+    helmet: null,
+    body: null,
+    legs: null,
+    boots: null,
+    gloves: null,
+    cape: null,
+    amulet: null,
+    ring: null,
+    weapon: null,
+    shield: null,
+    arrows: null,
+  };
+
+  beforeEach(() => {
+    mockShouldUseMobileUI = false;
+    ITEMS.clear();
+
+    ITEMS.set(
+      "bronze_sword",
+      createMockItem("bronze_sword", "Bronze Sword", EquipmentSlotName.WEAPON),
+    );
+    ITEMS.set(
+      "iron_helmet",
+      createMockItem("iron_helmet", "Iron Helmet", EquipmentSlotName.HELMET),
+    );
+    ITEMS.set(
+      "bronze_arrow",
+      createMockItem(
+        "bronze_arrow",
+        "Bronze Arrow",
+        EquipmentSlotName.ARROWS,
+        25,
+      ),
+    );
+  });
+
+  it("renders the paperdoll slots and fallback portrait when no world is available", () => {
+    const { container } = render(<EquipmentPanel equipment={emptyEquipment} />);
+
+    expect(container.querySelectorAll("[data-equipment-slot]")).toHaveLength(
+      11,
+    );
+
+    const portrait = container.querySelector(
+      '[data-equipment-portrait="true"]',
+    );
+    expect(portrait).toBeInTheDocument();
+    expect(portrait).toHaveAttribute("data-portrait-mode", "fallback");
+    expect(
+      container.querySelector('[data-portrait-fallback="true"]'),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTitle("Head (empty)")).toBeInTheDocument();
+    expect(screen.getByTitle("Weapon (empty)")).toBeInTheDocument();
+  });
+
+  it("shows equipped item icons without visible item-name labels in slot tiles", () => {
+    const equipment: PlayerEquipmentItems = {
+      ...emptyEquipment,
+      helmet: createMockItem(
+        "iron_helmet",
+        "Iron Helmet",
+        EquipmentSlotName.HELMET,
+      ),
+      weapon: createMockItem(
+        "bronze_sword",
+        "Bronze Sword",
+        EquipmentSlotName.WEAPON,
+      ),
+      arrows: createMockItem(
+        "bronze_arrow",
+        "Bronze Arrow",
+        EquipmentSlotName.ARROWS,
+        25,
+      ),
+    };
+
+    render(<EquipmentPanel equipment={equipment} />);
+
+    expect(screen.getByAltText("Iron Helmet")).toBeInTheDocument();
+    expect(screen.getByAltText("Bronze Sword")).toBeInTheDocument();
+    expect(screen.getByAltText("Bronze Arrow")).toBeInTheDocument();
+    expect(screen.queryByText("Bronze Sword")).not.toBeInTheDocument();
+    expect(screen.getByText("25")).toBeInTheDocument();
+  });
+
+  it("updates the rendered equipment when props change", () => {
+    const initialEquipment: PlayerEquipmentItems = {
+      ...emptyEquipment,
+      weapon: createMockItem(
+        "bronze_sword",
+        "Bronze Sword",
+        EquipmentSlotName.WEAPON,
+      ),
+    };
+
+    const { rerender } = render(
+      <EquipmentPanel equipment={initialEquipment} />,
+    );
+    expect(screen.getByAltText("Bronze Sword")).toBeInTheDocument();
+
+    rerender(<EquipmentPanel equipment={emptyEquipment} />);
+    expect(screen.queryByAltText("Bronze Sword")).not.toBeInTheDocument();
+
+    rerender(
+      <EquipmentPanel
+        equipment={{
+          ...emptyEquipment,
+          helmet: createMockItem(
+            "iron_helmet",
+            "Iron Helmet",
+            EquipmentSlotName.HELMET,
+          ),
+        }}
+      />,
+    );
+
+    expect(screen.getByAltText("Iron Helmet")).toBeInTheDocument();
+  });
+
+  it("keeps the portrait container in the compact mobile layout", () => {
+    mockShouldUseMobileUI = true;
+
+    const { container } = render(<EquipmentPanel equipment={emptyEquipment} />);
+
+    expect(
+      container.querySelector('[data-equipment-grid="paperdoll"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-equipment-portrait="true"]'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/client/tests/unit/EquipmentPanel.test.tsx
+++ b/packages/client/tests/unit/EquipmentPanel.test.tsx
@@ -106,7 +106,7 @@ describe("EquipmentPanel", () => {
     );
   });
 
-  it("renders the paperdoll slots and fallback portrait when no world is available", () => {
+  it("renders the paperdoll slots and keeps the portrait in a loading state before world data is available", () => {
     const { container } = render(<EquipmentPanel equipment={emptyEquipment} />);
 
     expect(container.querySelectorAll("[data-equipment-slot]")).toHaveLength(
@@ -117,16 +117,15 @@ describe("EquipmentPanel", () => {
       '[data-equipment-portrait="true"]',
     );
     expect(portrait).toBeInTheDocument();
-    expect(portrait).toHaveAttribute("data-portrait-mode", "fallback");
-    expect(
-      container.querySelector('[data-portrait-fallback="true"]'),
-    ).toBeInTheDocument();
+    expect(portrait).toHaveAttribute("data-portrait-mode", "loading");
 
     expect(screen.getByTitle("Head (empty)")).toBeInTheDocument();
     expect(screen.getByTitle("Weapon (empty)")).toBeInTheDocument();
+    expect(screen.getByText("Head")).toBeInTheDocument();
+    expect(screen.getByText("Weapon")).toBeInTheDocument();
   });
 
-  it("shows equipped item icons without visible item-name labels in slot tiles", () => {
+  it("shows equipped item icons with slot labels and without visible item-name labels in slot tiles", () => {
     const equipment: PlayerEquipmentItems = {
       ...emptyEquipment,
       helmet: createMockItem(

--- a/packages/shared/src/entities/player/PlayerLocal.ts
+++ b/packages/shared/src/entities/player/PlayerLocal.ts
@@ -2350,17 +2350,39 @@ export class PlayerLocal extends Entity implements HotReloadable {
       // Otherwise entities face AWAY from each other instead of towards
       angle += Math.PI;
 
-      // Apply instant rotation (RuneScape doesn't lerp combat rotation) using pre-allocated temps
-      if (this.base) {
-        _combatQuat.setFromAxisAngle(_combatAxis, angle);
-        this.base.quaternion.copy(_combatQuat);
+      _combatQuat.setFromAxisAngle(_combatAxis, angle);
 
-        // Issue #322: Store this rotation to preserve facing after combat ends
-        if (!this._lastCombatRotation) {
-          this._lastCombatRotation = new THREE.Quaternion();
-        }
-        this._lastCombatRotation.copy(_combatQuat);
+      // FIX: Route combat rotation through TileInterpolator when it controls this entity.
+      // Previously, PlayerLocal wrote directly to base.quaternion which caused a race condition:
+      // PlayerLocal.update() (hot entity) runs BEFORE TileInterpolator.update() (system),
+      // so TileInterpolator would overwrite the combat rotation with its stale state.quaternion,
+      // or vice versa — the two systems fought over base.quaternion every frame.
+      // Now combat rotation flows through TileInterpolator's state, matching how remote players work.
+      const tileControlled = this.data?.tileInterpolatorControlled === true;
+      if (tileControlled) {
+        const network = this.world.network as {
+          tileInterpolator?: {
+            setCombatRotation?: (
+              entityId: string,
+              quaternion: number[] | THREE.Quaternion,
+              entityPosition?: { x: number; y: number; z: number },
+            ) => boolean;
+          };
+        };
+        network?.tileInterpolator?.setCombatRotation?.(
+          this.data.id,
+          _combatQuat,
+        );
+      } else if (this.base) {
+        // Fallback: TileInterpolator hasn't touched this entity yet
+        this.base.quaternion.copy(_combatQuat);
       }
+
+      // Issue #322: Store this rotation to preserve facing after combat ends
+      if (!this._lastCombatRotation) {
+        this._lastCombatRotation = new THREE.Quaternion();
+      }
+      this._lastCombatRotation.copy(_combatQuat);
     } else if (
       !combatTarget &&
       !isMoving &&
@@ -2368,7 +2390,25 @@ export class PlayerLocal extends Entity implements HotReloadable {
       this.base
     ) {
       // Issue #322: When combat ends but player isn't moving, preserve combat facing direction
-      this.base.quaternion.copy(this._lastCombatRotation);
+      // Route through TileInterpolator to avoid the same race condition
+      const tileControlled = this.data?.tileInterpolatorControlled === true;
+      if (tileControlled) {
+        const network = this.world.network as {
+          tileInterpolator?: {
+            setCombatRotation?: (
+              entityId: string,
+              quaternion: number[] | THREE.Quaternion,
+              entityPosition?: { x: number; y: number; z: number },
+            ) => boolean;
+          };
+        };
+        network?.tileInterpolator?.setCombatRotation?.(
+          this.data.id,
+          this._lastCombatRotation,
+        );
+      } else {
+        this.base.quaternion.copy(this._lastCombatRotation);
+      }
     }
 
     // Server-authoritative movement: minimal updates only

--- a/packages/shared/src/index.client.ts
+++ b/packages/shared/src/index.client.ts
@@ -238,6 +238,19 @@ export { ClientRuntime } from "./systems/client/ClientRuntime"; // Client lifecy
 export { ClientAudio } from "./systems/client/ClientAudio";
 export { ClientLiveKit } from "./systems/client/ClientLiveKit";
 export { ClientInput } from "./systems/client/ClientInput";
+export {
+  attachEquipmentVisualToVRM,
+  extractEquipmentAttachmentData,
+  removeEquipmentVisual,
+  resolveEquipmentVisualData,
+  resolveEquipmentVisualUrls,
+} from "./systems/client/EquipmentVisualHelpers";
+export type {
+  EquipmentAttachmentData,
+  EquipmentVisualModelData,
+  EquipmentVisualStore,
+  EquipmentVisualUrlResolution,
+} from "./systems/client/EquipmentVisualHelpers";
 export { ClientActions } from "./systems/client/ClientActions";
 export { DevStats } from "./systems/client/DevStats"; // FPS counter and dev performance telemetry
 export { EventBus } from "./systems/shared";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -398,6 +398,19 @@ export type {
 
 // Export prayer data provider for UI panels
 export { prayerDataProvider } from "./data/PrayerDataProvider";
+export {
+  attachEquipmentVisualToVRM,
+  extractEquipmentAttachmentData,
+  removeEquipmentVisual,
+  resolveEquipmentVisualData,
+  resolveEquipmentVisualUrls,
+} from "./systems/client/EquipmentVisualHelpers";
+export type {
+  EquipmentAttachmentData,
+  EquipmentVisualModelData,
+  EquipmentVisualStore,
+  EquipmentVisualUrlResolution,
+} from "./systems/client/EquipmentVisualHelpers";
 
 // Export spell service for magic combat
 export { spellService } from "./systems/shared/combat/SpellService";

--- a/packages/shared/src/systems/client/EquipmentVisualHelpers.ts
+++ b/packages/shared/src/systems/client/EquipmentVisualHelpers.ts
@@ -1,0 +1,312 @@
+import { getItem } from "../../data/items";
+import type { VRM, VRMHumanBoneName } from "@pixiv/three-vrm";
+import * as THREE from "three";
+
+export interface EquipmentAttachmentData {
+  vrmBoneName: string;
+  originalSlot?: string;
+  weaponType?: string;
+  usage?: string;
+  note?: string;
+  version?: number;
+  relativeMatrix?: number[];
+  avatarId?: string;
+  avatarHeight?: number;
+}
+
+export interface EquipmentVisualModelData {
+  equippedModelPath?: string | null;
+  modelPath?: string | null;
+}
+
+export interface EquipmentVisualUrlResolution {
+  primaryUrl: string;
+  fallbackUrl: string | null;
+}
+
+export interface EquipmentVisualStore {
+  [slot: string]: THREE.Object3D | undefined;
+}
+
+export function removeEquipmentVisual(
+  store: EquipmentVisualStore,
+  slot: string,
+): void {
+  const slotKey = slot.toLowerCase();
+  const existingVisual = store[slotKey];
+
+  if (existingVisual?.parent) {
+    existingVisual.parent.remove(existingVisual);
+  }
+
+  store[slotKey] = undefined;
+}
+
+export function extractEquipmentAttachmentData(
+  root: THREE.Object3D,
+): EquipmentAttachmentData | undefined {
+  const rootAttachment = root.userData.hyperscape as
+    | EquipmentAttachmentData
+    | undefined;
+
+  if (rootAttachment) {
+    return rootAttachment;
+  }
+
+  return root.children[0]?.userData?.hyperscape as
+    | EquipmentAttachmentData
+    | undefined;
+}
+
+export function resolveEquipmentVisualUrls(options: {
+  assetsUrl: string;
+  itemId: string;
+  slot: string;
+  itemData?: EquipmentVisualModelData | null;
+  fallbackItemData?: EquipmentVisualModelData | null;
+}): EquipmentVisualUrlResolution | null {
+  const { assetsUrl, itemId, slot, itemData, fallbackItemData } = options;
+
+  let equippedModelPath = itemData?.equippedModelPath;
+  let modelPath = itemData?.modelPath;
+
+  if (equippedModelPath === null) {
+    return null;
+  }
+
+  if (!equippedModelPath) {
+    if (fallbackItemData?.equippedModelPath) {
+      equippedModelPath = fallbackItemData.equippedModelPath;
+    }
+    if (!modelPath && fallbackItemData?.modelPath) {
+      modelPath = fallbackItemData.modelPath;
+    }
+  }
+
+  if (equippedModelPath) {
+    return {
+      primaryUrl: equippedModelPath.replace("asset://", `${assetsUrl}/`),
+      fallbackUrl: null,
+    };
+  }
+
+  if (modelPath && typeof modelPath === "string") {
+    return {
+      primaryUrl: modelPath.replace("asset://", `${assetsUrl}/`),
+      fallbackUrl: null,
+    };
+  }
+
+  const parts = itemId.split("_");
+  let assetId = itemId.replace(/_/g, "-");
+  let category = "";
+
+  const materials = [
+    "bronze",
+    "steel",
+    "mithril",
+    "iron",
+    "rune",
+    "dragon",
+    "wood",
+    "oak",
+    "willow",
+    "yew",
+  ];
+
+  const categoryMap: Record<string, string> = {
+    sword: "swords-old",
+    longsword: "swords/long-swords",
+    scimitar: "swords/scimitars",
+    "2h_sword": "swords/2h-swords",
+    "2h": "swords/2h-swords",
+    shortsword: "swords/shortswords",
+    dagger: "swords/daggers",
+    hatchet: "hatchets",
+    pickaxe: "pickaxes",
+    arrow: "arrows",
+    bow: "bows",
+    staff: "magic-staffs",
+    shield: "shields",
+  };
+
+  if (parts.length >= 2 && materials.includes(parts[0])) {
+    const material = parts[0];
+    const itemParts = parts.slice(1);
+    const itemKey = itemParts.join("_");
+    assetId = `${itemParts.join("-")}-${material}`;
+    category = categoryMap[itemKey] || categoryMap[itemParts[0]] || "";
+  }
+
+  if (!category) {
+    return null;
+  }
+
+  const prefix = `${category}/`;
+  return {
+    primaryUrl: `${assetsUrl}/models/${prefix}${assetId}-aligned.glb`,
+    fallbackUrl: `${assetsUrl}/models/${prefix}${assetId}/${assetId}-aligned.glb`,
+  };
+}
+
+export function resolveEquipmentVisualData(options: {
+  itemId: string;
+  fallbackItemData?: EquipmentVisualModelData | null;
+}): EquipmentVisualModelData | null {
+  const itemData = getItem(options.itemId);
+
+  if (itemData) {
+    return {
+      equippedModelPath: itemData.equippedModelPath,
+      modelPath: itemData.modelPath,
+    };
+  }
+
+  return options.fallbackItemData ?? null;
+}
+
+function hasSkinnedMesh(root: THREE.Object3D): boolean {
+  let found = false;
+  root.traverse((child) => {
+    if (child instanceof THREE.SkinnedMesh) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function getPlayerSkeleton(vrm: VRM): THREE.Skeleton | undefined {
+  let playerSkeleton: THREE.Skeleton | undefined;
+
+  vrm.scene.traverse((child) => {
+    if (
+      !playerSkeleton &&
+      child instanceof THREE.SkinnedMesh &&
+      child.skeleton
+    ) {
+      playerSkeleton = child.skeleton;
+    }
+  });
+
+  return playerSkeleton;
+}
+
+function findTargetBone(
+  vrm: VRM,
+  avatarRoot: THREE.Object3D,
+  boneName: string,
+): THREE.Object3D | null {
+  const prefabBone = vrm.humanoid?.getRawBoneNode(boneName as VRMHumanBoneName);
+  if (!prefabBone) {
+    return null;
+  }
+
+  const targetBoneName = prefabBone.name;
+  let targetBone: THREE.Object3D | null = null;
+
+  avatarRoot.traverse((child) => {
+    if (!targetBone && child.name === targetBoneName) {
+      targetBone = child;
+    }
+  });
+
+  return targetBone;
+}
+
+export function attachEquipmentVisualToVRM(options: {
+  slot: string;
+  modelRoot: THREE.Object3D;
+  visuals: EquipmentVisualStore;
+  vrm: VRM;
+  avatarRoot?: THREE.Object3D;
+}): boolean {
+  const { slot, modelRoot, visuals, vrm } = options;
+  const slotKey = slot.toLowerCase();
+  const avatarRoot = options.avatarRoot ?? vrm.scene;
+  const attachmentData = extractEquipmentAttachmentData(modelRoot);
+  const boneName = attachmentData?.vrmBoneName || "rightHand";
+
+  const skinnedSlots = ["body", "legs", "boots", "gloves", "cape"];
+  const isSkinnedSlot = skinnedSlots.includes(slotKey);
+
+  if (isSkinnedSlot && hasSkinnedMesh(modelRoot)) {
+    const playerSkeleton = getPlayerSkeleton(vrm);
+    if (!playerSkeleton) {
+      return false;
+    }
+
+    modelRoot.traverse((child) => {
+      if (child instanceof THREE.SkinnedMesh) {
+        child.skeleton = playerSkeleton;
+        child.bind(playerSkeleton, child.bindMatrix);
+      }
+    });
+
+    removeEquipmentVisual(visuals, slot);
+    visuals[slotKey] = modelRoot;
+    vrm.scene.add(modelRoot);
+    return true;
+  }
+
+  const targetBone = findTargetBone(vrm, avatarRoot, boneName);
+  if (!targetBone) {
+    return false;
+  }
+
+  removeEquipmentVisual(visuals, slot);
+
+  const hasValidMatrix =
+    attachmentData?.version === 2 &&
+    Array.isArray(attachmentData.relativeMatrix) &&
+    attachmentData.relativeMatrix.length === 16 &&
+    attachmentData.relativeMatrix.every(
+      (value) => typeof value === "number" && !Number.isNaN(value),
+    );
+
+  if (hasValidMatrix) {
+    const equipmentWrapper = modelRoot.children.find(
+      (child) => child.name === "EquipmentWrapper",
+    );
+
+    if (equipmentWrapper) {
+      visuals[slotKey] = modelRoot;
+      targetBone.add(modelRoot);
+      return true;
+    }
+
+    const relativeMatrix = new THREE.Matrix4();
+    relativeMatrix.fromArray(attachmentData!.relativeMatrix!);
+
+    const wrapperGroup = new THREE.Group();
+    wrapperGroup.name = "EquipmentWrapper";
+
+    const position = new THREE.Vector3();
+    const quaternion = new THREE.Quaternion();
+    const scale = new THREE.Vector3();
+    relativeMatrix.decompose(position, quaternion, scale);
+
+    wrapperGroup.position.copy(position);
+    wrapperGroup.quaternion.copy(quaternion);
+    wrapperGroup.scale.copy(scale);
+    wrapperGroup.add(modelRoot);
+
+    visuals[slotKey] = wrapperGroup;
+    targetBone.add(wrapperGroup);
+    return true;
+  }
+
+  const equipmentWrapper = modelRoot.children.find(
+    (child) => child.name === "EquipmentWrapper",
+  );
+
+  if (equipmentWrapper) {
+    const weaponScaleMultiplier = 1.75;
+    modelRoot.scale.multiplyScalar(weaponScaleMultiplier);
+  } else if (!attachmentData) {
+    modelRoot.scale.set(0.01, 0.01, 0.01);
+  }
+
+  visuals[slotKey] = modelRoot;
+  targetBone.add(modelRoot);
+  return true;
+}

--- a/packages/shared/src/systems/client/EquipmentVisualSystem.ts
+++ b/packages/shared/src/systems/client/EquipmentVisualSystem.ts
@@ -24,10 +24,16 @@ import * as THREE from "three";
 import { EventType } from "../../types/events";
 import { SystemBase } from "../shared/infrastructure/SystemBase";
 import type { World } from "../../types";
-import type { VRM, VRMHumanBoneName } from "@pixiv/three-vrm";
-import { getItem } from "../../data/items";
+import type { VRM } from "@pixiv/three-vrm";
 import { EQUIPMENT_SLOT_NAMES } from "../../constants/EquipmentConstants";
 import type { Entity } from "../../entities/Entity";
+import {
+  attachEquipmentVisualToVRM,
+  removeEquipmentVisual,
+  resolveEquipmentVisualData,
+  resolveEquipmentVisualUrls,
+  type EquipmentVisualStore,
+} from "./EquipmentVisualHelpers";
 
 interface AvatarLike {
   instance?: {
@@ -50,19 +56,6 @@ interface PlayerWithAvatar extends Entity {
 /** Resolve avatar from either PlayerLocal (_avatar) or PlayerRemote (avatar) */
 function getAvatar(player: PlayerWithAvatar): AvatarLike | undefined {
   return player._avatar || player.avatar;
-}
-
-interface EquipmentAttachmentData {
-  vrmBoneName: string; // VRM bone to attach to (e.g., "rightHand")
-  originalSlot?: string; // Original Asset Forge slot
-  weaponType?: string; // Weapon type for debugging
-  usage?: string; // Usage instructions
-  note?: string; // Developer notes
-  // V2 format fields
-  version?: number; // Format version (2 = relative matrix approach)
-  relativeMatrix?: number[]; // 16-element matrix array (for v2)
-  avatarId?: string; // Avatar used for fitting (for v2)
-  avatarHeight?: number; // Avatar height used for fitting
 }
 
 interface PlayerEquipmentVisuals {
@@ -279,13 +272,7 @@ export class EquipmentVisualSystem extends SystemBase {
   ): void {
     // Remove existing visual for this slot
     const slotKey = slot.toLowerCase() as keyof PlayerEquipmentVisuals;
-    const existingVisual = equipment[slotKey];
-
-    if (existingVisual && existingVisual.parent) {
-      existingVisual.parent.remove(existingVisual);
-    }
-
-    equipment[slotKey] = undefined;
+    removeEquipmentVisual(equipment as EquipmentVisualStore, slotKey);
   }
 
   /**
@@ -320,108 +307,21 @@ export class EquipmentVisualSystem extends SystemBase {
     try {
       const assetsUrl = this.world.assetsUrl?.replace(/\/$/, "") || "";
 
-      // Look up item data from manifest for equippedModelPath.
-      // Primary: client-side ITEMS map.  Fallback: cached item data from the
-      // server's equipmentUpdated broadcast (handles race where manifest hasn't
-      // loaded yet or a new item ID isn't in the client build).
-      const itemData = getItem(itemId);
-      let equippedModelPath = itemData?.equippedModelPath;
-      let modelPath = itemData?.modelPath;
+      const cachedItem = this.getItemFromNetworkCache(playerId, slot);
+      const itemData = resolveEquipmentVisualData({
+        itemId,
+        fallbackItemData: cachedItem,
+      });
+      const urls = resolveEquipmentVisualUrls({
+        assetsUrl,
+        itemId,
+        slot,
+        itemData,
+        fallbackItemData: cachedItem,
+      });
 
-      // If equippedModelPath is explicitly null (not undefined), the item has no 3D model yet.
-      // Skip visual to avoid convention-based URL fallback producing 404 errors.
-      if (equippedModelPath === null) {
+      if (!urls) {
         return;
-      }
-
-      if (!equippedModelPath) {
-        const cachedItem = this.getItemFromNetworkCache(playerId, slot);
-        if (cachedItem?.equippedModelPath) {
-          equippedModelPath = cachedItem.equippedModelPath;
-        }
-        if (!modelPath && cachedItem?.modelPath) {
-          modelPath = cachedItem.modelPath;
-        }
-      }
-      let weaponUrl: string;
-      let fallbackUrl: string | null = null;
-
-      if (equippedModelPath) {
-        // Use explicit equippedModelPath from items.json
-        // Convert "asset://models/..." to full CDN URL
-        weaponUrl = equippedModelPath.replace("asset://", `${assetsUrl}/`);
-        console.log(
-          `[EquipmentVisual] ${itemId} → explicit path: ${weaponUrl}`,
-        );
-      } else if (modelPath && typeof modelPath === "string") {
-        // Use modelPath as equipped model (handles items like arrows where convention
-        // produces wrong directory name: arrow-bronze vs arrows-bronze)
-        weaponUrl = modelPath.replace("asset://", `${assetsUrl}/`);
-        console.log(
-          `[EquipmentVisual] ${itemId} → modelPath fallback: ${weaponUrl}`,
-        );
-      } else {
-        console.warn(
-          `[EquipmentVisual] ${itemId} → no manifest data (getItem returned ${itemData ? "partial" : "null"}), using convention`,
-        );
-        // Fallback to convention-based derivation
-        // itemId formats:
-        //   "{material}_{item}" e.g., "bronze_sword" → "sword-bronze"
-        //   "{material}_{item1}_{item2}" e.g., "bronze_2h_sword" → "2h-sword-bronze"
-        const parts = itemId.split("_");
-        let assetId = itemId.replace(/_/g, "-");
-        let category = "";
-
-        const materials = [
-          "bronze",
-          "steel",
-          "mithril",
-          "iron",
-          "rune",
-          "dragon",
-          "wood",
-          "oak",
-          "willow",
-          "yew",
-        ];
-
-        // Map item types to their category subdirectories
-        const categoryMap: Record<string, string> = {
-          sword: "swords-old",
-          longsword: "swords/long-swords",
-          scimitar: "swords/scimitars",
-          "2h_sword": "swords/2h-swords",
-          "2h": "swords/2h-swords",
-          shortsword: "swords/shortswords",
-          dagger: "swords/daggers",
-          hatchet: "hatchets",
-          pickaxe: "pickaxes",
-          arrow: "arrows",
-          bow: "bows",
-          staff: "magic-staffs",
-          shield: "shields",
-        };
-
-        if (parts.length >= 2 && materials.includes(parts[0])) {
-          const material = parts[0];
-          const itemParts = parts.slice(1); // e.g., ["2h", "sword"] or ["longsword"]
-          const itemKey = itemParts.join("_"); // e.g., "2h_sword" or "longsword"
-          assetId = `${itemParts.join("-")}-${material}`; // e.g., "2h-sword-bronze"
-          category = categoryMap[itemKey] || categoryMap[itemParts[0]] || "";
-        }
-
-        // If no matching category was found, this item type has no 3D models
-        // available (e.g., helms, platelegs, boots, gloves, capes).
-        // Skip visual to avoid generating 404 requests.
-        if (!category) {
-          return;
-        }
-
-        // Try fitted version: flat layout first (swords/long-swords/longsword-bronze-aligned.glb),
-        // then subdirectory layout (hatchets/hatchet-bronze/hatchet-bronze-aligned.glb)
-        const prefix = category ? `${category}/` : "";
-        weaponUrl = `${assetsUrl}/models/${prefix}${assetId}-aligned.glb`;
-        fallbackUrl = `${assetsUrl}/models/${prefix}${assetId}/${assetId}-aligned.glb`;
       }
 
       // Check cache first
@@ -433,11 +333,11 @@ export class EquipmentVisualSystem extends SystemBase {
         const loader = this.world.loader;
         let file: File | undefined;
         try {
-          file = loader ? await loader.loadFile(weaponUrl) : undefined;
+          file = loader ? await loader.loadFile(urls.primaryUrl) : undefined;
         } catch (error) {
           // Fallback to base model if fitted version not found (only for convention-based)
-          if (fallbackUrl) {
-            file = loader ? await loader.loadFile(fallbackUrl) : undefined;
+          if (urls.fallbackUrl) {
+            file = loader ? await loader.loadFile(urls.fallbackUrl) : undefined;
           } else {
             throw error;
           }
@@ -445,93 +345,20 @@ export class EquipmentVisualSystem extends SystemBase {
 
         if (!file) {
           throw new Error(
-            `[EquipmentVisual] Failed to load model: ${weaponUrl}`,
+            `[EquipmentVisual] Failed to load model: ${urls.primaryUrl}`,
           );
         }
 
         // Parse the cached bytes with GLTFLoader
         const buffer = await file.arrayBuffer();
-        gltf = (await this.gltfParser.parseAsync(buffer, weaponUrl)) as GLTF;
+        gltf = (await this.gltfParser.parseAsync(
+          buffer,
+          urls.primaryUrl,
+        )) as GLTF;
         this.weaponCache.set(itemId, gltf);
       }
 
       const weaponMesh: THREE.Object3D = gltf.scene.clone(true); // Clone to allow multiple instances
-
-      // Read attachment metadata from Asset Forge export
-      // Try root first, then first child (EquipmentWrapper)
-      let attachmentData = weaponMesh.userData.hyperscape as
-        | EquipmentAttachmentData
-        | undefined;
-
-      // If not on root, check first child (the EquipmentWrapper)
-      if (!attachmentData && weaponMesh.children[0]?.userData?.hyperscape) {
-        attachmentData = weaponMesh.children[0].userData
-          .hyperscape as EquipmentAttachmentData;
-      }
-
-      const boneName = attachmentData?.vrmBoneName || "rightHand";
-
-      // POSELAB TECH: Check if this is a skinned armor piece (Body, Legs, Boots, Gloves)
-      const skinnedSlots = ["body", "legs", "boots", "gloves", "cape"];
-      const isSkinnedSlot = skinnedSlots.includes(slot.toLowerCase());
-
-      let hasSkinnedMesh = false;
-      if (isSkinnedSlot) {
-        weaponMesh.traverse((child) => {
-          if (child instanceof THREE.SkinnedMesh) {
-            hasSkinnedMesh = true;
-          }
-        });
-      }
-
-      if (isSkinnedSlot && hasSkinnedMesh) {
-        // Find player skeleton
-        let playerSkeleton: THREE.Skeleton | undefined;
-        vrm.scene.traverse((child) => {
-          if (child instanceof THREE.SkinnedMesh && child.skeleton) {
-            playerSkeleton = child.skeleton;
-          }
-        });
-
-        if (playerSkeleton) {
-          const skeleton = playerSkeleton;
-          // Bind all skinned meshes in equipment to player skeleton
-          weaponMesh.traverse((child) => {
-            if (child instanceof THREE.SkinnedMesh) {
-              child.skeleton = skeleton;
-              child.bind(skeleton, child.bindMatrix);
-            }
-          });
-
-          // Remove existing visual
-          this.unequipVisual(playerId, slot, equipment, vrm);
-
-          // Add directly to VRM scene for skinned animation
-          const slotKey = slot.toLowerCase() as keyof PlayerEquipmentVisuals;
-          equipment[slotKey] = weaponMesh;
-          vrm.scene.add(weaponMesh);
-          return;
-        }
-      }
-
-      // Get VRM bone (cast to VRMHumanBoneName for type safety)
-      if (!vrm.humanoid) {
-        console.error(
-          `[EquipmentVisual] ❌ VRM has no humanoid property for ${itemId}`,
-        );
-        return;
-      }
-
-      const bone = vrm.humanoid.getNormalizedBoneNode(
-        boneName as VRMHumanBoneName,
-      );
-      if (!bone) {
-        console.error(`[EquipmentVisual] ❌ VRM bone not found: ${boneName}`);
-        return;
-      }
-
-      // Remove existing visual for this slot first
-      this.unequipVisual(playerId, slot, equipment, vrm);
 
       // Get player entity for bone attachment
       const player = this.world.entities.get(playerId);
@@ -542,126 +369,32 @@ export class EquipmentVisualSystem extends SystemBase {
         return;
       }
 
-      // Find the target bone in the player's live hierarchy
-      const prefabBone = vrm.humanoid.getRawBoneNode(
-        boneName as VRMHumanBoneName,
-      );
-      if (!prefabBone) {
-        console.error(
-          `[EquipmentVisual] ❌ VRM bone not found in prefab: ${boneName}`,
-        );
-        return;
-      }
-
-      const targetBoneName = prefabBone.name;
-      let targetBone: THREE.Object3D | undefined = undefined;
-
-      // Traverse the avatar's visual root (instance.raw) to find the bone
       const playerWithAvatar = player as PlayerWithAvatar;
       const rawInstance = getAvatar(playerWithAvatar)?.instance?.raw;
       const avatarRoot = (rawInstance?.scene || rawInstance) as
         | THREE.Object3D
         | undefined;
 
-      if (avatarRoot && avatarRoot.traverse) {
-        avatarRoot.traverse((child) => {
-          if (child.name === targetBoneName) {
-            targetBone = child;
-          }
-        });
-      } else {
-        if (player.node) {
-          player.node.traverse((child) => {
-            if (child.name === targetBoneName) {
-              targetBone = child;
-            }
-          });
-        }
-      }
-
-      if (!targetBone) {
+      if (!avatarRoot) {
         console.error(
-          `[EquipmentVisual] ❌ Could not find bone '${targetBoneName}' in avatar hierarchy`,
+          `[EquipmentVisual] ❌ Could not resolve avatar root for ${playerId}`,
         );
         return;
       }
 
-      // Store in component for tracking
-      const slotKey = slot.toLowerCase() as keyof PlayerEquipmentVisuals;
+      const attached = attachEquipmentVisualToVRM({
+        slot,
+        modelRoot: weaponMesh,
+        visuals: equipment as EquipmentVisualStore,
+        vrm,
+        avatarRoot,
+      });
 
-      // === V2 FORMAT: Use relative matrix directly ===
-      // Validate relativeMatrix is a proper 16-element array of numbers
-      const hasValidMatrix =
-        attachmentData?.version === 2 &&
-        Array.isArray(attachmentData.relativeMatrix) &&
-        attachmentData.relativeMatrix.length === 16 &&
-        attachmentData.relativeMatrix.every(
-          (n) => typeof n === "number" && !isNaN(n),
+      if (!attached) {
+        console.error(
+          `[EquipmentVisual] ❌ Failed to attach ${itemId} to slot ${slot}`,
         );
-
-      if (hasValidMatrix) {
-        // Find the EquipmentWrapper which has the pre-baked transforms
-        const equipmentWrapper = weaponMesh.children.find(
-          (child) => child.name === "EquipmentWrapper",
-        );
-
-        if (equipmentWrapper) {
-          // V2: The wrapper already has the correct relative transform baked in
-          // Just attach it directly - no scale hacks needed!
-          equipment[slotKey] = weaponMesh;
-          (targetBone as THREE.Object3D).add(weaponMesh);
-        } else {
-          // Fallback: Apply relativeMatrix manually if no wrapper found
-          const relativeMatrix = new THREE.Matrix4();
-          // Safe to assert: hasValidMatrix guarantees attachmentData.relativeMatrix is valid
-          relativeMatrix.fromArray(attachmentData!.relativeMatrix!);
-
-          // Create a wrapper group with the relative transform
-          const wrapperGroup = new THREE.Group();
-          wrapperGroup.name = "EquipmentWrapper";
-
-          // Decompose and apply the matrix
-          const position = new THREE.Vector3();
-          const quaternion = new THREE.Quaternion();
-          const scale = new THREE.Vector3();
-          relativeMatrix.decompose(position, quaternion, scale);
-
-          wrapperGroup.position.copy(position);
-          wrapperGroup.quaternion.copy(quaternion);
-          wrapperGroup.scale.copy(scale);
-
-          // Add weapon as child
-          wrapperGroup.add(weaponMesh);
-
-          equipment[slotKey] = wrapperGroup;
-          (targetBone as THREE.Object3D).add(wrapperGroup);
-        }
-        return;
       }
-
-      // === LEGACY FORMAT (V1): Use old logic with scale hack ===
-
-      // Find the EquipmentWrapper child which has the fitting position
-      const equipmentWrapper = weaponMesh.children.find(
-        (child) => child.name === "EquipmentWrapper",
-      );
-
-      if (equipmentWrapper) {
-        // LEGACY: Apply scale multiplier hack for V1 exports
-        const WEAPON_SCALE_MULTIPLIER = 1.75;
-        weaponMesh.scale.multiplyScalar(WEAPON_SCALE_MULTIPLIER);
-      } else if (!attachmentData) {
-        console.warn(
-          `[EquipmentVisual] ⚠️ No EquipmentWrapper or metadata - applying default transform`,
-        );
-        // Fallback: Scale down to reasonable size
-        weaponMesh.scale.set(0.01, 0.01, 0.01);
-      }
-
-      equipment[slotKey] = weaponMesh;
-
-      // Add to the LIVE bone
-      (targetBone as THREE.Object3D).add(weaponMesh);
     } catch (error) {
       console.error(`[EquipmentVisual] ❌ Error equipping ${itemId}:`, error);
     }

--- a/packages/shared/src/systems/client/TileInterpolator.ts
+++ b/packages/shared/src/systems/client/TileInterpolator.ts
@@ -1554,12 +1554,12 @@ export class TileInterpolator {
    * face their combat target while moving (OSRS PvP behavior).
    *
    * @param entityId - Entity to update
-   * @param quaternion - Combat rotation from server [x, y, z, w]
+   * @param quaternion - Combat rotation as [x, y, z, w] array or THREE.Quaternion
    * @returns true if rotation was applied, false if entity has no state
    */
   setCombatRotation(
     entityId: string,
-    quaternion: number[],
+    quaternion: number[] | THREE.Quaternion,
     entityPosition?: { x: number; y: number; z: number },
   ): boolean {
     let state = this.entityStates.get(entityId);
@@ -1615,18 +1615,24 @@ export class TileInterpolator {
     state.inCombatRotation = true;
 
     // Apply combat rotation to state - TileInterpolator.update() will apply to entity.base
-    state.quaternion.set(
-      quaternion[0],
-      quaternion[1],
-      quaternion[2],
-      quaternion[3],
-    );
-    state.targetQuaternion.set(
-      quaternion[0],
-      quaternion[1],
-      quaternion[2],
-      quaternion[3],
-    );
+    // Support both number[] (from server packets) and THREE.Quaternion (from local player)
+    if (Array.isArray(quaternion)) {
+      state.quaternion.set(
+        quaternion[0],
+        quaternion[1],
+        quaternion[2],
+        quaternion[3],
+      );
+      state.targetQuaternion.set(
+        quaternion[0],
+        quaternion[1],
+        quaternion[2],
+        quaternion[3],
+      );
+    } else {
+      state.quaternion.copy(quaternion);
+      state.targetQuaternion.copy(quaternion);
+    }
 
     return true; // Rotation accepted
   }


### PR DESCRIPTION
## Summary

- **Combat panel redesign** — Replace vertical combat style list with horizontal heraldic shield banners (SVG shields, protruding icons, theme gradients, style-colored tints). Add optimistic state updates so combat style changes and auto-retaliate respond instantly.
- **Unified panel layout constants** — Extract shared `PANEL_*` dimensions into `panelLayout.ts` so Inventory, Prayer, Skills, Spells, and Equipment panels all use consistent spacing on desktop and mobile.
- **SpellsPanel added to default layout** — Include Spells tab alongside Prayer in the right-column window (schema v17 migration).
- **Tab persistence fix** — Render all window tabs simultaneously with `display:none/flex` toggling instead of unmounting, preserving scroll position and state across tab switches.
- **Equipment panel refinements** — Adjust slot sizes, grid gaps, tooltip positioning, and portrait scaling for compact/mobile viewports.
- **CursorTooltip component** — New reusable portal-based mouse-following tooltip with auto-measurement and viewport-edge flipping.
- **Tighter tab chrome** — Reduce tab minHeight/padding for a more compact window bar.

## Test plan

- [ ] Verify combat style banners render correctly on desktop (4 shields in a row with text labels)
- [ ] Verify clicking a combat style changes the active style immediately (optimistic update)
- [ ] Verify auto-retaliate toggle responds on click
- [ ] Verify mobile layout shows compact banners
- [ ] Verify switching between tabs (e.g. Prayer ↔ Spells) preserves scroll state
- [ ] Verify equipment panel renders correctly on mobile with adjusted slot sizes
- [ ] Verify Prayer, Skills, Spells panels use consistent spacing