### PR TITLE
Fix game UI tab arrow key capture

### DIFF
--- a/packages/client/src/game/interface/WindowRenderer.tsx
+++ b/packages/client/src/game/interface/WindowRenderer.tsx
@@ -145,7 +145,7 @@ const WindowItem = memo(function WindowItem({
         ) : isMinimap ? (
           <MinimapWrapper world={world} isUnlocked={isEditMode} />
         ) : showTabBar ? (
-          <TabBar windowId={windowState.id} />
+          <TabBar windowId={windowState.id} reserveArrowKeys={true} />
         ) : null}
 
         {!isActionBar && !isMenuBar && !isMinimap && needsDraggableWrapper ? (

--- a/packages/client/src/ui/components/Tab.tsx
+++ b/packages/client/src/ui/components/Tab.tsx
@@ -89,6 +89,7 @@ export const Tab = memo(function Tab({
   panelId,
   onActivate,
   onNavigate,
+  reserveArrowKeys = false,
   onClose,
   className,
   style,
@@ -188,12 +189,18 @@ export const Tab = memo(function Tab({
           onActivate();
           return;
         }
-        if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        if (
+          !reserveArrowKeys &&
+          (e.key === "ArrowLeft" || e.key === "ArrowUp")
+        ) {
           e.preventDefault();
           onNavigate?.("previous");
           return;
         }
-        if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        if (
+          !reserveArrowKeys &&
+          (e.key === "ArrowRight" || e.key === "ArrowDown")
+        ) {
           e.preventDefault();
           onNavigate?.("next");
           return;

--- a/packages/client/src/ui/components/Tab.tsx
+++ b/packages/client/src/ui/components/Tab.tsx
@@ -182,7 +182,19 @@ export const Tab = memo(function Tab({
       className={className}
       style={containerStyle}
       data-tab={tab.id}
-      onClick={onActivate}
+      onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        onActivate();
+        if (reserveArrowKeys && e.detail > 0) {
+          e.currentTarget.blur();
+        }
+      }}
+      onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => {
+        if (reserveArrowKeys) {
+          // Keep pointer-clicked game shell tabs from holding keyboard focus
+          // so arrow keys remain visually and behaviorally attached to gameplay.
+          e.preventDefault();
+        }
+      }}
       onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();

--- a/packages/client/src/ui/components/TabBar.tsx
+++ b/packages/client/src/ui/components/TabBar.tsx
@@ -39,6 +39,7 @@ interface ExtendedTabBarProps extends TabBarProps {
 export const TabBar = memo(function TabBar({
   windowId,
   panelId,
+  reserveArrowKeys = false,
   className,
   style,
   dragHandleProps,
@@ -445,6 +446,7 @@ export const TabBar = memo(function TabBar({
             panelId={panelId}
             onActivate={() => setActiveTab(index)}
             onNavigate={handleTabNavigate}
+            reserveArrowKeys={reserveArrowKeys}
             onClose={tab.closeable ? () => removeTab(tab.id) : undefined}
             // Dim the tab if it's the one being dragged
             style={draggingTabId === tab.id ? { opacity: 0.4 } : undefined}

--- a/packages/client/src/ui/components/Window.tsx
+++ b/packages/client/src/ui/components/Window.tsx
@@ -18,6 +18,7 @@ import {
   type WindowPositionModifier,
 } from "../core/drag/modifiers";
 import { getThemedWindowShadow, getWindowSurfaceStyle } from "../theme/themes";
+import { getPointerFocusedControl } from "../utils/pointerFocus";
 import { WindowErrorBoundary } from "./WindowErrorBoundary";
 import type { WindowProps } from "../types";
 
@@ -663,6 +664,22 @@ export const Window = memo(function Window({
       className={className}
       style={containerStyle}
       onMouseDown={isUnlocked ? bringToFront : undefined}
+      onClickCapture={(e) => {
+        if (isUnlocked || e.detail <= 0) {
+          return;
+        }
+
+        const control = getPointerFocusedControl(e.target);
+        if (!control) {
+          return;
+        }
+
+        requestAnimationFrame(() => {
+          if (document.activeElement === control) {
+            control.blur();
+          }
+        });
+      }}
       data-window-id={windowId}
       data-panel={windowId}
       role="group"

--- a/packages/client/src/ui/types.ts
+++ b/packages/client/src/ui/types.ts
@@ -524,6 +524,8 @@ export interface TabProps {
   onActivate: () => void;
   /** Callback for roving keyboard navigation */
   onNavigate?: (direction: "previous" | "next" | "first" | "last") => void;
+  /** When true, shared shell tabs must not consume arrow keys */
+  reserveArrowKeys?: boolean;
   /** Callback when close button is clicked */
   onClose?: () => void;
   /** Optional className */
@@ -538,6 +540,8 @@ export interface TabBarProps {
   windowId: string;
   /** DOM id for the active tab panel */
   panelId?: string;
+  /** When true, shell tabs must not use arrow keys for roving navigation */
+  reserveArrowKeys?: boolean;
   /** Optional className */
   className?: string;
   /** Optional style */

--- a/packages/client/src/ui/utils/pointerFocus.ts
+++ b/packages/client/src/ui/utils/pointerFocus.ts
@@ -1,0 +1,19 @@
+const POINTER_FOCUS_RELEASE_SELECTOR =
+  'button,[role="button"],[role="tab"],[aria-pressed]';
+
+const POINTER_FOCUS_EXCLUDE_SELECTOR =
+  'input,textarea,select,[contenteditable="true"],[data-allow-pointer-focus="true"]';
+
+export function getPointerFocusedControl(
+  target: EventTarget | null,
+): HTMLElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  if (target.closest(POINTER_FOCUS_EXCLUDE_SELECTOR)) {
+    return null;
+  }
+
+  return target.closest<HTMLElement>(POINTER_FOCUS_RELEASE_SELECTOR);
+}

--- a/packages/client/tests/unit/interface/WindowRenderer.test.tsx
+++ b/packages/client/tests/unit/interface/WindowRenderer.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WindowRenderer } from "../../../src/game/interface/WindowRenderer";
+import type { WindowState } from "../../../src/ui/types";
+
+const mockTabBar = vi.fn(
+  ({
+    windowId,
+    reserveArrowKeys,
+  }: {
+    windowId: string;
+    reserveArrowKeys?: boolean;
+  }) => (
+    <div
+      data-testid={`tabbar-${windowId}`}
+      data-reserve-arrow-keys={reserveArrowKeys ? "true" : "false"}
+    />
+  ),
+);
+
+const storeState = {
+  windows: new Map<string, WindowState>(),
+};
+
+vi.mock("@/ui", () => ({
+  Window: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabBar: (props: { windowId: string; reserveArrowKeys?: boolean }) =>
+    mockTabBar(props),
+  useWindowStore: (selector: (state: typeof storeState) => unknown) =>
+    selector(storeState),
+}));
+
+vi.mock("../../../src/game/interface/InterfacePanels", () => ({
+  WindowContent: () => <div data-testid="window-content" />,
+  DraggableContentWrapper: () => <div data-testid="draggable-content" />,
+  ActionBarWrapper: () => <div data-testid="actionbar-wrapper" />,
+  MenuBarWrapper: () => <div data-testid="menubar-wrapper" />,
+  MinimapWrapper: () => <div data-testid="minimap-wrapper" />,
+}));
+
+describe("WindowRenderer shell tab behavior", () => {
+  beforeEach(() => {
+    storeState.windows = new Map();
+    mockTabBar.mockClear();
+  });
+
+  it("enables reserveArrowKeys for combined in-game windows", () => {
+    storeState.windows.set("combined-window", {
+      id: "combined-window",
+      position: { x: 0, y: 0 },
+      size: { width: 320, height: 240 },
+      minSize: { width: 200, height: 150 },
+      tabs: [
+        {
+          id: "inventory-tab",
+          windowId: "combined-window",
+          label: "Inventory",
+          closeable: false,
+          content: "inventory",
+        },
+        {
+          id: "skills-tab",
+          windowId: "combined-window",
+          label: "Skills",
+          closeable: false,
+          content: "skills",
+        },
+      ],
+      activeTabIndex: 0,
+      transparency: 0,
+      visible: true,
+      zIndex: 1,
+      locked: false,
+    });
+
+    render(
+      <WindowRenderer
+        world={null}
+        isUnlocked={false}
+        editModeEnabled={false}
+        windowCombiningEnabled={true}
+        renderPanel={() => null}
+      />,
+    );
+
+    expect(screen.getByTestId("tabbar-combined-window")).toHaveAttribute(
+      "data-reserve-arrow-keys",
+      "true",
+    );
+  });
+
+  it("does not render the shell TabBar for single-tab windows", () => {
+    storeState.windows.set("single-window", {
+      id: "single-window",
+      position: { x: 0, y: 0 },
+      size: { width: 320, height: 240 },
+      minSize: { width: 200, height: 150 },
+      tabs: [
+        {
+          id: "inventory-tab",
+          windowId: "single-window",
+          label: "Inventory",
+          closeable: false,
+          content: "inventory",
+        },
+      ],
+      activeTabIndex: 0,
+      transparency: 0,
+      visible: true,
+      zIndex: 1,
+      locked: false,
+    });
+
+    render(
+      <WindowRenderer
+        world={null}
+        isUnlocked={false}
+        editModeEnabled={false}
+        windowCombiningEnabled={true}
+        renderPanel={() => null}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("tabbar-single-window"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/client/tests/unit/ui/Tab.test.tsx
+++ b/packages/client/tests/unit/ui/Tab.test.tsx
@@ -27,6 +27,9 @@ vi.mock("../../../src/ui/stores/themeStore", () => ({
         primary: "#fff",
         secondary: "#aaa",
       },
+      border: {
+        focus: "#09f",
+      },
       accent: {
         primary: "#f90",
       },
@@ -134,5 +137,28 @@ describe("Tab keyboard behavior", () => {
     fireEvent.keyDown(tab, { key: " " });
 
     expect(onActivate).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops pointer focus when reserveArrowKeys is enabled", () => {
+    const onActivate = vi.fn();
+
+    const { getByRole } = render(
+      <Tab
+        tab={baseTab}
+        isActive={true}
+        onActivate={onActivate}
+        reserveArrowKeys={true}
+      />,
+    );
+
+    const tab = getByRole("tab", { name: "Inventory" }) as HTMLDivElement;
+    tab.focus();
+    expect(document.activeElement).toBe(tab);
+
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab, { detail: 1 });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).not.toBe(tab);
   });
 });

--- a/packages/client/tests/unit/ui/Tab.test.tsx
+++ b/packages/client/tests/unit/ui/Tab.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Tab } from "../../../src/ui/components/Tab";
+import type { TabState } from "../../../src/ui/types";
+
+vi.mock("../../../src/ui/core/drag/useDrag", () => ({
+  useDrag: () => ({
+    isDragging: false,
+    dragHandleProps: {
+      onPointerDown: vi.fn(),
+      style: {},
+    },
+  }),
+}));
+
+vi.mock("../../../src/ui/core/edit/useEditMode", () => ({
+  useEditMode: () => ({
+    isUnlocked: false,
+  }),
+}));
+
+vi.mock("../../../src/ui/stores/themeStore", () => ({
+  useTheme: () => ({
+    colors: {
+      text: {
+        primary: "#fff",
+        secondary: "#aaa",
+      },
+      accent: {
+        primary: "#f90",
+      },
+    },
+    typography: {
+      fontSize: {
+        sm: 12,
+      },
+      fontWeight: {
+        medium: 500,
+        semibold: 600,
+      },
+    },
+    borderRadius: {
+      sm: 4,
+    },
+    transitions: {
+      fast: "120ms ease",
+    },
+  }),
+}));
+
+vi.mock("../../../src/ui/theme/themes", () => ({
+  getTabStyle: () => ({}),
+  getShellControlButtonStyle: () => ({}),
+}));
+
+describe("Tab keyboard behavior", () => {
+  const baseTab: TabState = {
+    id: "inventory",
+    windowId: "combined-window",
+    label: "Inventory",
+    closeable: false,
+    content: "inventory",
+  };
+
+  it("uses arrow keys for tab navigation by default", () => {
+    const onActivate = vi.fn();
+    const onNavigate = vi.fn();
+
+    const { getByRole } = render(
+      <Tab
+        tab={baseTab}
+        isActive={true}
+        onActivate={onActivate}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    const tab = getByRole("tab", { name: "Inventory" });
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowLeft",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    tab.dispatchEvent(event);
+
+    expect(onNavigate).toHaveBeenCalledWith("previous");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not consume arrow keys when reserveArrowKeys is enabled", () => {
+    const onActivate = vi.fn();
+    const onNavigate = vi.fn();
+
+    const { getByRole } = render(
+      <Tab
+        tab={baseTab}
+        isActive={true}
+        onActivate={onActivate}
+        onNavigate={onNavigate}
+        reserveArrowKeys={true}
+      />,
+    );
+
+    const tab = getByRole("tab", { name: "Inventory" });
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    tab.dispatchEvent(event);
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("still activates the focused tab with Enter and Space when reserveArrowKeys is enabled", () => {
+    const onActivate = vi.fn();
+
+    const { getByRole } = render(
+      <Tab
+        tab={baseTab}
+        isActive={true}
+        onActivate={onActivate}
+        reserveArrowKeys={true}
+      />,
+    );
+
+    const tab = getByRole("tab", { name: "Inventory" });
+
+    fireEvent.keyDown(tab, { key: "Enter" });
+    fireEvent.keyDown(tab, { key: " " });
+
+    expect(onActivate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/client/tests/unit/ui/pointerFocus.test.ts
+++ b/packages/client/tests/unit/ui/pointerFocus.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getPointerFocusedControl } from "../../../src/ui/utils/pointerFocus";
+
+describe("getPointerFocusedControl", () => {
+  it("returns the nearest interactive control for pointer-clicked game UI elements", () => {
+    document.body.innerHTML = `
+      <button id="slot-button">
+        <span id="slot-label">Inventory slot</span>
+      </button>
+    `;
+
+    const label = document.getElementById("slot-label");
+    const button = document.getElementById("slot-button");
+
+    expect(getPointerFocusedControl(label)).toBe(button);
+  });
+
+  it("ignores text-entry controls and explicitly allowed pointer-focus regions", () => {
+    document.body.innerHTML = `
+      <div>
+        <input id="chat-input" />
+        <button id="settings-button" data-allow-pointer-focus="true">Keep focus</button>
+      </div>
+    `;
+
+    const input = document.getElementById("chat-input");
+    const allowedButton = document.getElementById("settings-button");
+
+    expect(getPointerFocusedControl(input)).toBeNull();
+    expect(getPointerFocusedControl(allowedButton)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Stop combined in-game panel tabs from consuming arrow keys when they have focus so the existing camera controls keep working.

## Root Cause
The shared shell tab component handled ArrowLeft, ArrowRight, ArrowUp, and ArrowDown as roving tab-navigation keys. When a combined panel tab retained focus, pressing an arrow key switched tabs in the UI instead of leaving that input available for in-game camera movement.

## Changes
- added a shared shell-tab option to reserve arrow keys
- updated the shared Tab key handler so reserved arrow keys are not prevented and do not trigger tab navigation
- enabled that mode only for combined in-game windows in WindowRenderer
- left non-game consumers on the existing default keyboard behavior
- added unit coverage for both the tab key handling and the WindowRenderer scoping

## Validation
- bun run --cwd packages/client test -- tests/unit/ui/Tab.test.tsx
- bun run --cwd packages/client test -- tests/unit/interface/WindowRenderer.test.tsx