### PR TITLE
Fix prayer login sync

### DIFF
--- a/packages/client/src/hooks/usePlayerData.ts
+++ b/packages/client/src/hooks/usePlayerData.ts
@@ -53,6 +53,10 @@ function cloneInventoryItems(
   return items.map((item) => ({ ...item }));
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 function areEquipmentItemsEqual(
   left: PlayerEquipmentItems | null,
   right: PlayerEquipmentItems | null,
@@ -423,26 +427,15 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
       }
     };
 
-    // Register event listeners
-    world.on(EventType.UI_UPDATE, handleUIUpdate, undefined);
-    world.on(EventType.INVENTORY_UPDATED, handleInventory, undefined);
-    world.on(EventType.INVENTORY_UPDATE_COINS, handleCoins, undefined);
-    world.on(EventType.UI_EQUIPMENT_UPDATE, handleEquipment, undefined);
-    world.on(EventType.STATS_UPDATE, handleStats, undefined);
-    world.on(EventType.SKILLS_UPDATED, handleSkillsUpdate, undefined);
-    world.on(EventType.PRAYER_STATE_SYNC, handlePrayerStateSync, undefined);
-    world.on(
-      EventType.PRAYER_POINTS_CHANGED,
-      handlePrayerPointsChanged,
-      undefined,
-    );
-
-    // Request initial data from cache - uses extracted playerId from deps
+    // Request initial data from cache and live entity state.
     const requestInitial = () => {
-      if (!playerId) return false;
+      const resolvedPlayerId =
+        world.entities?.player?.id ?? world.getPlayer?.()?.id ?? playerId;
+      if (!resolvedPlayerId) return false;
 
       // Get cached inventory
-      const cachedInv = world.network?.lastInventoryByPlayerId?.[playerId];
+      const cachedInv =
+        world.network?.lastInventoryByPlayerId?.[resolvedPlayerId];
       if (cachedInv && Array.isArray(cachedInv.items)) {
         const cachedItems = cachedInv.items as InventorySlotViewItem[];
         setInventory((prev) =>
@@ -459,7 +452,8 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
       // Note: lastSkillsByPlayerId is typed as Record<string, { level: number; xp: number }>
       // but at runtime contains Skills data. The intermediate unknown is required because
       // TypeScript sees them as incompatible even though they're structurally similar.
-      const cachedSkills = world.network?.lastSkillsByPlayerId?.[playerId];
+      const cachedSkills =
+        world.network?.lastSkillsByPlayerId?.[resolvedPlayerId];
       if (cachedSkills) {
         // Runtime: cachedSkills has skill-specific keys (attack, strength, etc.)
         const skills = cachedSkills as unknown as PlayerStats["skills"];
@@ -473,7 +467,7 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
 
       // Get cached equipment
       const cachedEquipment =
-        world.network?.lastEquipmentByPlayerId?.[playerId];
+        world.network?.lastEquipmentByPlayerId?.[resolvedPlayerId];
       if (cachedEquipment) {
         const nextEquipment = processRawEquipment(
           cachedEquipment as RawEquipmentData,
@@ -484,7 +478,8 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
       }
 
       // Get cached prayer state
-      const cachedPrayer = world.network?.lastPrayerStateByPlayerId?.[playerId];
+      const cachedPrayer =
+        world.network?.lastPrayerStateByPlayerId?.[resolvedPlayerId];
       if (cachedPrayer) {
         setPlayerStats((prev) => {
           const merged = prev
@@ -504,7 +499,7 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
         });
       }
 
-      // Get player entity for health/prayer
+      // Get player entity for health and explicit prayer fallback.
       // Entity has health/data properties at runtime that aren't fully exposed in the base type.
       // The intermediate unknown is required because Entity.maxHealth is protected.
       const playerEntity = world.entities?.player;
@@ -522,16 +517,32 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
         const entityData = playerEntity as unknown as PlayerEntityData;
 
         const health = entityData.health ?? entityData.data?.health;
-        const maxHealth =
-          entityData.maxHealth ?? entityData.data?.maxHealth ?? 10;
-        const prayerPoints = entityData.data?.prayerPoints ?? 0;
-        const maxPrayerPoints = entityData.data?.maxPrayerPoints ?? 1;
+        const maxHealth = isFiniteNumber(entityData.maxHealth)
+          ? entityData.maxHealth
+          : isFiniteNumber(entityData.data?.maxHealth)
+            ? entityData.data.maxHealth
+            : 10;
+        const prayerPoints = entityData.data?.prayerPoints;
+        const maxPrayerPoints = entityData.data?.maxPrayerPoints;
+        const hasExplicitPrayerPoints =
+          isFiniteNumber(prayerPoints) && isFiniteNumber(maxPrayerPoints);
 
-        if (typeof health === "number") {
+        if (isFiniteNumber(health) || hasExplicitPrayerPoints) {
           setPlayerStats((prev) => {
             const merged = mergePlayerStats(prev, {
-              health: { current: health, max: maxHealth },
-              prayerPoints: { current: prayerPoints, max: maxPrayerPoints },
+              ...(isFiniteNumber(health)
+                ? {
+                    health: { current: health, max: maxHealth },
+                  }
+                : {}),
+              ...(hasExplicitPrayerPoints
+                ? {
+                    prayerPoints: {
+                      current: prayerPoints,
+                      max: maxPrayerPoints,
+                    },
+                  }
+                : {}),
             });
             return arePlayerStatsEqual(prev, merged) ? prev : merged;
           });
@@ -539,9 +550,48 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
       }
 
       // Request fresh data from server
-      world.emit(EventType.INVENTORY_REQUEST, { playerId });
+      world.emit(EventType.INVENTORY_REQUEST, {
+        playerId: resolvedPlayerId,
+      });
       return true;
     };
+
+    const handlePlayerSpawned = (event: unknown) => {
+      const spawnedPlayerId =
+        typeof event === "object" &&
+        event !== null &&
+        "playerId" in event &&
+        typeof (event as { playerId?: unknown }).playerId === "string"
+          ? (event as { playerId: string }).playerId
+          : null;
+
+      const localPlayerId =
+        world.entities?.player?.id ?? world.getPlayer?.()?.id ?? playerId;
+      if (
+        spawnedPlayerId &&
+        localPlayerId &&
+        spawnedPlayerId !== localPlayerId
+      ) {
+        return;
+      }
+
+      requestInitial();
+    };
+
+    // Register event listeners
+    world.on(EventType.UI_UPDATE, handleUIUpdate, undefined);
+    world.on(EventType.INVENTORY_UPDATED, handleInventory, undefined);
+    world.on(EventType.INVENTORY_UPDATE_COINS, handleCoins, undefined);
+    world.on(EventType.UI_EQUIPMENT_UPDATE, handleEquipment, undefined);
+    world.on(EventType.STATS_UPDATE, handleStats, undefined);
+    world.on(EventType.SKILLS_UPDATED, handleSkillsUpdate, undefined);
+    world.on(EventType.PRAYER_STATE_SYNC, handlePrayerStateSync, undefined);
+    world.on(
+      EventType.PRAYER_POINTS_CHANGED,
+      handlePrayerPointsChanged,
+      undefined,
+    );
+    world.on(EventType.PLAYER_SPAWNED, handlePlayerSpawned, undefined);
 
     // Try to get initial data immediately, or retry after a short delay
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -586,6 +636,12 @@ export function usePlayerDataState(world: ClientWorld | null): PlayerDataState {
       world.off(
         EventType.PRAYER_POINTS_CHANGED,
         handlePrayerPointsChanged,
+        undefined,
+        undefined,
+      );
+      world.off(
+        EventType.PLAYER_SPAWNED,
+        handlePlayerSpawned,
         undefined,
         undefined,
       );

--- a/packages/client/tests/e2e/prayer-sync.spec.ts
+++ b/packages/client/tests/e2e/prayer-sync.spec.ts
@@ -1,0 +1,118 @@
+import { expect } from "@playwright/test";
+import { evmTest } from "./fixtures/wallet-fixtures";
+import {
+  completeFullLoginFlow,
+  selectFirstCharacter,
+  waitForAppReady,
+  waitForCharacterSelect,
+  waitForGameClient,
+} from "./fixtures/privy-helpers";
+import { BASE_URL } from "./fixtures/test-config";
+import { openPanel, waitForPlayerSpawn } from "./utils/testWorld";
+
+const test = evmTest;
+
+test.describe("Prayer login sync", () => {
+  test.setTimeout(6 * 60 * 1000);
+
+  test("restores active prayer state after reload without needing a prayer toggle", async ({
+    page,
+    wallet,
+  }) => {
+    await waitForAppReady(page, BASE_URL);
+    expect(await completeFullLoginFlow(page, wallet)).toBe(true);
+    await waitForPlayerSpawn(page, 30_000);
+
+    await openPanel(page, "prayer");
+    const prayerPanel = page.locator('[data-panel="prayer"]');
+    const thickSkinButton = prayerPanel.getByRole("button", {
+      name: /Thick Skin/i,
+    });
+    await thickSkinButton.click();
+    await expect(thickSkinButton).toHaveAttribute("aria-pressed", "true");
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    const backInGameDirectly = await waitForGameClient(page, 10_000);
+    if (!backInGameDirectly) {
+      expect(await waitForCharacterSelect(page, 20_000)).toBe(true);
+      await selectFirstCharacter(page);
+      expect(await completeFullLoginFlow(page, wallet)).toBe(true);
+    }
+
+    await waitForPlayerSpawn(page, 30_000);
+
+    const prayerCacheState = await page.waitForFunction(() => {
+      const win = window as unknown as {
+        world?: {
+          entities?: {
+            player?: {
+              id?: string;
+            };
+          };
+          network?: {
+            id?: string | null;
+            lastPrayerStateByPlayerId?: Record<
+              string,
+              {
+                points: number;
+                maxPoints: number;
+                active: string[];
+              }
+            >;
+          };
+        };
+      };
+
+      const playerId =
+        win.world?.entities?.player?.id ?? win.world?.network?.id ?? null;
+      if (!playerId) {
+        return null;
+      }
+
+      const prayerState =
+        win.world?.network?.lastPrayerStateByPlayerId?.[playerId] ?? null;
+      if (
+        !prayerState ||
+        !Array.isArray(prayerState.active) ||
+        !prayerState.active.includes("thick_skin")
+      ) {
+        return null;
+      }
+
+      return {
+        points: prayerState.points,
+        maxPoints: prayerState.maxPoints,
+        active: prayerState.active,
+      };
+    });
+
+    const prayerState = (await prayerCacheState.jsonValue()) as {
+      points: number;
+      maxPoints: number;
+      active: string[];
+    } | null;
+
+    expect(prayerState).not.toBeNull();
+    if (!prayerState) {
+      throw new Error("Prayer state cache was unavailable after reconnect");
+    }
+
+    expect(prayerState.active).toContain("thick_skin");
+    expect(prayerState.points).toBeGreaterThanOrEqual(0);
+    expect(prayerState.maxPoints).toBeGreaterThan(0);
+
+    await openPanel(page, "prayer");
+    await expect(
+      prayerPanel.getByRole("button", { name: /Thick Skin/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      prayerPanel.getByText(
+        `${prayerState.points} / ${prayerState.maxPoints}`,
+        {
+          exact: false,
+        },
+      ),
+    ).toBeVisible();
+  });
+});

--- a/packages/client/tests/unit/hooks/usePlayerData.test.ts
+++ b/packages/client/tests/unit/hooks/usePlayerData.test.ts
@@ -1,0 +1,172 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EventType } from "@hyperscape/shared";
+import { usePlayerDataState } from "../../../src/hooks/usePlayerData";
+import {
+  asClientWorld,
+  createEventTracker,
+  createMockWorld,
+} from "../../mocks/MockWorld";
+
+describe("usePlayerDataState", () => {
+  it("preserves cached prayer state when the entity only has health data", async () => {
+    const eventTracker = createEventTracker();
+    const world = createMockWorld({
+      on: eventTracker.on,
+      off: eventTracker.off,
+      entities: {
+        player: {
+          id: "player-1",
+          health: 8,
+          maxHealth: 10,
+          data: {
+            health: 8,
+            maxHealth: 10,
+          },
+        } as never,
+      },
+    });
+    world.network.lastPrayerStateByPlayerId = {
+      "player-1": {
+        points: 37,
+        maxPoints: 50,
+        active: ["thick_skin"],
+      },
+    };
+
+    const { result } = renderHook(() =>
+      usePlayerDataState(asClientWorld(world)),
+    );
+
+    await waitFor(() => {
+      expect(result.current.playerStats?.health).toEqual({
+        current: 8,
+        max: 10,
+      });
+      expect(result.current.playerStats?.prayerPoints).toEqual({
+        current: 37,
+        max: 50,
+      });
+    });
+
+    expect(world.emit).toHaveBeenCalledWith(EventType.INVENTORY_REQUEST, {
+      playerId: "player-1",
+    });
+  });
+
+  it("hydrates prayer state when the local player becomes available via PLAYER_SPAWNED", async () => {
+    const eventTracker = createEventTracker();
+    const world = createMockWorld({
+      on: eventTracker.on,
+      off: eventTracker.off,
+      getPlayer: vi.fn(() => null),
+      entities: {
+        player: null,
+      },
+    });
+    world.network.lastPrayerStateByPlayerId = {
+      "spawned-player": {
+        points: 12,
+        maxPoints: 18,
+        active: ["thick_skin"],
+      },
+    };
+
+    const { result } = renderHook(() =>
+      usePlayerDataState(asClientWorld(world)),
+    );
+
+    expect(result.current.playerStats).toBeNull();
+
+    act(() => {
+      world.entities.player = {
+        id: "spawned-player",
+        health: 9,
+        maxHealth: 10,
+        data: {
+          health: 9,
+          maxHealth: 10,
+        },
+      } as never;
+      world.getPlayer.mockReturnValue({ id: "spawned-player" });
+      eventTracker.trigger(EventType.PLAYER_SPAWNED, {
+        playerId: "spawned-player",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.playerStats?.prayerPoints).toEqual({
+        current: 12,
+        max: 18,
+      });
+      expect(result.current.playerStats?.health).toEqual({
+        current: 9,
+        max: 10,
+      });
+    });
+  });
+
+  it("only seeds entity prayer points when both values are finite", async () => {
+    const missingMaxEventTracker = createEventTracker();
+    const missingMaxWorld = createMockWorld({
+      on: missingMaxEventTracker.on,
+      off: missingMaxEventTracker.off,
+      entities: {
+        player: {
+          id: "player-2",
+          health: 6,
+          maxHealth: 10,
+          data: {
+            health: 6,
+            maxHealth: 10,
+            prayerPoints: 14,
+          },
+        } as never,
+      },
+    });
+
+    const { result: missingMaxResult, unmount } = renderHook(() =>
+      usePlayerDataState(asClientWorld(missingMaxWorld)),
+    );
+
+    await waitFor(() => {
+      expect(missingMaxResult.current.playerStats?.health).toEqual({
+        current: 6,
+        max: 10,
+      });
+    });
+    expect(missingMaxResult.current.playerStats?.prayerPoints).toBeUndefined();
+
+    unmount();
+
+    const finiteEventTracker = createEventTracker();
+    const finiteWorld = createMockWorld({
+      on: finiteEventTracker.on,
+      off: finiteEventTracker.off,
+      entities: {
+        player: {
+          id: "player-3",
+          health: 7,
+          maxHealth: 10,
+          data: {
+            health: 7,
+            maxHealth: 10,
+            prayerPoints: 14,
+            maxPrayerPoints: 20,
+          },
+        } as never,
+      },
+    });
+
+    const { result: finiteResult } = renderHook(() =>
+      usePlayerDataState(asClientWorld(finiteWorld)),
+    );
+
+    await waitFor(() => {
+      expect(finiteResult.current.playerStats?.prayerPoints).toEqual({
+        current: 14,
+        max: 20,
+      });
+    });
+  });
+});

--- a/packages/shared/src/systems/shared/character/PrayerSystem.ts
+++ b/packages/shared/src/systems/shared/character/PrayerSystem.ts
@@ -32,6 +32,7 @@ import {
   prayerDataProvider,
   type PrayerDefinition,
 } from "../../../data/PrayerDataProvider";
+import type { PlayerJoinedPayload } from "../../../types/events";
 import {
   type PrayerState,
   isValidPrayerId,
@@ -270,6 +271,33 @@ export class PrayerSystem extends SystemBase {
   };
 
   /**
+   * Handler for PLAYER_JOINED events.
+   * Re-emits the authoritative prayer snapshot for the new session after join.
+   */
+  private readonly onPlayerJoined = async (event: unknown): Promise<void> => {
+    if (!this.world.isServer) {
+      return;
+    }
+
+    const payload = event as Partial<PlayerJoinedPayload>;
+    if (!payload.playerId || typeof payload.playerId !== "string") {
+      Logger.systemError(
+        "PrayerSystem",
+        "Invalid PLAYER_JOINED payload",
+        new Error(`Invalid payload: ${JSON.stringify(event)}`),
+      );
+      return;
+    }
+
+    const state = await this.ensurePlayerPrayerInitialized(payload.playerId);
+    if (!state) {
+      return;
+    }
+
+    this.emitPrayerStateSync(payload.playerId, state);
+  };
+
+  /**
    * Handler for PRAYER_TOGGLE events
    * Validates payload including prayer ID format before processing.
    */
@@ -379,6 +407,7 @@ export class PrayerSystem extends SystemBase {
     this.world.on(EventType.PLAYER_REGISTERED, this.onPlayerRegistered);
     this.world.on(EventType.PLAYER_CLEANUP, this.onPlayerCleanup);
     this.world.on(EventType.PLAYER_LEFT, this.onPlayerLeft);
+    this.world.on(EventType.PLAYER_JOINED, this.onPlayerJoined);
     this.world.on(EventType.PRAYER_TOGGLE, this.onPrayerToggle);
     this.world.on(EventType.ALTAR_PRAY, this.onAltarPray);
     // Listen for deactivate-all requests (prayerId === "*")
@@ -1340,6 +1369,7 @@ export class PrayerSystem extends SystemBase {
     this.world.off(EventType.PLAYER_REGISTERED, this.onPlayerRegistered);
     this.world.off(EventType.PLAYER_CLEANUP, this.onPlayerCleanup);
     this.world.off(EventType.PLAYER_LEFT, this.onPlayerLeft);
+    this.world.off(EventType.PLAYER_JOINED, this.onPlayerJoined);
     this.world.off(EventType.PRAYER_TOGGLE, this.onPrayerToggle);
     this.world.off(EventType.ALTAR_PRAY, this.onAltarPray);
     this.world.off(EventType.PRAYER_DEACTIVATED, this.onPrayerDeactivated);

--- a/packages/shared/src/systems/shared/character/__tests__/PrayerSystem.sync.test.ts
+++ b/packages/shared/src/systems/shared/character/__tests__/PrayerSystem.sync.test.ts
@@ -1,0 +1,114 @@
+import EventEmitter from "eventemitter3";
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../infrastructure/EventBus";
+import { PrayerSystem } from "../PrayerSystem";
+import { EventType, type PlayerJoinedPayload } from "../../../../types/events";
+import type { World } from "../../../../core/World";
+
+interface MockDatabaseRow {
+  prayerLevel: number;
+  prayerPoints: number;
+  activePrayers: string[];
+}
+
+interface PrayerTestWorld extends EventEmitter<string | symbol, unknown> {
+  isServer: boolean;
+  $eventBus: EventBus;
+  entities: {
+    get: ReturnType<typeof vi.fn>;
+  };
+  getPlayers: ReturnType<typeof vi.fn>;
+  getSystem: ReturnType<typeof vi.fn>;
+}
+
+function createPrayerTestWorld(row: MockDatabaseRow): {
+  world: PrayerTestWorld;
+  emitted: Array<{ event: string; payload: unknown }>;
+  database: {
+    getPlayerAsync: ReturnType<typeof vi.fn>;
+    savePlayer: ReturnType<typeof vi.fn>;
+  };
+} {
+  const emitter = new EventEmitter<string | symbol, unknown>();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const database = {
+    getPlayerAsync: vi.fn(async () => row),
+    savePlayer: vi.fn(),
+  };
+
+  const originalEmit = emitter.emit.bind(emitter);
+  const world = emitter as PrayerTestWorld;
+  world.isServer = true;
+  world.$eventBus = new EventBus();
+  world.entities = {
+    get: vi.fn(() => undefined),
+  };
+  world.getPlayers = vi.fn(() => []);
+  world.getSystem = vi.fn((name: string) =>
+    name === "database" ? database : undefined,
+  );
+  world.emit = ((event: string, payload?: unknown) => {
+    emitted.push({ event, payload });
+    return originalEmit(event, payload);
+  }) as PrayerTestWorld["emit"];
+
+  return { world, emitted, database };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("PrayerSystem authoritative sync", () => {
+  it("loads persisted prayer data on PLAYER_REGISTERED and re-syncs it on PLAYER_JOINED", async () => {
+    const { world, emitted, database } = createPrayerTestWorld({
+      prayerLevel: 7,
+      prayerPoints: 5,
+      activePrayers: ["thick_skin"],
+    });
+    const system = new PrayerSystem(world as unknown as World);
+
+    await system.init();
+
+    world.emit(EventType.PLAYER_REGISTERED, {
+      playerId: "player-1",
+    });
+    await flushAsyncWork();
+
+    const prayerSyncEventsAfterRegister = emitted.filter(
+      ({ event }) => event === EventType.PRAYER_STATE_SYNC,
+    );
+    expect(database.getPlayerAsync).toHaveBeenCalledWith("player-1");
+    expect(prayerSyncEventsAfterRegister).toHaveLength(1);
+    expect(prayerSyncEventsAfterRegister[0]?.payload).toEqual({
+      playerId: "player-1",
+      level: 7,
+      xp: 0,
+      points: 5,
+      maxPoints: 7,
+      active: ["thick_skin"],
+    });
+
+    world.emit(EventType.PLAYER_JOINED, {
+      playerId: "player-1",
+      player: {} as PlayerJoinedPayload["player"],
+    });
+    await flushAsyncWork();
+
+    const prayerSyncEventsAfterJoin = emitted.filter(
+      ({ event }) => event === EventType.PRAYER_STATE_SYNC,
+    );
+    expect(prayerSyncEventsAfterJoin).toHaveLength(2);
+    expect(prayerSyncEventsAfterJoin[1]?.payload).toEqual({
+      playerId: "player-1",
+      level: 7,
+      xp: 0,
+      points: 5,
+      maxPoints: 7,
+      active: ["thick_skin"],
+    });
+
+    system.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
Fix prayer login hydration so the HUD and prayer panel reflect persisted server state immediately after login or reconnect.

## Root Cause
The client bootstrap path was overwriting authoritative cached prayer state with local entity fallback values before real prayer data had finished hydrating, so the UI stayed stale until the player toggled a prayer again.

## Changes
- preserve authoritative prayer cache during initial player-data hydration
- only use entity prayer fallback when both prayer values are explicitly present and finite
- rerun initial hydration when the local player becomes available via PLAYER_SPAWNED
- re-emit authoritative PRAYER_STATE_SYNC on PLAYER_JOINED from PrayerSystem
- add regression coverage for the hook, PrayerSystem join sync, and reconnect login flow

## Validation
- bun run --cwd packages/client test -- tests/unit/hooks/usePlayerData.test.ts
- bun test packages/shared/src/systems/shared/character/__tests__/PrayerSystem.sync.test.ts
- bun run --cwd packages/client test -- tests/unit/PrayerPanel/PrayerPanel.test.tsx
- bun run --cwd packages/client typecheck (still shows unrelated pre-existing InventoryActionDispatcher errors)