### PR TITLE
Polish skilling panels and dialogue handoffs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,6 +75,7 @@ export default [
         PromiseRejectionEvent: "readonly",
         SecurityPolicyViolationEvent: "readonly",
         EventListener: "readonly",
+        EventTarget: "readonly",
         Node: "readonly",
         Element: "readonly",
         DOMRect: "readonly",

--- a/packages/client/src/game/interface/InterfaceModals.tsx
+++ b/packages/client/src/game/interface/InterfaceModals.tsx
@@ -41,6 +41,7 @@ import type {
 import { BankPanel } from "../panels/BankPanel";
 import { StorePanel } from "../panels/StorePanel";
 import { DialoguePanel } from "../panels/DialoguePanel";
+import { DialoguePopupShell } from "../panels/dialogue/DialoguePopupShell";
 import { SmeltingPanel } from "../panels/SmeltingPanel";
 import { SmithingPanel } from "../panels/SmithingPanel";
 import { CraftingPanel } from "../panels/CraftingPanel";
@@ -936,28 +937,45 @@ export const InterfaceModalsRenderer = memo(function InterfaceModalsRenderer({
         </ModalWindow>
       )}
 
-      {/* Dialogue Panel - renders with its own fixed positioning, no ModalWindow wrapper needed */}
+      {/* Dialogue Panel */}
       {dialogueData?.visible && (
-        <DialoguePanel
-          visible={dialogueData.visible}
-          npcName={dialogueData.npcName}
-          npcId={dialogueData.npcId}
-          text={dialogueData.text}
-          responses={dialogueData.responses}
-          npcEntityId={dialogueData.npcEntityId}
-          world={world}
-          onSelectResponse={(_index, response) => {
-            if (!response.nextNodeId) {
-              setDialogueData(null);
-            }
-          }}
+        <DialoguePopupShell
+          visible={true}
           onClose={() => {
             setDialogueData(null);
             world?.network?.send?.("dialogueEnd", {
               npcId: dialogueData.npcId,
             });
           }}
-        />
+          title={dialogueData.npcName}
+          width={700}
+          maxWidth="min(86vw, 700px)"
+          maxHeight="min(40vh, 400px)"
+          contentStyle={{
+            overflow: "hidden",
+          }}
+        >
+          <DialoguePanel
+            visible={dialogueData.visible}
+            npcName={dialogueData.npcName}
+            npcId={dialogueData.npcId}
+            text={dialogueData.text}
+            responses={dialogueData.responses}
+            npcEntityId={dialogueData.npcEntityId}
+            world={world}
+            onSelectResponse={(_index, response) => {
+              if (!response.nextNodeId) {
+                setDialogueData(null);
+              }
+            }}
+            onClose={() => {
+              setDialogueData(null);
+              world?.network?.send?.("dialogueEnd", {
+                npcId: dialogueData.npcId,
+              });
+            }}
+          />
+        </DialoguePopupShell>
       )}
 
       {/* Smelting Panel */}

--- a/packages/client/src/game/interface/InterfaceModals.tsx
+++ b/packages/client/src/game/interface/InterfaceModals.tsx
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-import React, { memo, useMemo } from "react";
+import React, { memo, useCallback, useMemo } from "react";
 import { EventType, getItem } from "@hyperscape/shared";
 import type { PlayerStats, PlayerID, StakedItem } from "@hyperscape/shared";
 import { ModalWindow, useThemeStore } from "@/ui";
@@ -844,6 +844,17 @@ export const InterfaceModalsRenderer = memo(function InterfaceModalsRenderer({
   setStatsModalOpen,
   setDeathModalOpen,
 }: InterfaceModalsRendererProps): React.ReactElement {
+  const closeDialogue = useCallback(() => {
+    if (!dialogueData) {
+      return;
+    }
+
+    setDialogueData(null);
+    world?.network?.send?.("dialogueEnd", {
+      npcId: dialogueData.npcId,
+    });
+  }, [dialogueData, setDialogueData, world]);
+
   const myStakeValue = useMemo(
     () => duelData?.myStakes.reduce((sum, s) => sum + s.value, 0) ?? 0,
     [duelData?.myStakes],
@@ -941,12 +952,7 @@ export const InterfaceModalsRenderer = memo(function InterfaceModalsRenderer({
       {dialogueData?.visible && (
         <DialoguePopupShell
           visible={true}
-          onClose={() => {
-            setDialogueData(null);
-            world?.network?.send?.("dialogueEnd", {
-              npcId: dialogueData.npcId,
-            });
-          }}
+          onClose={closeDialogue}
           title={dialogueData.npcName}
           width={700}
           maxWidth="min(86vw, 700px)"
@@ -967,12 +973,6 @@ export const InterfaceModalsRenderer = memo(function InterfaceModalsRenderer({
               if (!response.nextNodeId) {
                 setDialogueData(null);
               }
-            }}
-            onClose={() => {
-              setDialogueData(null);
-              world?.network?.send?.("dialogueEnd", {
-                npcId: dialogueData.npcId,
-              });
             }}
           />
         </DialoguePopupShell>

--- a/packages/client/src/game/interface/MobileInterfaceManager.tsx
+++ b/packages/client/src/game/interface/MobileInterfaceManager.tsx
@@ -123,6 +123,17 @@ export function MobileInterfaceManager({
     setXpLampData,
   } = useModalPanels(world);
 
+  const closeDialogue = useCallback(() => {
+    if (!dialogueData) {
+      return;
+    }
+
+    setDialogueData(null);
+    world?.network?.send?.("dialogueEnd", {
+      npcId: dialogueData.npcId,
+    });
+  }, [dialogueData, setDialogueData, world]);
+
   // Handle radial menu button clicks (by panel id)
   const handleRadialButtonClick = useCallback(
     (panelId: string) => {
@@ -639,12 +650,7 @@ export function MobileInterfaceManager({
       {dialogueData?.visible && (
         <DialoguePopupShell
           visible={true}
-          onClose={() => {
-            setDialogueData(null);
-            world?.network?.send?.("dialogueEnd", {
-              npcId: dialogueData.npcId,
-            });
-          }}
+          onClose={closeDialogue}
           title={dialogueData.npcName}
           width="min(88vw, 640px)"
           maxWidth="88vw"
@@ -665,12 +671,6 @@ export function MobileInterfaceManager({
               if (!response.nextNodeId) {
                 setDialogueData(null);
               }
-            }}
-            onClose={() => {
-              setDialogueData(null);
-              world?.network?.send?.("dialogueEnd", {
-                npcId: dialogueData.npcId,
-              });
             }}
           />
         </DialoguePopupShell>

--- a/packages/client/src/game/interface/MobileInterfaceManager.tsx
+++ b/packages/client/src/game/interface/MobileInterfaceManager.tsx
@@ -31,6 +31,7 @@ import { zIndex } from "../../constants";
 import { BankPanel } from "../../game/panels/BankPanel";
 import { StorePanel } from "../../game/panels/StorePanel";
 import { DialoguePanel } from "../../game/panels/DialoguePanel";
+import { DialoguePopupShell } from "../../game/panels/dialogue/DialoguePopupShell";
 import { SmeltingPanel } from "../../game/panels/SmeltingPanel";
 import { SmithingPanel } from "../../game/panels/SmithingPanel";
 import { CraftingPanel } from "../../game/panels/CraftingPanel";
@@ -634,19 +635,45 @@ export function MobileInterfaceManager({
         </ModalWindow>
       )}
 
-      {/* Dialogue Panel - renders with its own fixed positioning, no ModalWindow wrapper needed */}
+      {/* Dialogue Panel */}
       {dialogueData?.visible && (
-        <DialoguePanel
+        <DialoguePopupShell
           visible={true}
-          world={world}
-          npcId={dialogueData.npcId}
-          npcName={dialogueData.npcName}
-          text={dialogueData.text}
-          responses={dialogueData.responses}
-          npcEntityId={dialogueData.npcEntityId}
-          onSelectResponse={() => {}}
-          onClose={() => setDialogueData(null)}
-        />
+          onClose={() => {
+            setDialogueData(null);
+            world?.network?.send?.("dialogueEnd", {
+              npcId: dialogueData.npcId,
+            });
+          }}
+          title={dialogueData.npcName}
+          width="min(88vw, 640px)"
+          maxWidth="88vw"
+          maxHeight="min(48vh, 400px)"
+          contentStyle={{
+            overflow: "hidden",
+          }}
+        >
+          <DialoguePanel
+            visible={true}
+            world={world}
+            npcId={dialogueData.npcId}
+            npcName={dialogueData.npcName}
+            text={dialogueData.text}
+            responses={dialogueData.responses}
+            npcEntityId={dialogueData.npcEntityId}
+            onSelectResponse={(_index, response) => {
+              if (!response.nextNodeId) {
+                setDialogueData(null);
+              }
+            }}
+            onClose={() => {
+              setDialogueData(null);
+              world?.network?.send?.("dialogueEnd", {
+                npcId: dialogueData.npcId,
+              });
+            }}
+          />
+        </DialoguePopupShell>
       )}
 
       {smeltingData?.visible && (

--- a/packages/client/src/game/panels/CraftingPanel.tsx
+++ b/packages/client/src/game/panels/CraftingPanel.tsx
@@ -9,11 +9,17 @@
  * - Sends crafting request to server
  */
 
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import type { ClientWorld } from "../../types";
 import { useThemeStore } from "@/ui";
-import { getPanelSurfaceStyle } from "@/ui/theme/themes";
 import { formatItemName } from "@/utils";
+import {
+  getSkillingBadgeStyle,
+  getSkillingSelectableStyle,
+  SkillingPanelBody,
+  SkillingQuantitySelector,
+  SkillingSection,
+} from "./skilling/SkillingPanelShared";
 
 interface CraftingRecipe {
   output: string;
@@ -34,52 +40,35 @@ interface CraftingPanelProps {
   station?: string;
 }
 
-/**
- * Get icon for crafting item type
- */
 function getItemIcon(output: string, category: string): string {
   const id = output.toLowerCase();
 
-  // Leather items
   if (id.includes("leather") && !id.includes("dragon")) return "🧥";
   if (id.includes("vambraces") || id.includes("vambrace")) return "🧤";
   if (id.includes("chaps")) return "👖";
   if (id.includes("coif")) return "⛑️";
   if (id.includes("cowl")) return "⛑️";
   if (id.includes("body")) return "🛡️";
-
-  // Dragonhide
   if (
     category === "dragonhide" ||
     id.includes("dhide") ||
     id.includes("dragon")
   )
     return "🐉";
-
-  // Studded
   if (id.includes("studded")) return "🔩";
-
-  // Jewelry
   if (id.includes("ring")) return "💍";
   if (id.includes("necklace")) return "📿";
   if (id.includes("amulet")) return "📿";
   if (id.includes("bracelet")) return "⌚";
-
-  // Gems
   if (id.includes("sapphire")) return "💎";
   if (id.includes("emerald")) return "💚";
   if (id.includes("ruby")) return "❤️";
   if (id.includes("diamond")) return "💠";
-
-  // Gem cutting
   if (category === "gem_cutting") return "💎";
 
   return "🧵";
 }
 
-/**
- * Category display order and labels
- */
 const CATEGORY_ORDER = [
   "leather",
   "studded",
@@ -87,6 +76,7 @@ const CATEGORY_ORDER = [
   "jewelry",
   "gem_cutting",
 ];
+
 const CATEGORY_LABELS: Record<string, string> = {
   leather: "Leather",
   studded: "Studded",
@@ -95,7 +85,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   gem_cutting: "Gem Cutting",
 };
 
-/** localStorage key for Make X memory */
 const CRAFTING_LAST_X_KEY = "crafting_last_x";
 
 export function CraftingPanel({
@@ -110,7 +99,6 @@ export function CraftingPanel({
   const [showQuantityInput, setShowQuantityInput] = useState(false);
   const [customQuantity, setCustomQuantity] = useState("");
 
-  // Make X memory - remember last custom quantity (OSRS feature)
   const [lastCustomQuantity, setLastCustomQuantity] = useState(() => {
     try {
       const stored = localStorage.getItem(CRAFTING_LAST_X_KEY);
@@ -120,7 +108,6 @@ export function CraftingPanel({
     }
   });
 
-  // Group recipes by category
   const groupedRecipes = useMemo(() => {
     const groups: Record<string, CraftingRecipe[]> = {};
 
@@ -132,24 +119,22 @@ export function CraftingPanel({
       groups[category].push(recipe);
     }
 
-    // Sort by category order
     const sorted: Array<[string, CraftingRecipe[]]> = [];
-    for (const cat of CATEGORY_ORDER) {
-      if (groups[cat]) {
-        sorted.push([cat, groups[cat]]);
+    for (const category of CATEGORY_ORDER) {
+      if (groups[category]) {
+        sorted.push([category, groups[category]]);
       }
     }
-    // Add any categories not in the predefined order
-    for (const cat of Object.keys(groups)) {
-      if (!CATEGORY_ORDER.includes(cat)) {
-        sorted.push([cat, groups[cat]]);
+
+    for (const category of Object.keys(groups)) {
+      if (!CATEGORY_ORDER.includes(category)) {
+        sorted.push([category, groups[category]]);
       }
     }
 
     return sorted;
   }, [availableRecipes]);
 
-  // Auto-select when only one recipe (e.g., chisel + uncut gem → skip to quantity)
   useEffect(() => {
     if (availableRecipes.length === 1) {
       setSelectedRecipe(availableRecipes[0]);
@@ -187,233 +172,135 @@ export function CraftingPanel({
   };
 
   return (
-    <div
-      className="rounded-lg shadow-2xl border"
-      style={{
-        ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-        minWidth: "380px",
-        maxWidth: "480px",
-        maxHeight: "80vh",
-      }}
+    <SkillingPanelBody
+      theme={theme}
+      intro="Browse available recipes by category, then inspect the exact inputs and crafting XP before starting a batch."
+      emptyMessage={
+        availableRecipes.length === 0
+          ? "You don't have the materials to craft anything."
+          : undefined
+      }
     >
-      {/* Content */}
-      <div
-        className="p-3 overflow-y-auto"
-        style={{
-          maxHeight: "calc(80vh - 100px)",
-          background:
-            theme.name === "hyperscape"
-              ? "linear-gradient(180deg, rgba(255, 255, 255, 0.015) 0%, rgba(0, 0, 0, 0.12) 100%)"
-              : "transparent",
-        }}
-      >
-        {availableRecipes.length === 0 ? (
-          <div
-            className="text-center py-4 text-sm"
-            style={{ color: theme.colors.text.secondary }}
-          >
-            You don&apos;t have the materials to craft anything.
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            {groupedRecipes.map(([category, recipes]) => (
-              <div key={category}>
-                {/* Category Header */}
-                <div
-                  className="text-xs font-semibold uppercase tracking-wider mb-1.5 px-1"
-                  style={{ color: theme.colors.text.muted }}
-                >
-                  {CATEGORY_LABELS[category] || category}
-                </div>
+      <div className="flex flex-col gap-3">
+        {groupedRecipes.map(([category, recipes]) => (
+          <SkillingSection key={category} theme={theme}>
+            <div
+              className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+              style={{ color: theme.colors.text.muted }}
+            >
+              {CATEGORY_LABELS[category] || category}
+            </div>
 
-                {/* Recipe Grid */}
-                <div className="grid grid-cols-2 gap-1">
-                  {recipes.map((recipe) => {
-                    const canCraft = recipe.meetsLevel && recipe.hasInputs;
-                    return (
-                      <button
-                        key={recipe.output}
-                        onClick={() => setSelectedRecipe(recipe)}
-                        className={`flex items-center gap-2 p-2 rounded border transition-all text-left ${
-                          selectedRecipe?.output === recipe.output
-                            ? "ring-2 ring-yellow-500"
-                            : ""
-                        }`}
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              {recipes.map((recipe) => {
+                const isSelected = selectedRecipe?.output === recipe.output;
+                const canCraft = recipe.meetsLevel && recipe.hasInputs;
+
+                return (
+                  <button
+                    key={recipe.output}
+                    onClick={() => setSelectedRecipe(recipe)}
+                    className="flex items-center gap-3 rounded-xl border p-3 text-left transition-all"
+                    style={getSkillingSelectableStyle(
+                      theme,
+                      isSelected,
+                      !canCraft,
+                    )}
+                  >
+                    <span className="text-xl">
+                      {getItemIcon(recipe.output, recipe.category)}
+                    </span>
+
+                    <div className="min-w-0 flex-1">
+                      <div
+                        className="truncate text-sm font-semibold"
                         style={{
-                          background:
-                            selectedRecipe?.output === recipe.output
-                              ? `${theme.colors.accent.primary}15`
-                              : theme.colors.background.tertiary,
-                          borderColor:
-                            selectedRecipe?.output === recipe.output
-                              ? `${theme.colors.accent.primary}50`
-                              : theme.colors.border.default,
-                          opacity: canCraft ? 1 : 0.5,
+                          color: recipe.meetsLevel
+                            ? theme.colors.accent.primary
+                            : theme.colors.state.danger,
                         }}
                       >
-                        {/* Item Icon */}
-                        <span className="text-lg">
-                          {getItemIcon(recipe.output, recipe.category)}
-                        </span>
-
-                        {/* Item Info */}
-                        <div className="flex-1 min-w-0">
-                          <div
-                            className="font-medium text-xs truncate"
-                            style={{
-                              color: recipe.meetsLevel
-                                ? theme.colors.accent.primary
-                                : theme.colors.state.danger,
-                            }}
-                          >
-                            {recipe.name || formatItemName(recipe.output)}
-                          </div>
-                          <div
-                            className="text-[9px] flex items-center gap-1"
-                            style={{ color: theme.colors.text.muted }}
-                          >
-                            <span>Lv{recipe.level}</span>
-                            <span className="mx-0.5">|</span>
-                            <span>{recipe.xp} XP</span>
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-
-            {/* Selected Recipe Details & Quantity */}
-            {selectedRecipe && (
-              <div
-                className="mt-2 pt-3"
-                style={{
-                  borderTop: `1px solid ${theme.colors.border.default}`,
-                }}
-              >
-                {/* Recipe Details */}
-                <div className="flex items-center gap-3 mb-3">
-                  <span className="text-2xl">
-                    {getItemIcon(
-                      selectedRecipe.output,
-                      selectedRecipe.category,
-                    )}
-                  </span>
-                  <div>
-                    <div
-                      className="font-semibold text-sm"
-                      style={{ color: theme.colors.accent.primary }}
-                    >
-                      {selectedRecipe.name ||
-                        formatItemName(selectedRecipe.output)}
-                    </div>
-                    <div
-                      className="text-xs"
-                      style={{ color: theme.colors.text.secondary }}
-                    >
-                      {selectedRecipe.inputs
-                        .map(
-                          (inp) => `${inp.amount}× ${formatItemName(inp.item)}`,
-                        )
-                        .join(", ")}{" "}
-                      | {selectedRecipe.xp} XP
-                    </div>
-                    {!selectedRecipe.meetsLevel && (
-                      <div
-                        className="text-[10px]"
-                        style={{ color: theme.colors.state.danger }}
-                      >
-                        Requires Crafting level {selectedRecipe.level}
+                        {recipe.name || formatItemName(recipe.output)}
                       </div>
-                    )}
-                  </div>
-                </div>
+                      <div
+                        className="mt-1 flex items-center gap-1 text-[10px]"
+                        style={{ color: theme.colors.text.muted }}
+                      >
+                        <span>Lv {recipe.level}</span>
+                        <span className="mx-1">•</span>
+                        <span>{recipe.xp} XP</span>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </SkillingSection>
+        ))}
 
-                {/* Quantity Selection */}
+        {selectedRecipe ? (
+          <SkillingSection theme={theme}>
+            <div className="mb-3 flex items-start gap-3">
+              <span className="text-2xl">
+                {getItemIcon(selectedRecipe.output, selectedRecipe.category)}
+              </span>
+              <div className="min-w-0 flex-1">
                 <div
-                  className="text-xs mb-2"
+                  className="text-sm font-semibold"
+                  style={{ color: theme.colors.accent.primary }}
+                >
+                  {selectedRecipe.name || formatItemName(selectedRecipe.output)}
+                </div>
+                <div
+                  className="mt-1 text-xs"
                   style={{ color: theme.colors.text.secondary }}
                 >
-                  How many?
+                  {selectedRecipe.inputs
+                    .map(
+                      (input) =>
+                        `${input.amount}x ${formatItemName(input.item)}`,
+                    )
+                    .join(", ")}
                 </div>
-
-                {showQuantityInput ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="number"
-                      value={customQuantity}
-                      onChange={(e) => setCustomQuantity(e.target.value)}
-                      className="flex-1 px-2 py-1 rounded text-sm"
-                      style={{
-                        background: theme.colors.background.panelSecondary,
-                        border: `1px solid ${theme.colors.border.default}`,
-                        color: theme.colors.accent.primary,
-                      }}
-                      placeholder={`Amount (last: ${lastCustomQuantity})`}
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleCustomQuantitySubmit();
-                        if (e.key === "Escape") setShowQuantityInput(false);
-                      }}
-                    />
-                    <button
-                      onClick={handleCustomQuantitySubmit}
-                      className="px-3 py-1 rounded text-sm font-medium transition-colors"
-                      style={{
-                        background: `${theme.colors.state.success}30`,
-                        border: `1px solid ${theme.colors.state.success}50`,
-                        color: theme.colors.state.success,
-                      }}
-                    >
-                      OK
-                    </button>
+                {!selectedRecipe.meetsLevel ? (
+                  <div
+                    className="mt-1 text-[10px]"
+                    style={{ color: theme.colors.state.danger }}
+                  >
+                    Requires Crafting level {selectedRecipe.level}
                   </div>
-                ) : (
-                  <div className="flex gap-1">
-                    {[1, 5, 10].map((qty) => (
-                      <button
-                        key={qty}
-                        onClick={() => handleCraft(selectedRecipe, qty)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        {qty}
-                      </button>
-                    ))}
-                    <button
-                      onClick={() => handleCraft(selectedRecipe, -1)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      All
-                    </button>
-                    <button
-                      onClick={() => setShowQuantityInput(true)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      X
-                    </button>
-                  </div>
-                )}
+                ) : null}
               </div>
-            )}
-          </div>
-        )}
+              <div
+                className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                style={getSkillingBadgeStyle(theme)}
+              >
+                {selectedRecipe.xp} XP
+              </div>
+            </div>
+
+            <div
+              className="mb-2 text-xs font-medium"
+              style={{ color: theme.colors.text.secondary }}
+            >
+              How many?
+            </div>
+
+            <SkillingQuantitySelector
+              theme={theme}
+              showCustomInput={showQuantityInput}
+              customQuantity={customQuantity}
+              lastCustomQuantity={lastCustomQuantity}
+              onCustomQuantityChange={setCustomQuantity}
+              onCustomSubmit={handleCustomQuantitySubmit}
+              onCancelCustomInput={() => setShowQuantityInput(false)}
+              onPresetQuantity={(qty) => handleCraft(selectedRecipe, qty)}
+              allQuantity={-1}
+              onShowCustomInput={() => setShowQuantityInput(true)}
+            />
+          </SkillingSection>
+        ) : null}
       </div>
-    </div>
+    </SkillingPanelBody>
   );
 }

--- a/packages/client/src/game/panels/DialoguePanel.tsx
+++ b/packages/client/src/game/panels/DialoguePanel.tsx
@@ -16,16 +16,10 @@
  */
 
 import React from "react";
-import type { World } from "@hyperscape/shared";
 import { useThemeStore } from "@/ui";
-import {
-  getInteractiveTileStyle,
-  getPanelHeaderStyle,
-  getPanelInsetStyle,
-  getPanelSurfaceStyle,
-  getShellControlButtonStyle,
-} from "@/ui/theme/themes";
-import { UI } from "@/ui/core";
+import { getInteractiveTileStyle, getPanelInsetStyle } from "@/ui/theme/themes";
+import { DialogueCharacterPortrait } from "./dialogue/DialogueCharacterPortrait";
+import type { ClientWorld } from "../../types";
 
 interface DialogueResponse {
   text: string;
@@ -42,7 +36,7 @@ interface DialoguePanelProps {
   npcEntityId?: string;
   onSelectResponse: (index: number, response: DialogueResponse) => void;
   onClose: () => void;
-  world: World;
+  world: ClientWorld;
 }
 
 export function DialoguePanel({
@@ -51,13 +45,12 @@ export function DialoguePanel({
   npcId,
   text,
   responses,
-  npcEntityId: _npcEntityId,
+  npcEntityId,
   onSelectResponse,
   onClose,
   world,
 }: DialoguePanelProps) {
   const theme = useThemeStore((s) => s.theme);
-  const closeButtonStyle = getShellControlButtonStyle(theme, "danger");
 
   // NOTE: Distance validation is handled server-side by InteractionSessionManager.
   // The server sends 'dialogueClose' packets when the player moves too far away.
@@ -91,162 +84,121 @@ export function DialoguePanel({
   };
 
   return (
-    <div
-      className="fixed bottom-24 left-1/2 -translate-x-1/2 pointer-events-auto"
-      style={{
-        zIndex: UI.Z_INDEX.MODAL,
-        width: "42rem",
-        maxWidth: "90vw",
-        ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-        borderRadius: theme.borderRadius.xl,
-        padding: "1.5rem",
-        boxShadow:
-          "0 18px 38px rgba(0, 0, 0, 0.46), inset 0 1px 0 rgba(255,255,255,0.05)",
-      }}
-      onClick={(e) => e.stopPropagation()}
-    >
-      {/* NPC Name Header */}
+    <div className="flex min-w-0 w-full flex-col gap-2 overflow-visible">
       <div
-        className="flex justify-between items-center mb-3 pb-2"
-        style={{
-          ...getPanelHeaderStyle(theme),
-          margin: "-1.5rem -1.5rem 0.75rem",
-          padding: "0.75rem 1rem",
-        }}
+        className="grid min-h-0 gap-3 md:grid-cols-[136px_minmax(0,1fr)]"
+        style={{ alignItems: "start" }}
       >
-        <h3
-          className="m-0 text-lg font-bold"
-          style={{ color: theme.colors.text.accent }}
-        >
-          <span
-            className="block text-[10px] uppercase tracking-[0.18em] mb-1"
-            style={{ color: theme.colors.text.muted }}
+        <DialogueCharacterPortrait
+          world={world}
+          npcEntityId={npcEntityId}
+          npcName={npcName}
+          className="self-start"
+        />
+
+        <div className="flex min-w-0 flex-col gap-2">
+          <div
+            className="shrink-0 text-white leading-relaxed"
+            style={{
+              fontSize: "0.89rem",
+              lineHeight: 1.5,
+              minHeight: "3.8rem",
+              color: theme.colors.text.primary,
+              ...getPanelInsetStyle(theme, {
+                emphasis: "normal",
+                radius: theme.borderRadius.lg,
+                padding: `${theme.spacing.sm - 1}px ${theme.spacing.md - 1}px`,
+              }),
+            }}
           >
-            Encounter
-          </span>
-          {npcName}
-        </h3>
-        <button
-          onClick={onClose}
-          className="cursor-pointer text-xl leading-none"
-          style={{ ...closeButtonStyle, width: 28, height: 28, fontSize: 18 }}
-          title="Close dialogue"
-          aria-label="Close dialogue"
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = String(
-              closeButtonStyle["--shell-button-hover-bg"],
-            );
-            e.currentTarget.style.color = String(
-              closeButtonStyle["--shell-button-hover-fg"],
-            );
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = String(
-              closeButtonStyle.background,
-            );
-            e.currentTarget.style.color = String(closeButtonStyle.color);
-          }}
-        >
-          x
-        </button>
-      </div>
+            {text}
+          </div>
 
-      {/* Dialogue Text */}
-      <div
-        className="mb-4 text-white leading-relaxed"
-        style={{
-          fontSize: "1rem",
-          minHeight: "3rem",
-          color: theme.colors.text.primary,
-          ...getPanelInsetStyle(theme, {
-            emphasis: "normal",
-            radius: theme.borderRadius.lg,
-            padding: `${theme.spacing.md}px`,
-          }),
-        }}
-      >
-        {text}
-      </div>
-
-      {/* Response Options */}
-      <div className="flex flex-col gap-2">
-        {responses.length > 0 ? (
-          responses.map((response, index) => (
-            <button
-              key={index}
-              onClick={() => handleResponseClick(index, response)}
-              className="w-full text-left py-2 px-4 rounded cursor-pointer transition-all"
-              aria-label={`Response ${index + 1}: ${response.text}`}
-              style={{
-                ...getInteractiveTileStyle(theme, {
-                  radius: theme.borderRadius.md,
-                  accentColor: theme.colors.accent.primary,
-                }),
-                color: theme.colors.text.primary,
-                padding: `${theme.spacing.sm + 2}px ${theme.spacing.md}px`,
-                fontWeight: theme.typography.fontWeight.medium,
-                display: "flex",
-                alignItems: "flex-start",
-                gap: theme.spacing.sm,
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background =
-                  theme.name === "hyperscape"
-                    ? "linear-gradient(180deg, rgba(255, 255, 255, 0.065) 0%, rgba(190, 165, 123, 0.12) 22%, rgba(25, 29, 35, 0.98) 100%)"
-                    : `${theme.colors.accent.primary}18`;
-                e.currentTarget.style.borderColor = `${theme.colors.accent.primary}80`;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background =
-                  theme.name === "hyperscape"
-                    ? "linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.012) 18%, rgba(22, 26, 31, 0.99) 100%)"
-                    : `${theme.colors.accent.primary}12`;
-                e.currentTarget.style.borderColor = `${theme.colors.border.default}80`;
-              }}
-            >
-              <span
+          <div
+            className="flex min-h-0 flex-col gap-2 overflow-y-auto pr-1"
+            style={{ maxHeight: "min(10.5rem, 22vh)" }}
+          >
+            {responses.length > 0 ? (
+              responses.map((response, index) => (
+                <button
+                  key={index}
+                  onClick={() => handleResponseClick(index, response)}
+                  className="w-full rounded text-left transition-all"
+                  aria-label={`Response ${index + 1}: ${response.text}`}
+                  style={{
+                    ...getInteractiveTileStyle(theme, {
+                      radius: theme.borderRadius.md,
+                      accentColor: theme.colors.accent.primary,
+                    }),
+                    color: theme.colors.text.primary,
+                    padding: `${theme.spacing.sm - 1}px ${theme.spacing.md - 1}px`,
+                    fontWeight: theme.typography.fontWeight.semibold,
+                    fontSize: "0.95rem",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: theme.spacing.sm - 1,
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background =
+                      theme.name === "hyperscape"
+                        ? "linear-gradient(180deg, rgba(255, 255, 255, 0.065) 0%, rgba(190, 165, 123, 0.12) 22%, rgba(25, 29, 35, 0.98) 100%)"
+                        : `${theme.colors.accent.primary}18`;
+                    e.currentTarget.style.borderColor = `${theme.colors.accent.primary}80`;
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background =
+                      theme.name === "hyperscape"
+                        ? "linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.012) 18%, rgba(22, 26, 31, 0.99) 100%)"
+                        : `${theme.colors.accent.primary}12`;
+                    e.currentTarget.style.borderColor = `${theme.colors.border.default}80`;
+                  }}
+                >
+                  <span
+                    style={{
+                      color: theme.colors.text.muted,
+                      fontSize: "10px",
+                      minWidth: 14,
+                    }}
+                  >
+                    {index + 1}.
+                  </span>
+                  <span className="leading-snug">{response.text}</span>
+                </button>
+              ))
+            ) : (
+              <button
+                onClick={handleContinue}
+                className="w-full rounded transition-all"
+                aria-label="Continue dialogue"
                 style={{
-                  color: theme.colors.text.muted,
-                  fontSize: "11px",
-                  minWidth: 16,
+                  ...getInteractiveTileStyle(theme, {
+                    active: true,
+                    radius: theme.borderRadius.md,
+                    accentColor: theme.colors.accent.primary,
+                  }),
+                  color: theme.colors.text.primary,
+                  padding: `${theme.spacing.sm - 1}px ${theme.spacing.md - 1}px`,
+                  fontWeight: theme.typography.fontWeight.semibold,
+                  fontSize: "0.95rem",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background =
+                    theme.name === "hyperscape"
+                      ? "linear-gradient(180deg, rgba(255, 255, 255, 0.075) 0%, rgba(190, 165, 123, 0.14) 22%, rgba(27, 31, 37, 0.98) 100%)"
+                      : `${theme.colors.accent.primary}28`;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background =
+                    theme.name === "hyperscape"
+                      ? "linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(190, 165, 123, 0.12) 20%, rgba(25, 29, 35, 0.98) 100%)"
+                      : `${theme.colors.accent.primary}20`;
                 }}
               >
-                {index + 1}.
-              </span>
-              <span>{response.text}</span>
-            </button>
-          ))
-        ) : (
-          <button
-            onClick={handleContinue}
-            className="w-full py-2 px-4 rounded cursor-pointer transition-all"
-            aria-label="Continue dialogue"
-            style={{
-              ...getInteractiveTileStyle(theme, {
-                active: true,
-                radius: theme.borderRadius.md,
-                accentColor: theme.colors.accent.primary,
-              }),
-              color: theme.colors.text.primary,
-              padding: `${theme.spacing.sm + 2}px ${theme.spacing.md}px`,
-              fontWeight: theme.typography.fontWeight.semibold,
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background =
-                theme.name === "hyperscape"
-                  ? "linear-gradient(180deg, rgba(255, 255, 255, 0.075) 0%, rgba(190, 165, 123, 0.14) 22%, rgba(27, 31, 37, 0.98) 100%)"
-                  : `${theme.colors.accent.primary}28`;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background =
-                theme.name === "hyperscape"
-                  ? "linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(190, 165, 123, 0.12) 20%, rgba(25, 29, 35, 0.98) 100%)"
-                  : `${theme.colors.accent.primary}20`;
-            }}
-          >
-            Click to continue...
-          </button>
-        )}
+                Click to continue...
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/client/src/game/panels/DialoguePanel.tsx
+++ b/packages/client/src/game/panels/DialoguePanel.tsx
@@ -35,7 +35,6 @@ interface DialoguePanelProps {
   responses: DialogueResponse[];
   npcEntityId?: string;
   onSelectResponse: (index: number, response: DialogueResponse) => void;
-  onClose: () => void;
   world: ClientWorld;
 }
 
@@ -47,7 +46,6 @@ export function DialoguePanel({
   responses,
   npcEntityId,
   onSelectResponse,
-  onClose,
   world,
 }: DialoguePanelProps) {
   const theme = useThemeStore((s) => s.theme);
@@ -73,14 +71,12 @@ export function DialoguePanel({
 
   const handleContinue = () => {
     // Terminal node - send continue packet to server so it can execute any pending effects
-    // Server will then send dialogueEnd which clears the active modal state
+    // Server will then send dialogueEnd which clears the shell-owned modal state.
     if (world.network?.send) {
       world.network.send("dialogueContinue", {
         npcId,
       });
     }
-    // Close the dialogue UI immediately for responsive feel
-    onClose();
   };
 
   return (

--- a/packages/client/src/game/panels/FletchingPanel.tsx
+++ b/packages/client/src/game/panels/FletchingPanel.tsx
@@ -10,11 +10,17 @@
  * - Sends fletching request to server
  */
 
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import type { ClientWorld } from "../../types";
 import { useThemeStore } from "@/ui";
-import { getPanelSurfaceStyle } from "@/ui/theme/themes";
 import { formatItemName } from "@/utils";
+import {
+  getSkillingBadgeStyle,
+  getSkillingSelectableStyle,
+  SkillingPanelBody,
+  SkillingQuantitySelector,
+  SkillingSection,
+} from "./skilling/SkillingPanelShared";
 
 interface FletchingRecipe {
   recipeId: string;
@@ -36,9 +42,6 @@ interface FletchingPanelProps {
   onClose: () => void;
 }
 
-/**
- * Get icon for fletching item type
- */
 function getItemIcon(output: string, category: string): string {
   const id = output.toLowerCase();
 
@@ -51,9 +54,6 @@ function getItemIcon(output: string, category: string): string {
   return "🪓";
 }
 
-/**
- * Category display order and labels
- */
 const CATEGORY_ORDER = [
   "arrow_shafts",
   "shortbows",
@@ -61,6 +61,7 @@ const CATEGORY_ORDER = [
   "stringing",
   "arrows",
 ];
+
 const CATEGORY_LABELS: Record<string, string> = {
   arrow_shafts: "Arrow Shafts",
   shortbows: "Shortbows",
@@ -69,7 +70,6 @@ const CATEGORY_LABELS: Record<string, string> = {
   arrows: "Arrows",
 };
 
-/** localStorage key for Make X memory */
 const FLETCHING_LAST_X_KEY = "fletching_last_x";
 
 export function FletchingPanel({
@@ -84,7 +84,6 @@ export function FletchingPanel({
   const [showQuantityInput, setShowQuantityInput] = useState(false);
   const [customQuantity, setCustomQuantity] = useState("");
 
-  // Make X memory - remember last custom quantity (OSRS feature)
   const [lastCustomQuantity, setLastCustomQuantity] = useState(() => {
     try {
       const stored = localStorage.getItem(FLETCHING_LAST_X_KEY);
@@ -94,7 +93,6 @@ export function FletchingPanel({
     }
   });
 
-  // Group recipes by category
   const groupedRecipes = useMemo(() => {
     const groups: Record<string, FletchingRecipe[]> = {};
 
@@ -106,24 +104,22 @@ export function FletchingPanel({
       groups[category].push(recipe);
     }
 
-    // Sort by category order
     const sorted: Array<[string, FletchingRecipe[]]> = [];
-    for (const cat of CATEGORY_ORDER) {
-      if (groups[cat]) {
-        sorted.push([cat, groups[cat]]);
+    for (const category of CATEGORY_ORDER) {
+      if (groups[category]) {
+        sorted.push([category, groups[category]]);
       }
     }
-    // Add any categories not in the predefined order
-    for (const cat of Object.keys(groups)) {
-      if (!CATEGORY_ORDER.includes(cat)) {
-        sorted.push([cat, groups[cat]]);
+
+    for (const category of Object.keys(groups)) {
+      if (!CATEGORY_ORDER.includes(category)) {
+        sorted.push([category, groups[category]]);
       }
     }
 
     return sorted;
   }, [availableRecipes]);
 
-  // Auto-select when only one recipe (e.g., stringing a specific bow)
   useEffect(() => {
     if (availableRecipes.length === 1) {
       setSelectedRecipe(availableRecipes[0]);
@@ -160,244 +156,143 @@ export function FletchingPanel({
     setCustomQuantity("");
   };
 
-  /**
-   * Format recipe display name, appending output quantity for multi-output recipes
-   */
   const getDisplayName = (recipe: FletchingRecipe): string => {
     const name = recipe.name || formatItemName(recipe.output);
-    if (recipe.outputQuantity > 1) {
-      return `${name} (x${recipe.outputQuantity})`;
-    }
-    return name;
+    return recipe.outputQuantity > 1
+      ? `${name} (x${recipe.outputQuantity})`
+      : name;
   };
 
   return (
-    <div
-      className="rounded-lg shadow-2xl border"
-      style={{
-        ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-        minWidth: "380px",
-        maxWidth: "480px",
-        maxHeight: "80vh",
-      }}
+    <SkillingPanelBody
+      theme={theme}
+      intro="Review each fletching recipe by category, including multi-output results and required materials, before starting."
+      emptyMessage={
+        availableRecipes.length === 0
+          ? "You don't have the materials to fletch anything."
+          : undefined
+      }
     >
-      {/* Content */}
-      <div
-        className="p-3 overflow-y-auto"
-        style={{
-          maxHeight: "calc(80vh - 100px)",
-          background:
-            theme.name === "hyperscape"
-              ? "linear-gradient(180deg, rgba(255, 255, 255, 0.015) 0%, rgba(0, 0, 0, 0.12) 100%)"
-              : "transparent",
-        }}
-      >
-        {availableRecipes.length === 0 ? (
-          <div
-            className="text-center py-4 text-sm"
-            style={{ color: theme.colors.text.secondary }}
-          >
-            You don&apos;t have the materials to fletch anything.
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            {groupedRecipes.map(([category, recipes]) => (
-              <div key={category}>
-                {/* Category Header */}
-                <div
-                  className="text-xs font-semibold uppercase tracking-wider mb-1.5 px-1"
-                  style={{ color: theme.colors.text.muted }}
-                >
-                  {CATEGORY_LABELS[category] || category}
-                </div>
+      <div className="flex flex-col gap-3">
+        {groupedRecipes.map(([category, recipes]) => (
+          <SkillingSection key={category} theme={theme}>
+            <div
+              className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+              style={{ color: theme.colors.text.muted }}
+            >
+              {CATEGORY_LABELS[category] || category}
+            </div>
 
-                {/* Recipe Grid */}
-                <div className="grid grid-cols-2 gap-1">
-                  {recipes.map((recipe) => {
-                    const canFletch = recipe.meetsLevel && recipe.hasInputs;
-                    return (
-                      <button
-                        key={recipe.recipeId}
-                        onClick={() => setSelectedRecipe(recipe)}
-                        className={`flex items-center gap-2 p-2 rounded border transition-all text-left ${
-                          selectedRecipe?.recipeId === recipe.recipeId
-                            ? "ring-2 ring-yellow-500"
-                            : ""
-                        }`}
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              {recipes.map((recipe) => {
+                const isSelected = selectedRecipe?.recipeId === recipe.recipeId;
+                const canFletch = recipe.meetsLevel && recipe.hasInputs;
+
+                return (
+                  <button
+                    key={recipe.recipeId}
+                    onClick={() => setSelectedRecipe(recipe)}
+                    className="flex items-center gap-3 rounded-xl border p-3 text-left transition-all"
+                    style={getSkillingSelectableStyle(
+                      theme,
+                      isSelected,
+                      !canFletch,
+                    )}
+                  >
+                    <span className="text-xl">
+                      {getItemIcon(recipe.output, recipe.category)}
+                    </span>
+
+                    <div className="min-w-0 flex-1">
+                      <div
+                        className="truncate text-sm font-semibold"
                         style={{
-                          background:
-                            selectedRecipe?.recipeId === recipe.recipeId
-                              ? `${theme.colors.accent.primary}15`
-                              : theme.colors.background.tertiary,
-                          borderColor:
-                            selectedRecipe?.recipeId === recipe.recipeId
-                              ? `${theme.colors.accent.primary}50`
-                              : theme.colors.border.default,
-                          opacity: canFletch ? 1 : 0.5,
+                          color: recipe.meetsLevel
+                            ? theme.colors.accent.primary
+                            : theme.colors.state.danger,
                         }}
                       >
-                        {/* Item Icon */}
-                        <span className="text-lg">
-                          {getItemIcon(recipe.output, recipe.category)}
-                        </span>
-
-                        {/* Item Info */}
-                        <div className="flex-1 min-w-0">
-                          <div
-                            className="font-medium text-xs truncate"
-                            style={{
-                              color: recipe.meetsLevel
-                                ? theme.colors.accent.primary
-                                : theme.colors.state.danger,
-                            }}
-                          >
-                            {getDisplayName(recipe)}
-                          </div>
-                          <div
-                            className="text-[9px] flex items-center gap-1"
-                            style={{ color: theme.colors.text.muted }}
-                          >
-                            <span>Lv{recipe.level}</span>
-                            <span className="mx-0.5">|</span>
-                            <span>{recipe.xp} XP</span>
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-
-            {/* Selected Recipe Details & Quantity */}
-            {selectedRecipe && (
-              <div
-                className="mt-2 pt-3"
-                style={{
-                  borderTop: `1px solid ${theme.colors.border.default}`,
-                }}
-              >
-                {/* Recipe Details */}
-                <div className="flex items-center gap-3 mb-3">
-                  <span className="text-2xl">
-                    {getItemIcon(
-                      selectedRecipe.output,
-                      selectedRecipe.category,
-                    )}
-                  </span>
-                  <div>
-                    <div
-                      className="font-semibold text-sm"
-                      style={{ color: theme.colors.accent.primary }}
-                    >
-                      {getDisplayName(selectedRecipe)}
-                    </div>
-                    <div
-                      className="text-xs"
-                      style={{ color: theme.colors.text.secondary }}
-                    >
-                      {selectedRecipe.inputs
-                        .map(
-                          (inp) => `${inp.amount}x ${formatItemName(inp.item)}`,
-                        )
-                        .join(", ")}{" "}
-                      | {selectedRecipe.xp} XP
-                    </div>
-                    {!selectedRecipe.meetsLevel && (
-                      <div
-                        className="text-[10px]"
-                        style={{ color: theme.colors.state.danger }}
-                      >
-                        Requires Fletching level {selectedRecipe.level}
+                        {getDisplayName(recipe)}
                       </div>
-                    )}
-                  </div>
-                </div>
+                      <div
+                        className="mt-1 flex items-center gap-1 text-[10px]"
+                        style={{ color: theme.colors.text.muted }}
+                      >
+                        <span>Lv {recipe.level}</span>
+                        <span className="mx-1">•</span>
+                        <span>{recipe.xp} XP</span>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </SkillingSection>
+        ))}
 
-                {/* Quantity Selection */}
+        {selectedRecipe ? (
+          <SkillingSection theme={theme}>
+            <div className="mb-3 flex items-start gap-3">
+              <span className="text-2xl">
+                {getItemIcon(selectedRecipe.output, selectedRecipe.category)}
+              </span>
+              <div className="min-w-0 flex-1">
                 <div
-                  className="text-xs mb-2"
+                  className="text-sm font-semibold"
+                  style={{ color: theme.colors.accent.primary }}
+                >
+                  {getDisplayName(selectedRecipe)}
+                </div>
+                <div
+                  className="mt-1 text-xs"
                   style={{ color: theme.colors.text.secondary }}
                 >
-                  How many?
+                  {selectedRecipe.inputs
+                    .map(
+                      (input) =>
+                        `${input.amount}x ${formatItemName(input.item)}`,
+                    )
+                    .join(", ")}
                 </div>
-
-                {showQuantityInput ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="number"
-                      value={customQuantity}
-                      onChange={(e) => setCustomQuantity(e.target.value)}
-                      className="flex-1 px-2 py-1 rounded text-sm"
-                      style={{
-                        background: theme.colors.background.panelSecondary,
-                        border: `1px solid ${theme.colors.border.default}`,
-                        color: theme.colors.accent.primary,
-                      }}
-                      placeholder={`Amount (last: ${lastCustomQuantity})`}
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleCustomQuantitySubmit();
-                        if (e.key === "Escape") setShowQuantityInput(false);
-                      }}
-                    />
-                    <button
-                      onClick={handleCustomQuantitySubmit}
-                      className="px-3 py-1 rounded text-sm font-medium transition-colors"
-                      style={{
-                        background: `${theme.colors.state.success}30`,
-                        border: `1px solid ${theme.colors.state.success}50`,
-                        color: theme.colors.state.success,
-                      }}
-                    >
-                      OK
-                    </button>
+                {!selectedRecipe.meetsLevel ? (
+                  <div
+                    className="mt-1 text-[10px]"
+                    style={{ color: theme.colors.state.danger }}
+                  >
+                    Requires Fletching level {selectedRecipe.level}
                   </div>
-                ) : (
-                  <div className="flex gap-1">
-                    {[1, 5, 10].map((qty) => (
-                      <button
-                        key={qty}
-                        onClick={() => handleFletch(selectedRecipe, qty)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        {qty}
-                      </button>
-                    ))}
-                    <button
-                      onClick={() => handleFletch(selectedRecipe, -1)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      All
-                    </button>
-                    <button
-                      onClick={() => setShowQuantityInput(true)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      X
-                    </button>
-                  </div>
-                )}
+                ) : null}
               </div>
-            )}
-          </div>
-        )}
+              <div
+                className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                style={getSkillingBadgeStyle(theme)}
+              >
+                {selectedRecipe.xp} XP
+              </div>
+            </div>
+
+            <div
+              className="mb-2 text-xs font-medium"
+              style={{ color: theme.colors.text.secondary }}
+            >
+              How many?
+            </div>
+
+            <SkillingQuantitySelector
+              theme={theme}
+              showCustomInput={showQuantityInput}
+              customQuantity={customQuantity}
+              lastCustomQuantity={lastCustomQuantity}
+              onCustomQuantityChange={setCustomQuantity}
+              onCustomSubmit={handleCustomQuantitySubmit}
+              onCancelCustomInput={() => setShowQuantityInput(false)}
+              onPresetQuantity={(qty) => handleFletch(selectedRecipe, qty)}
+              allQuantity={-1}
+              onShowCustomInput={() => setShowQuantityInput(true)}
+            />
+          </SkillingSection>
+        ) : null}
       </div>
-    </div>
+    </SkillingPanelBody>
   );
 }

--- a/packages/client/src/game/panels/SmeltingPanel.tsx
+++ b/packages/client/src/game/panels/SmeltingPanel.tsx
@@ -11,8 +11,14 @@
 import React, { useState } from "react";
 import type { ClientWorld } from "../../types";
 import { useThemeStore } from "@/ui";
-import { getPanelHeaderStyle, getPanelSurfaceStyle } from "@/ui/theme/themes";
 import { formatItemName } from "@/utils";
+import {
+  getSkillingBadgeStyle,
+  getSkillingSelectableStyle,
+  SkillingPanelBody,
+  SkillingQuantitySelector,
+  SkillingSection,
+} from "./skilling/SkillingPanelShared";
 
 interface SmeltingBar {
   barItemId: string;
@@ -29,9 +35,6 @@ interface SmeltingPanelProps {
   onClose: () => void;
 }
 
-/**
- * Get icon for bar/ore type
- */
 function getItemIcon(itemId: string): string {
   const id = itemId.toLowerCase();
   if (id.includes("bronze")) return "🟤";
@@ -47,7 +50,6 @@ function getItemIcon(itemId: string): string {
   return "🔶";
 }
 
-/** localStorage key for Make X memory */
 const SMELTING_LAST_X_KEY = "smelting_last_x";
 
 export function SmeltingPanel({
@@ -61,7 +63,6 @@ export function SmeltingPanel({
   const [showQuantityInput, setShowQuantityInput] = useState(false);
   const [customQuantity, setCustomQuantity] = useState("");
 
-  // Make X memory - remember last custom quantity (OSRS feature)
   const [lastCustomQuantity, setLastCustomQuantity] = useState(() => {
     try {
       const stored = localStorage.getItem(SMELTING_LAST_X_KEY);
@@ -83,13 +84,11 @@ export function SmeltingPanel({
   };
 
   const handleCustomQuantitySubmit = () => {
-    // Use entered quantity, or fall back to last X if empty (OSRS behavior)
     const qty = customQuantity.trim()
       ? parseInt(customQuantity, 10)
       : lastCustomQuantity;
 
     if (qty > 0 && selectedBar) {
-      // Save to localStorage for Make X memory (only if custom value entered)
       if (customQuantity.trim()) {
         try {
           localStorage.setItem(SMELTING_LAST_X_KEY, String(qty));
@@ -105,216 +104,114 @@ export function SmeltingPanel({
   };
 
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center z-[2000] pointer-events-auto"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <SkillingPanelBody
+      theme={theme}
+      intro="Choose a bar to review its ore mix and smithing requirement before smelting a batch."
+      emptyMessage={
+        availableBars.length === 0
+          ? "You don't have the materials to smelt anything."
+          : undefined
+      }
     >
-      <div
-        className="rounded-lg shadow-2xl border"
-        style={{
-          ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-          minWidth: "320px",
-          maxWidth: "400px",
-        }}
-      >
-        {/* Header */}
-        <div
-          className="flex items-center justify-between px-3 py-2 border-b"
-          style={{
-            ...getPanelHeaderStyle(theme),
-            borderColor: theme.colors.border.decorative,
-          }}
-        >
-          <div className="flex items-center gap-2">
-            <span className="text-lg">🔥</span>
-            <span
-              className="font-semibold text-sm"
-              style={{ color: theme.colors.accent.primary }}
-            >
-              Smelting
-            </span>
-          </div>
-          <button
-            onClick={onClose}
-            className="w-6 h-6 flex items-center justify-center rounded hover:bg-red-900/50 transition-colors"
-            style={{ color: theme.colors.accent.primary }}
+      <div className="flex flex-col gap-3">
+        <SkillingSection theme={theme}>
+          <div
+            className="mb-2 text-xs font-medium"
+            style={{ color: theme.colors.text.secondary }}
           >
-            ×
-          </button>
-        </div>
+            Select a bar to smelt:
+          </div>
 
-        {/* Content */}
-        <div className="p-3">
-          {availableBars.length === 0 ? (
-            <div
-              className="text-center py-4 text-sm"
-              style={{ color: theme.colors.text.secondary }}
-            >
-              You don't have the materials to smelt anything.
-            </div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              <div
-                className="text-xs mb-1"
-                style={{ color: theme.colors.text.secondary }}
-              >
-                Select a bar to smelt:
-              </div>
-
-              {/* Bar List */}
-              <div className="flex flex-col gap-1 max-h-60 overflow-y-auto">
-                {availableBars.map((bar) => (
-                  <button
-                    key={bar.barItemId}
-                    onClick={() => setSelectedBar(bar)}
-                    className={`flex items-center gap-2 p-2 rounded border transition-all ${
-                      selectedBar?.barItemId === bar.barItemId
-                        ? "ring-2 ring-yellow-500"
-                        : ""
-                    }`}
-                    style={{
-                      background:
-                        selectedBar?.barItemId === bar.barItemId
-                          ? `${theme.colors.accent.primary}15`
-                          : theme.colors.background.tertiary,
-                      borderColor:
-                        selectedBar?.barItemId === bar.barItemId
-                          ? `${theme.colors.accent.primary}50`
-                          : theme.colors.border.default,
-                    }}
-                  >
-                    {/* Bar Icon */}
-                    <span className="text-xl">
-                      {getItemIcon(bar.barItemId)}
-                    </span>
-
-                    {/* Bar Info */}
-                    <div className="flex-1 text-left">
-                      <div
-                        className="font-medium text-sm"
-                        style={{ color: theme.colors.accent.primary }}
-                      >
-                        {formatItemName(bar.barItemId)}
-                      </div>
-                      <div
-                        className="text-[10px]"
-                        style={{ color: theme.colors.text.muted }}
-                      >
-                        {formatItemName(bar.primaryOre)}
-                        {bar.secondaryOre &&
-                          ` + ${formatItemName(bar.secondaryOre)}`}
-                        {bar.coalRequired > 0 && ` + ${bar.coalRequired} Coal`}
-                      </div>
-                    </div>
-
-                    {/* Level Requirement */}
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        background: theme.colors.background.panelSecondary,
-                        color: theme.colors.text.secondary,
-                      }}
-                    >
-                      Lv {bar.levelRequired}
-                    </div>
-                  </button>
-                ))}
-              </div>
-
-              {/* Quantity Selection */}
-              {selectedBar && (
-                <div
-                  className="mt-2 pt-2"
-                  style={{
-                    borderTop: `1px solid ${theme.colors.border.default}`,
-                  }}
+          <div className="flex max-h-[20rem] flex-col gap-2 overflow-y-auto pr-1">
+            {availableBars.map((bar) => {
+              const isSelected = selectedBar?.barItemId === bar.barItemId;
+              return (
+                <button
+                  key={bar.barItemId}
+                  onClick={() => setSelectedBar(bar)}
+                  className="flex items-center gap-3 rounded-xl border p-3 text-left transition-all"
+                  style={getSkillingSelectableStyle(theme, isSelected)}
                 >
-                  <div
-                    className="text-xs mb-2"
-                    style={{ color: theme.colors.text.secondary }}
-                  >
-                    How many?
+                  <span className="text-xl">{getItemIcon(bar.barItemId)}</span>
+
+                  <div className="min-w-0 flex-1">
+                    <div
+                      className="text-sm font-semibold"
+                      style={{ color: theme.colors.accent.primary }}
+                    >
+                      {formatItemName(bar.barItemId)}
+                    </div>
+                    <div
+                      className="mt-1 text-[10px]"
+                      style={{ color: theme.colors.text.muted }}
+                    >
+                      {formatItemName(bar.primaryOre)}
+                      {bar.secondaryOre &&
+                        ` + ${formatItemName(bar.secondaryOre)}`}
+                      {bar.coalRequired > 0 && ` + ${bar.coalRequired} Coal`}
+                    </div>
                   </div>
 
-                  {showQuantityInput ? (
-                    <div className="flex gap-2">
-                      <input
-                        type="number"
-                        value={customQuantity}
-                        onChange={(e) => setCustomQuantity(e.target.value)}
-                        className="flex-1 px-2 py-1 rounded text-sm"
-                        style={{
-                          background: theme.colors.background.panelSecondary,
-                          border: `1px solid ${theme.colors.border.default}`,
-                          color: theme.colors.accent.primary,
-                        }}
-                        placeholder={`Amount (last: ${lastCustomQuantity})`}
-                        autoFocus
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") handleCustomQuantitySubmit();
-                          if (e.key === "Escape") setShowQuantityInput(false);
-                        }}
-                      />
-                      <button
-                        onClick={handleCustomQuantitySubmit}
-                        className="px-3 py-1 rounded text-sm font-medium transition-colors"
-                        style={{
-                          background: `${theme.colors.state.success}30`,
-                          border: `1px solid ${theme.colors.state.success}50`,
-                          color: theme.colors.state.success,
-                        }}
-                      >
-                        OK
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="flex gap-1">
-                      {[1, 5, 10].map((qty) => (
-                        <button
-                          key={qty}
-                          onClick={() => handleSmelt(selectedBar, qty)}
-                          className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                          style={{
-                            background: `${theme.colors.accent.primary}20`,
-                            border: `1px solid ${theme.colors.accent.primary}30`,
-                            color: theme.colors.accent.primary,
-                          }}
-                        >
-                          {qty}
-                        </button>
-                      ))}
-                      <button
-                        onClick={() => handleSmelt(selectedBar, 28)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        All
-                      </button>
-                      <button
-                        onClick={() => setShowQuantityInput(true)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        X
-                      </button>
-                    </div>
-                  )}
+                  <div
+                    className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                    style={getSkillingBadgeStyle(theme)}
+                  >
+                    Lv {bar.levelRequired}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </SkillingSection>
+
+        {selectedBar ? (
+          <SkillingSection theme={theme}>
+            <div className="mb-3 flex items-start gap-3">
+              <span className="text-2xl">
+                {getItemIcon(selectedBar.barItemId)}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: theme.colors.accent.primary }}
+                >
+                  {formatItemName(selectedBar.barItemId)}
                 </div>
-              )}
+                <div
+                  className="mt-1 text-xs"
+                  style={{ color: theme.colors.text.secondary }}
+                >
+                  {formatItemName(selectedBar.primaryOre)}
+                  {selectedBar.secondaryOre &&
+                    ` + ${formatItemName(selectedBar.secondaryOre)}`}
+                  {selectedBar.coalRequired > 0 &&
+                    ` + ${selectedBar.coalRequired} Coal`}
+                </div>
+              </div>
             </div>
-          )}
-        </div>
+
+            <div
+              className="mb-2 text-xs font-medium"
+              style={{ color: theme.colors.text.secondary }}
+            >
+              How many?
+            </div>
+
+            <SkillingQuantitySelector
+              theme={theme}
+              showCustomInput={showQuantityInput}
+              customQuantity={customQuantity}
+              lastCustomQuantity={lastCustomQuantity}
+              onCustomQuantityChange={setCustomQuantity}
+              onCustomSubmit={handleCustomQuantitySubmit}
+              onCancelCustomInput={() => setShowQuantityInput(false)}
+              onPresetQuantity={(qty) => handleSmelt(selectedBar, qty)}
+              allQuantity={28}
+              onShowCustomInput={() => setShowQuantityInput(true)}
+            />
+          </SkillingSection>
+        ) : null}
       </div>
-    </div>
+    </SkillingPanelBody>
   );
 }

--- a/packages/client/src/game/panels/SmithingPanel.tsx
+++ b/packages/client/src/game/panels/SmithingPanel.tsx
@@ -12,8 +12,14 @@
 import React, { useState, useMemo } from "react";
 import type { ClientWorld } from "../../types";
 import { useThemeStore } from "@/ui";
-import { getPanelHeaderStyle, getPanelSurfaceStyle } from "@/ui/theme/themes";
 import { formatItemName } from "@/utils";
+import {
+  getSkillingBadgeStyle,
+  getSkillingSelectableStyle,
+  SkillingPanelBody,
+  SkillingQuantitySelector,
+  SkillingSection,
+} from "./skilling/SkillingPanelShared";
 
 interface SmithingRecipe {
   itemId: string;
@@ -187,249 +193,123 @@ export function SmithingPanel({
   };
 
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center z-[2000] pointer-events-auto"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <SkillingPanelBody
+      theme={theme}
+      intro="Choose an anvil recipe to preview its bar cost, smithing level, and XP before starting a batch."
+      emptyMessage={
+        availableRecipes.length === 0
+          ? "You don't have the bars to smith anything."
+          : undefined
+      }
     >
-      <div
-        className="rounded-lg shadow-2xl border"
-        style={{
-          ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-          minWidth: "380px",
-          maxWidth: "480px",
-          maxHeight: "80vh",
-        }}
-      >
-        {/* Header */}
-        <div
-          className="flex items-center justify-between px-3 py-2 border-b"
-          style={{
-            ...getPanelHeaderStyle(theme),
-            borderColor: theme.colors.border.decorative,
-          }}
-        >
-          <div className="flex items-center gap-2">
-            <span className="text-lg">🔨</span>
-            <span
-              className="font-semibold text-sm"
-              style={{ color: theme.colors.accent.primary }}
-            >
-              Smithing
-            </span>
-          </div>
-          <button
-            onClick={onClose}
-            className="w-6 h-6 flex items-center justify-center rounded hover:bg-red-900/50 transition-colors"
-            style={{ color: theme.colors.accent.primary }}
-          >
-            ×
-          </button>
-        </div>
-
-        {/* Content */}
-        <div
-          className="p-3 overflow-y-auto"
-          style={{ maxHeight: "calc(80vh - 100px)" }}
-        >
-          {availableRecipes.length === 0 ? (
+      <div className="flex flex-col gap-3">
+        {groupedRecipes.map(([category, recipes]) => (
+          <SkillingSection key={category} theme={theme}>
             <div
-              className="text-center py-4 text-sm"
-              style={{ color: theme.colors.text.secondary }}
+              className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+              style={{ color: theme.colors.text.muted }}
             >
-              You don't have the bars to smith anything.
+              {category}
             </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              {groupedRecipes.map(([category, recipes]) => (
-                <div key={category}>
-                  {/* Category Header */}
-                  <div
-                    className="text-xs font-semibold uppercase tracking-wider mb-1.5 px-1"
-                    style={{ color: theme.colors.text.muted }}
+
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              {recipes.map((recipe) => {
+                const isSelected = selectedRecipe?.itemId === recipe.itemId;
+                return (
+                  <button
+                    key={recipe.itemId}
+                    onClick={() => setSelectedRecipe(recipe)}
+                    className="flex items-center gap-3 rounded-xl border p-3 text-left transition-all"
+                    style={getSkillingSelectableStyle(theme, isSelected)}
                   >
-                    {category}
-                  </div>
-
-                  {/* Recipe Grid */}
-                  <div className="grid grid-cols-2 gap-1">
-                    {recipes.map((recipe) => (
-                      <button
-                        key={recipe.itemId}
-                        onClick={() => setSelectedRecipe(recipe)}
-                        className={`flex items-center gap-2 p-2 rounded border transition-all text-left ${
-                          selectedRecipe?.itemId === recipe.itemId
-                            ? "ring-2 ring-yellow-500"
-                            : ""
-                        }`}
-                        style={{
-                          background:
-                            selectedRecipe?.itemId === recipe.itemId
-                              ? `${theme.colors.accent.primary}15`
-                              : theme.colors.background.tertiary,
-                          borderColor:
-                            selectedRecipe?.itemId === recipe.itemId
-                              ? `${theme.colors.accent.primary}50`
-                              : theme.colors.border.default,
-                        }}
-                      >
-                        {/* Item Icon */}
-                        <span className="text-lg">
-                          {getItemIcon(recipe.itemId, recipe.category)}
-                        </span>
-
-                        {/* Item Info */}
-                        <div className="flex-1 min-w-0">
-                          <div
-                            className="font-medium text-xs truncate"
-                            style={{ color: theme.colors.accent.primary }}
-                          >
-                            {recipe.name || formatItemName(recipe.itemId)}
-                            {recipe.outputQuantity && recipe.outputQuantity > 1
-                              ? ` (x${recipe.outputQuantity})`
-                              : ""}
-                          </div>
-                          <div
-                            className="text-[9px] flex items-center gap-1"
-                            style={{ color: theme.colors.text.muted }}
-                          >
-                            <span>{getBarIcon(recipe.barType)}</span>
-                            <span>×{recipe.barsRequired}</span>
-                            <span className="mx-0.5">|</span>
-                            <span>Lv{recipe.levelRequired}</span>
-                          </div>
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              ))}
-
-              {/* Selected Recipe Details & Quantity */}
-              {selectedRecipe && (
-                <div
-                  className="mt-2 pt-3"
-                  style={{
-                    borderTop: `1px solid ${theme.colors.border.default}`,
-                  }}
-                >
-                  {/* Recipe Details */}
-                  <div className="flex items-center gap-3 mb-3">
-                    <span className="text-2xl">
-                      {getItemIcon(
-                        selectedRecipe.itemId,
-                        selectedRecipe.category,
-                      )}
+                    <span className="text-xl">
+                      {getItemIcon(recipe.itemId, recipe.category)}
                     </span>
-                    <div>
+
+                    <div className="flex-1 min-w-0">
                       <div
-                        className="font-semibold text-sm"
+                        className="truncate text-sm font-semibold"
                         style={{ color: theme.colors.accent.primary }}
                       >
-                        {selectedRecipe.name ||
-                          formatItemName(selectedRecipe.itemId)}
-                        {selectedRecipe.outputQuantity &&
-                        selectedRecipe.outputQuantity > 1
-                          ? ` (x${selectedRecipe.outputQuantity})`
+                        {recipe.name || formatItemName(recipe.itemId)}
+                        {recipe.outputQuantity && recipe.outputQuantity > 1
+                          ? ` (x${recipe.outputQuantity})`
                           : ""}
                       </div>
                       <div
-                        className="text-xs"
-                        style={{ color: theme.colors.text.secondary }}
+                        className="mt-1 flex items-center gap-1 text-[10px]"
+                        style={{ color: theme.colors.text.muted }}
                       >
-                        {selectedRecipe.barsRequired}×{" "}
-                        {formatItemName(selectedRecipe.barType)} |{" "}
-                        {selectedRecipe.xp} XP
+                        <span>{getBarIcon(recipe.barType)}</span>
+                        <span>×{recipe.barsRequired}</span>
+                        <span className="mx-1">•</span>
+                        <span>Lv {recipe.levelRequired}</span>
+                        <span className="mx-1">•</span>
+                        <span>{recipe.xp} XP</span>
                       </div>
                     </div>
-                  </div>
-
-                  {/* Quantity Selection */}
-                  <div
-                    className="text-xs mb-2"
-                    style={{ color: theme.colors.text.secondary }}
-                  >
-                    How many?
-                  </div>
-
-                  {showQuantityInput ? (
-                    <div className="flex gap-2">
-                      <input
-                        type="number"
-                        value={customQuantity}
-                        onChange={(e) => setCustomQuantity(e.target.value)}
-                        className="flex-1 px-2 py-1 rounded text-sm"
-                        style={{
-                          background: theme.colors.background.panelSecondary,
-                          border: `1px solid ${theme.colors.border.default}`,
-                          color: theme.colors.accent.primary,
-                        }}
-                        placeholder={`Amount (last: ${lastCustomQuantity})`}
-                        autoFocus
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") handleCustomQuantitySubmit();
-                          if (e.key === "Escape") setShowQuantityInput(false);
-                        }}
-                      />
-                      <button
-                        onClick={handleCustomQuantitySubmit}
-                        className="px-3 py-1 rounded text-sm font-medium transition-colors"
-                        style={{
-                          background: `${theme.colors.state.success}30`,
-                          border: `1px solid ${theme.colors.state.success}50`,
-                          color: theme.colors.state.success,
-                        }}
-                      >
-                        OK
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="flex gap-1">
-                      {[1, 5, 10].map((qty) => (
-                        <button
-                          key={qty}
-                          onClick={() => handleSmith(selectedRecipe, qty)}
-                          className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                          style={{
-                            background: `${theme.colors.accent.primary}20`,
-                            border: `1px solid ${theme.colors.accent.primary}30`,
-                            color: theme.colors.accent.primary,
-                          }}
-                        >
-                          {qty}
-                        </button>
-                      ))}
-                      <button
-                        onClick={() => handleSmith(selectedRecipe, 28)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        All
-                      </button>
-                      <button
-                        onClick={() => setShowQuantityInput(true)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        X
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
+                  </button>
+                );
+              })}
             </div>
-          )}
-        </div>
+          </SkillingSection>
+        ))}
+
+        {selectedRecipe ? (
+          <SkillingSection theme={theme}>
+            <div className="mb-3 flex items-start gap-3">
+              <span className="text-2xl">
+                {getItemIcon(selectedRecipe.itemId, selectedRecipe.category)}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: theme.colors.accent.primary }}
+                >
+                  {selectedRecipe.name || formatItemName(selectedRecipe.itemId)}
+                  {selectedRecipe.outputQuantity &&
+                  selectedRecipe.outputQuantity > 1
+                    ? ` (x${selectedRecipe.outputQuantity})`
+                    : ""}
+                </div>
+                <div
+                  className="mt-1 text-xs"
+                  style={{ color: theme.colors.text.secondary }}
+                >
+                  {selectedRecipe.barsRequired}x{" "}
+                  {formatItemName(selectedRecipe.barType)} needed
+                </div>
+              </div>
+              <div
+                className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                style={getSkillingBadgeStyle(theme)}
+              >
+                {selectedRecipe.xp} XP
+              </div>
+            </div>
+
+            <div
+              className="mb-2 text-xs font-medium"
+              style={{ color: theme.colors.text.secondary }}
+            >
+              How many?
+            </div>
+
+            <SkillingQuantitySelector
+              theme={theme}
+              showCustomInput={showQuantityInput}
+              customQuantity={customQuantity}
+              lastCustomQuantity={lastCustomQuantity}
+              onCustomQuantityChange={setCustomQuantity}
+              onCustomSubmit={handleCustomQuantitySubmit}
+              onCancelCustomInput={() => setShowQuantityInput(false)}
+              onPresetQuantity={(qty) => handleSmith(selectedRecipe, qty)}
+              allQuantity={28}
+              onShowCustomInput={() => setShowQuantityInput(true)}
+            />
+          </SkillingSection>
+        ) : null}
       </div>
-    </div>
+    </SkillingPanelBody>
   );
 }

--- a/packages/client/src/game/panels/TanningPanel.tsx
+++ b/packages/client/src/game/panels/TanningPanel.tsx
@@ -11,8 +11,14 @@
 import React, { useState } from "react";
 import type { ClientWorld } from "../../types";
 import { useThemeStore } from "@/ui";
-import { getPanelSurfaceStyle } from "@/ui/theme/themes";
 import { formatItemName } from "@/utils";
+import {
+  getSkillingBadgeStyle,
+  getSkillingSelectableStyle,
+  SkillingPanelBody,
+  SkillingQuantitySelector,
+  SkillingSection,
+} from "./skilling/SkillingPanelShared";
 
 interface TanningRecipe {
   input: string;
@@ -29,9 +35,6 @@ interface TanningPanelProps {
   onClose: () => void;
 }
 
-/**
- * Get icon for tanning item
- */
 function getHideIcon(input: string): string {
   const id = input.toLowerCase();
   if (id.includes("dragon")) return "🐉";
@@ -39,7 +42,6 @@ function getHideIcon(input: string): string {
   return "🧶";
 }
 
-/** localStorage key for Make X memory */
 const TANNING_LAST_X_KEY = "tanning_last_x";
 
 export function TanningPanel({
@@ -54,7 +56,6 @@ export function TanningPanel({
   const [showQuantityInput, setShowQuantityInput] = useState(false);
   const [customQuantity, setCustomQuantity] = useState("");
 
-  // Make X memory - remember last custom quantity (OSRS feature)
   const [lastCustomQuantity, setLastCustomQuantity] = useState(() => {
     try {
       const stored = localStorage.getItem(TANNING_LAST_X_KEY);
@@ -95,76 +96,49 @@ export function TanningPanel({
   };
 
   return (
-    <div
-      className="rounded-lg shadow-2xl border"
-      style={{
-        ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
-        minWidth: "320px",
-        maxWidth: "400px",
-      }}
+    <SkillingPanelBody
+      theme={theme}
+      intro="Select a hide to see its leather result, cost, and how many you can process from your current inventory."
+      emptyMessage={
+        availableRecipes.length === 0
+          ? "No hides available for tanning."
+          : undefined
+      }
     >
-      {/* Content */}
-      <div
-        className="p-3"
-        style={{
-          background:
-            theme.name === "hyperscape"
-              ? "linear-gradient(180deg, rgba(255, 255, 255, 0.015) 0%, rgba(0, 0, 0, 0.12) 100%)"
-              : "transparent",
-        }}
-      >
-        {availableRecipes.length === 0 ? (
+      <div className="flex flex-col gap-3">
+        <SkillingSection theme={theme}>
           <div
-            className="text-center py-4 text-sm"
+            className="mb-2 text-xs font-medium"
             style={{ color: theme.colors.text.secondary }}
           >
-            No hides available for tanning.
+            Select a hide to tan:
           </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <div
-              className="text-xs mb-1"
-              style={{ color: theme.colors.text.secondary }}
-            >
-              Select a hide to tan:
-            </div>
 
-            {/* Recipe List */}
-            <div className="flex flex-col gap-1 max-h-60 overflow-y-auto">
-              {availableRecipes.map((recipe) => (
+          <div className="flex max-h-[20rem] flex-col gap-2 overflow-y-auto pr-1">
+            {availableRecipes.map((recipe) => {
+              const isSelected = selectedRecipe?.input === recipe.input;
+              return (
                 <button
                   key={recipe.input}
                   onClick={() => setSelectedRecipe(recipe)}
-                  className={`flex items-center gap-2 p-2 rounded border transition-all ${
-                    selectedRecipe?.input === recipe.input
-                      ? "ring-2 ring-yellow-500"
-                      : ""
-                  }`}
-                  style={{
-                    background:
-                      selectedRecipe?.input === recipe.input
-                        ? `${theme.colors.accent.primary}15`
-                        : theme.colors.background.tertiary,
-                    borderColor:
-                      selectedRecipe?.input === recipe.input
-                        ? `${theme.colors.accent.primary}50`
-                        : theme.colors.border.default,
-                    opacity: recipe.hasHide ? 1 : 0.5,
-                  }}
+                  className="flex items-center gap-3 rounded-xl border p-3 text-left transition-all"
+                  style={getSkillingSelectableStyle(
+                    theme,
+                    isSelected,
+                    !recipe.hasHide,
+                  )}
                 >
-                  {/* Hide Icon */}
                   <span className="text-xl">{getHideIcon(recipe.input)}</span>
 
-                  {/* Recipe Info */}
-                  <div className="flex-1 text-left">
+                  <div className="min-w-0 flex-1">
                     <div
-                      className="font-medium text-sm"
+                      className="text-sm font-semibold"
                       style={{ color: theme.colors.accent.primary }}
                     >
                       {recipe.name || formatItemName(recipe.output)}
                     </div>
                     <div
-                      className="text-[10px]"
+                      className="mt-1 text-[10px]"
                       style={{ color: theme.colors.text.muted }}
                     >
                       {formatItemName(recipe.input)}
@@ -173,111 +147,70 @@ export function TanningPanel({
                     </div>
                   </div>
 
-                  {/* Cost */}
                   <div
-                    className="text-xs px-2 py-1 rounded"
-                    style={{
-                      background: theme.colors.background.panelSecondary,
-                      color: theme.colors.text.secondary,
-                    }}
+                    className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                    style={getSkillingBadgeStyle(theme)}
                   >
                     {recipe.cost} gp
                   </div>
                 </button>
-              ))}
-            </div>
+              );
+            })}
+          </div>
+        </SkillingSection>
 
-            {/* Quantity Selection */}
-            {selectedRecipe && (
-              <div
-                className="mt-2 pt-2"
-                style={{
-                  borderTop: `1px solid ${theme.colors.border.default}`,
-                }}
-              >
+        {selectedRecipe ? (
+          <SkillingSection theme={theme}>
+            <div className="mb-3 flex items-start gap-3">
+              <span className="text-2xl">
+                {getHideIcon(selectedRecipe.input)}
+              </span>
+              <div className="min-w-0 flex-1">
                 <div
-                  className="text-xs mb-2"
+                  className="text-sm font-semibold"
+                  style={{ color: theme.colors.accent.primary }}
+                >
+                  {selectedRecipe.name || formatItemName(selectedRecipe.output)}
+                </div>
+                <div
+                  className="mt-1 text-xs"
                   style={{ color: theme.colors.text.secondary }}
                 >
-                  How many?
+                  {formatItemName(selectedRecipe.input)}
+                  {selectedRecipe.hideCount > 0 &&
+                    ` (${selectedRecipe.hideCount} in inventory)`}
                 </div>
-
-                {showQuantityInput ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="number"
-                      value={customQuantity}
-                      onChange={(e) => setCustomQuantity(e.target.value)}
-                      className="flex-1 px-2 py-1 rounded text-sm"
-                      style={{
-                        background: theme.colors.background.panelSecondary,
-                        border: `1px solid ${theme.colors.border.default}`,
-                        color: theme.colors.accent.primary,
-                      }}
-                      placeholder={`Amount (last: ${lastCustomQuantity})`}
-                      autoFocus
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleCustomQuantitySubmit();
-                        if (e.key === "Escape") setShowQuantityInput(false);
-                      }}
-                    />
-                    <button
-                      onClick={handleCustomQuantitySubmit}
-                      className="px-3 py-1 rounded text-sm font-medium transition-colors"
-                      style={{
-                        background: `${theme.colors.state.success}30`,
-                        border: `1px solid ${theme.colors.state.success}50`,
-                        color: theme.colors.state.success,
-                      }}
-                    >
-                      OK
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex gap-1">
-                    {[1, 5, 10].map((qty) => (
-                      <button
-                        key={qty}
-                        onClick={() => handleTan(selectedRecipe, qty)}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                        style={{
-                          background: `${theme.colors.accent.primary}20`,
-                          border: `1px solid ${theme.colors.accent.primary}30`,
-                          color: theme.colors.accent.primary,
-                        }}
-                      >
-                        {qty}
-                      </button>
-                    ))}
-                    <button
-                      onClick={() => handleTan(selectedRecipe, -1)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      All
-                    </button>
-                    <button
-                      onClick={() => setShowQuantityInput(true)}
-                      className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors hover:brightness-110"
-                      style={{
-                        background: `${theme.colors.accent.primary}20`,
-                        border: `1px solid ${theme.colors.accent.primary}30`,
-                        color: theme.colors.accent.primary,
-                      }}
-                    >
-                      X
-                    </button>
-                  </div>
-                )}
               </div>
-            )}
-          </div>
-        )}
+              <div
+                className="rounded-full px-2.5 py-1 text-[11px] font-medium"
+                style={getSkillingBadgeStyle(theme)}
+              >
+                {selectedRecipe.cost} gp
+              </div>
+            </div>
+
+            <div
+              className="mb-2 text-xs font-medium"
+              style={{ color: theme.colors.text.secondary }}
+            >
+              How many?
+            </div>
+
+            <SkillingQuantitySelector
+              theme={theme}
+              showCustomInput={showQuantityInput}
+              customQuantity={customQuantity}
+              lastCustomQuantity={lastCustomQuantity}
+              onCustomQuantityChange={setCustomQuantity}
+              onCustomSubmit={handleCustomQuantitySubmit}
+              onCancelCustomInput={() => setShowQuantityInput(false)}
+              onPresetQuantity={(qty) => handleTan(selectedRecipe, qty)}
+              allQuantity={-1}
+              onShowCustomInput={() => setShowQuantityInput(true)}
+            />
+          </SkillingSection>
+        ) : null}
       </div>
-    </div>
+    </SkillingPanelBody>
   );
 }

--- a/packages/client/src/game/panels/dialogue/DialogueCharacterPortrait.tsx
+++ b/packages/client/src/game/panels/dialogue/DialogueCharacterPortrait.tsx
@@ -1,0 +1,426 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Emotes, EventType, THREE } from "@hyperscape/shared";
+import type { VRM } from "@pixiv/three-vrm";
+import { useThemeStore } from "@/ui";
+import { createAvatarPreviewViewport } from "@/game/character/avatarPreviewViewport";
+import { ThreeResourceManager } from "@/lib/ThreeResourceManager";
+import type { ClientWorld } from "../../../types";
+
+type PortraitMode = "loading" | "live" | "fallback";
+
+interface DialogueCharacterPortraitProps {
+  world: ClientWorld;
+  npcEntityId?: string;
+  npcName: string;
+  className?: string;
+}
+
+interface PreviewAvatarScene {
+  scene?: THREE.Object3D & {
+    visible?: boolean;
+    userData?: {
+      vrm?: VRM;
+    };
+  };
+  userData?: {
+    vrm?: VRM;
+  };
+}
+
+interface PreviewAvatarInstance {
+  update(delta: number): void;
+  raw: PreviewAvatarScene;
+  disableRateCheck?: () => void;
+  setEmote?: (emote: string) => void;
+  setEmoteAndWait?: (emote: string, timeoutMs?: number) => Promise<void>;
+}
+
+interface PreviewAvatarNode {
+  instance: PreviewAvatarInstance | null;
+  mount?: () => Promise<void>;
+  position: THREE.Vector3;
+  visible: boolean;
+  parent: { matrixWorld: THREE.Matrix4 };
+  activate(ctx: ClientWorld): void;
+  deactivate?: () => void;
+}
+
+function getPreviewVRM(instance: PreviewAvatarInstance | null): VRM | null {
+  if (!instance?.raw) {
+    return null;
+  }
+
+  const rawScene = instance.raw.scene;
+  const fromUserData = rawScene?.userData?.vrm ?? instance.raw.userData?.vrm;
+  if (fromUserData?.scene && fromUserData.humanoid) {
+    return fromUserData;
+  }
+
+  const rawCandidate = instance.raw as unknown as VRM;
+  if (rawCandidate.scene && rawCandidate.humanoid) {
+    return rawCandidate;
+  }
+
+  return null;
+}
+
+function frameDialogueAvatar(
+  avatarRoot: THREE.Object3D,
+  camera: THREE.PerspectiveCamera,
+  baseStateRef?: React.MutableRefObject<{
+    camY: number;
+    lookY: number;
+    distance: number;
+    center: THREE.Vector3;
+  } | null>,
+) {
+  if (baseStateRef?.current) {
+    const { camY, lookY, distance, center } = baseStateRef.current;
+    camera.position.set(center.x, camY, -distance);
+    camera.lookAt(center.x, lookY, center.z);
+    return;
+  }
+
+  avatarRoot.updateMatrixWorld(true);
+  const box = new THREE.Box3().setFromObject(avatarRoot);
+
+  if (box.isEmpty()) {
+    camera.position.set(0, 1.58, 1.02);
+    camera.lookAt(0, 1.44, 0);
+    return;
+  }
+
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  const height = Math.max(size.y, 1.6);
+  const width = Math.max(size.x, 0.7);
+  const lookY = center.y + height * 0.29;
+  const camY = lookY + height * 0.035;
+  const distance = Math.max(0.86, height * 0.42, width * 0.95);
+
+  if (baseStateRef) {
+    baseStateRef.current = { camY, lookY, distance, center: center.clone() };
+  }
+
+  camera.position.set(center.x, camY, -distance);
+  camera.lookAt(center.x, lookY, center.z);
+  camera.near = 0.1;
+  camera.far = Math.max(10, distance + height * 2.5);
+  camera.updateProjectionMatrix();
+}
+
+function PortraitFallback({
+  npcName,
+  mode,
+}: {
+  npcName: string;
+  mode: PortraitMode;
+}) {
+  const theme = useThemeStore((s) => s.theme);
+  const initials = npcName
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex flex-col items-center gap-3">
+        <div
+          className="flex h-24 w-24 items-center justify-center rounded-full border text-2xl font-bold"
+          style={{
+            background:
+              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.1), rgba(12,15,22,0.22) 72%)",
+            borderColor: `${theme.colors.border.decorative}88`,
+            color: theme.colors.accent.primary,
+            boxShadow: "0 12px 26px rgba(0,0,0,0.18)",
+          }}
+        >
+          {initials}
+        </div>
+        <div
+          className="text-center text-[11px] uppercase tracking-[0.18em]"
+          style={{ color: theme.colors.text.muted }}
+        >
+          {mode === "loading" ? "Loading portrait" : "Portrait unavailable"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const DialogueCharacterPortrait = React.memo(
+  function DialogueCharacterPortrait({
+    world,
+    npcEntityId,
+    npcName,
+    className = "",
+  }: DialogueCharacterPortraitProps) {
+    const theme = useThemeStore((s) => s.theme);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const viewportRef = useRef<Awaited<
+      ReturnType<typeof createAvatarPreviewViewport>
+    > | null>(null);
+    const avatarNodeRef = useRef<PreviewAvatarNode | null>(null);
+    const avatarSceneRef = useRef<THREE.Object3D | null>(null);
+    const baseCameraStateRef = useRef<{
+      camY: number;
+      lookY: number;
+      distance: number;
+      center: THREE.Vector3;
+    } | null>(null);
+    const [rendererReady, setRendererReady] = useState(false);
+    const [mode, setMode] = useState<PortraitMode>("loading");
+    const [refreshNonce, setRefreshNonce] = useState(0);
+
+    const modelUrl = useMemo(() => {
+      if (!npcEntityId) {
+        return null;
+      }
+
+      const entity = world.entities.get(npcEntityId);
+      const config =
+        entity && typeof entity === "object"
+          ? (Reflect.get(entity, "config") as { model?: unknown } | undefined)
+          : undefined;
+      const candidate = config?.model;
+      return typeof candidate === "string" && candidate.length > 0
+        ? candidate
+        : null;
+    }, [npcEntityId, refreshNonce, world.entities]);
+
+    const clearPreviewAvatar = () => {
+      const avatarScene = avatarSceneRef.current;
+      const avatarNode = avatarNodeRef.current;
+
+      avatarNode?.deactivate?.();
+
+      if (avatarScene) {
+        ThreeResourceManager.disposeObject(avatarScene, {
+          disposeGeometry: false,
+          disposeTextures: false,
+          disposeMaterial: true,
+          removeFromParent: false,
+        });
+      }
+
+      avatarSceneRef.current = null;
+      avatarNodeRef.current = null;
+      baseCameraStateRef.current = null;
+    };
+
+    useEffect(() => {
+      const container = containerRef.current;
+      const canvas = canvasRef.current;
+
+      if (!container || !canvas) {
+        return;
+      }
+
+      let cancelled = false;
+      let resizeObserver: ResizeObserver | null = null;
+
+      createAvatarPreviewViewport({
+        container,
+        canvas,
+        cameraPosition: new THREE.Vector3(0, 1.45, 1.95),
+        adjustCameraDepth: false,
+        fov: 26,
+      })
+        .then((viewport) => {
+          if (cancelled) {
+            viewport.dispose();
+            return;
+          }
+
+          viewportRef.current = viewport;
+          viewport.start((delta) => {
+            avatarNodeRef.current?.instance?.update(delta);
+          });
+          setRendererReady(true);
+
+          if (typeof ResizeObserver !== "undefined") {
+            resizeObserver = new ResizeObserver(() => viewport.resize());
+            resizeObserver.observe(container);
+          } else {
+            window.addEventListener("resize", viewport.resize);
+          }
+        })
+        .catch((error) => {
+          console.error(
+            "[DialogueCharacterPortrait] Failed to initialize preview viewport:",
+            error,
+          );
+          if (!cancelled) {
+            setMode("fallback");
+            setRendererReady(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+        resizeObserver?.disconnect();
+        if (viewportRef.current) {
+          window.removeEventListener("resize", viewportRef.current.resize);
+        }
+        clearPreviewAvatar();
+        viewportRef.current?.dispose();
+        viewportRef.current = null;
+        setRendererReady(false);
+      };
+    }, []);
+
+    useEffect(() => {
+      const triggerRefresh = () => setRefreshNonce((current) => current + 1);
+      triggerRefresh();
+      world.on(EventType.AVATAR_LOAD_COMPLETE, triggerRefresh, undefined);
+
+      return () => {
+        world.off(
+          EventType.AVATAR_LOAD_COMPLETE,
+          triggerRefresh,
+          undefined,
+          undefined,
+        );
+      };
+    }, [world]);
+
+    useEffect(() => {
+      if (!world || !rendererReady || !viewportRef.current) {
+        return;
+      }
+
+      let cancelled = false;
+
+      const buildPortrait = async () => {
+        const viewport = viewportRef.current;
+        setMode("loading");
+        clearPreviewAvatar();
+
+        if (!modelUrl || !modelUrl.endsWith(".vrm")) {
+          setMode("fallback");
+          return;
+        }
+
+        if (!world.loader || !viewport) {
+          setMode("loading");
+          return;
+        }
+
+        try {
+          const loadedAvatar = (await world.loader.load(
+            "avatar",
+            modelUrl,
+          )) as {
+            toNodes: (
+              customHooks?: Record<string, unknown>,
+            ) => Map<string, unknown>;
+          };
+
+          if (cancelled) {
+            return;
+          }
+
+          const avatarNode = loadedAvatar
+            .toNodes({
+              scene: viewport.scene,
+              loader: world.loader,
+            })
+            .get("avatar") as PreviewAvatarNode | undefined;
+
+          if (!avatarNode) {
+            setMode("fallback");
+            return;
+          }
+
+          avatarNode.parent = { matrixWorld: new THREE.Matrix4() };
+          avatarNode.position.set(0, 0, 0);
+          avatarNode.activate(world);
+          await avatarNode.mount?.();
+
+          if (cancelled) {
+            avatarNode.deactivate?.();
+            return;
+          }
+
+          const avatarInstance = avatarNode.instance;
+          const avatarScene = avatarInstance?.raw?.scene;
+          const vrm = getPreviewVRM(avatarInstance ?? null);
+
+          if (!avatarInstance || !avatarScene || !vrm) {
+            avatarNode.deactivate?.();
+            setMode("fallback");
+            return;
+          }
+
+          avatarNodeRef.current = avatarNode;
+          avatarSceneRef.current = avatarScene;
+          avatarInstance.disableRateCheck?.();
+
+          avatarNode.visible = false;
+          avatarScene.visible = false;
+          avatarScene.rotation.y = Math.PI * 0.06;
+          vrm.scene.rotation.y = Math.PI * 0.06;
+
+          if (avatarInstance.setEmoteAndWait) {
+            await avatarInstance.setEmoteAndWait(Emotes.IDLE, 3000);
+          } else {
+            avatarInstance.setEmote?.(Emotes.IDLE);
+          }
+
+          if (cancelled) {
+            return;
+          }
+
+          avatarNode.visible = true;
+          avatarScene.visible = true;
+          viewport.resize();
+          frameDialogueAvatar(avatarScene, viewport.camera, baseCameraStateRef);
+          setMode("live");
+        } catch (error) {
+          console.error(
+            "[DialogueCharacterPortrait] Failed to build portrait:",
+            error,
+          );
+          if (!cancelled) {
+            setMode("fallback");
+          }
+        }
+      };
+
+      void buildPortrait();
+
+      return () => {
+        cancelled = true;
+        clearPreviewAvatar();
+      };
+    }, [modelUrl, rendererReady, world]);
+
+    return (
+      <div
+        ref={containerRef}
+        className={`relative min-h-[194px] overflow-hidden rounded-xl ${className}`}
+        style={{
+          background:
+            "radial-gradient(circle at 52% 20%, rgba(255,255,255,0.05), transparent 34%), linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(9, 12, 18, 0.03) 22%, rgba(9, 12, 18, 0) 100%)",
+          border: `1px solid ${theme.colors.border.default}40`,
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          className="absolute inset-0 h-full w-full"
+          style={{ display: mode === "live" ? "block" : "none" }}
+        />
+
+        {mode !== "live" ? (
+          <div className="absolute inset-0">
+            <PortraitFallback npcName={npcName} mode={mode} />
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);

--- a/packages/client/src/game/panels/dialogue/DialogueCharacterPortrait.tsx
+++ b/packages/client/src/game/panels/dialogue/DialogueCharacterPortrait.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Emotes, EventType, THREE } from "@hyperscape/shared";
+import {
+  Emotes,
+  EventType,
+  THREE,
+  type EntityConfig,
+} from "@hyperscape/shared";
 import type { VRM } from "@pixiv/three-vrm";
 import { useThemeStore } from "@/ui";
 import { createAvatarPreviewViewport } from "@/game/character/avatarPreviewViewport";
@@ -43,6 +48,18 @@ interface PreviewAvatarNode {
   parent: { matrixWorld: THREE.Matrix4 };
   activate(ctx: ClientWorld): void;
   deactivate?: () => void;
+}
+
+type EntityWithModelConfig = {
+  config?: Pick<EntityConfig, "model">;
+};
+
+function getEntityModelUrl(entity: unknown): string | null {
+  const candidate = (entity as EntityWithModelConfig | undefined)?.config
+    ?.model;
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : null;
 }
 
 function getPreviewVRM(instance: PreviewAvatarInstance | null): VRM | null {
@@ -180,15 +197,7 @@ export const DialogueCharacterPortrait = React.memo(
         return null;
       }
 
-      const entity = world.entities.get(npcEntityId);
-      const config =
-        entity && typeof entity === "object"
-          ? (Reflect.get(entity, "config") as { model?: unknown } | undefined)
-          : undefined;
-      const candidate = config?.model;
-      return typeof candidate === "string" && candidate.length > 0
-        ? candidate
-        : null;
+      return getEntityModelUrl(world.entities.get(npcEntityId));
     }, [npcEntityId, refreshNonce, world.entities]);
 
     const clearPreviewAvatar = () => {
@@ -212,6 +221,8 @@ export const DialogueCharacterPortrait = React.memo(
     };
 
     useEffect(() => {
+      // The preview viewport should be created once per mounted portrait shell.
+      // The effect intentionally closes over refs so renderer state survives prop updates.
       const container = containerRef.current;
       const canvas = canvasRef.current;
 

--- a/packages/client/src/game/panels/dialogue/DialoguePopupShell.tsx
+++ b/packages/client/src/game/panels/dialogue/DialoguePopupShell.tsx
@@ -1,0 +1,173 @@
+import React, {
+  useEffect,
+  useId,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { X } from "lucide-react";
+import { UI, useThemeStore } from "@/ui";
+import {
+  getPanelHeaderStyle,
+  getPanelSurfaceStyle,
+  getShellControlButtonStyle,
+} from "@/ui/theme/themes";
+
+interface DialoguePopupShellProps {
+  visible: boolean;
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+  width?: number | string;
+  maxWidth?: number | string;
+  maxHeight?: number | string;
+  contentStyle?: CSSProperties;
+}
+
+export function DialoguePopupShell({
+  visible,
+  title,
+  children,
+  onClose,
+  width = 700,
+  maxWidth = "min(86vw, 700px)",
+  maxHeight = "min(40vh, 400px)",
+  contentStyle,
+}: DialoguePopupShellProps) {
+  const theme = useThemeStore((s) => s.theme);
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    panelRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, visible]);
+
+  if (!visible) {
+    return null;
+  }
+
+  const closeButtonStyle = {
+    ...getShellControlButtonStyle(theme, "danger"),
+    width: 22,
+    height: 22,
+  } satisfies CSSProperties;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-modal="true"
+      className="fixed inset-0 flex items-end justify-center p-4 md:px-6 md:pt-6"
+      style={{
+        zIndex: UI.Z_INDEX.MODAL,
+        pointerEvents: "auto",
+        paddingBottom: "clamp(2.5rem, 5vh, 4.75rem)",
+      }}
+      onMouseDown={(e) => {
+        (e.nativeEvent as PointerEvent & { isCoreUI?: boolean }).isCoreUI =
+          true;
+      }}
+      onPointerDown={(e) => {
+        (e.nativeEvent as PointerEvent & { isCoreUI?: boolean }).isCoreUI =
+          true;
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onClose();
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        className="relative flex w-full flex-col overflow-hidden outline-none"
+        style={{
+          width,
+          maxWidth,
+          maxHeight,
+          borderRadius: theme.borderRadius.xl,
+          ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
+          boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255, 255, 255, 0.07), inset 0 0 18px rgba(92, 103, 118, 0.05)`,
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <div
+          className="absolute left-1/2 top-0 h-[3px] w-[62%] -translate-x-1/2"
+          style={{
+            background: `linear-gradient(to right, transparent, ${theme.colors.accent.gold}cc, transparent)`,
+          }}
+        />
+
+        <div
+          className="flex items-center justify-between gap-3 px-4 py-1.5 md:px-5 md:py-1.5"
+          style={{
+            ...getPanelHeaderStyle(theme),
+            minHeight: 32,
+          }}
+        >
+          <h2
+            id={titleId}
+            className="m-0 text-[0.9rem] font-bold tracking-[0.005em]"
+            style={{
+              color: theme.colors.text.primary,
+              fontFamily: theme.typography.fontFamily.heading,
+            }}
+          >
+            {title}
+          </h2>
+
+          <button
+            type="button"
+            aria-label="Close dialogue"
+            style={closeButtonStyle}
+            onClick={onClose}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background =
+                "var(--shell-button-hover-bg)" as string;
+              e.currentTarget.style.color =
+                "var(--shell-button-hover-fg)" as string;
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background =
+                closeButtonStyle.background as string;
+              e.currentTarget.style.color = closeButtonStyle.color as string;
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div
+          className="min-h-0 flex-1 overflow-hidden px-3 py-3 md:px-4 md:py-3"
+          style={contentStyle}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/game/panels/dialogue/DialoguePopupShell.tsx
+++ b/packages/client/src/game/panels/dialogue/DialoguePopupShell.tsx
@@ -2,6 +2,7 @@ import React, {
   useEffect,
   useId,
   useRef,
+  useState,
   type CSSProperties,
   type ReactNode,
 } from "react";
@@ -37,6 +38,12 @@ export function DialoguePopupShell({
   const theme = useThemeStore((s) => s.theme);
   const titleId = useId();
   const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const [isCloseHovered, setIsCloseHovered] = useState(false);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     if (!visible) {
@@ -52,12 +59,12 @@ export function DialoguePopupShell({
 
       event.preventDefault();
       event.stopPropagation();
-      onClose();
+      onCloseRef.current();
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, visible]);
+  }, [visible]);
 
   if (!visible) {
     return null;
@@ -68,6 +75,10 @@ export function DialoguePopupShell({
     width: 22,
     height: 22,
   } satisfies CSSProperties;
+  const closeButtonHoverBackground =
+    "var(--shell-button-hover-bg)" as CSSProperties["background"];
+  const closeButtonHoverColor =
+    "var(--shell-button-hover-fg)" as CSSProperties["color"];
 
   return (
     <div
@@ -143,19 +154,18 @@ export function DialoguePopupShell({
           <button
             type="button"
             aria-label="Close dialogue"
-            style={closeButtonStyle}
+            style={{
+              ...closeButtonStyle,
+              background: isCloseHovered
+                ? closeButtonHoverBackground
+                : closeButtonStyle.background,
+              color: isCloseHovered
+                ? closeButtonHoverColor
+                : closeButtonStyle.color,
+            }}
             onClick={onClose}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background =
-                "var(--shell-button-hover-bg)" as string;
-              e.currentTarget.style.color =
-                "var(--shell-button-hover-fg)" as string;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background =
-                closeButtonStyle.background as string;
-              e.currentTarget.style.color = closeButtonStyle.color as string;
-            }}
+            onMouseEnter={() => setIsCloseHovered(true)}
+            onMouseLeave={() => setIsCloseHovered(false)}
           >
             <X size={18} />
           </button>

--- a/packages/client/src/game/panels/skilling/SkillingPanelShared.tsx
+++ b/packages/client/src/game/panels/skilling/SkillingPanelShared.tsx
@@ -1,0 +1,215 @@
+import React from "react";
+import type { CSSProperties, ReactNode } from "react";
+import type { Theme } from "@/ui";
+
+interface SkillingPanelBodyProps {
+  theme: Theme;
+  children?: ReactNode;
+  emptyMessage?: string;
+  intro?: string;
+}
+
+interface SkillingSectionProps {
+  theme: Theme;
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+interface SkillingQuantitySelectorProps {
+  theme: Theme;
+  showCustomInput: boolean;
+  customQuantity: string;
+  lastCustomQuantity: number;
+  onCustomQuantityChange: (value: string) => void;
+  onCustomSubmit: () => void;
+  onCancelCustomInput: () => void;
+  onPresetQuantity: (quantity: number) => void;
+  allQuantity: number;
+  onShowCustomInput: () => void;
+}
+
+export function SkillingPanelBody({
+  theme,
+  children,
+  emptyMessage,
+  intro,
+}: SkillingPanelBodyProps) {
+  return (
+    <div className="flex min-w-0 w-full flex-col gap-3">
+      {intro ? (
+        <p
+          className="text-xs leading-relaxed"
+          style={{ color: theme.colors.text.secondary }}
+        >
+          {intro}
+        </p>
+      ) : null}
+
+      {emptyMessage ? (
+        <div
+          className="rounded-xl border px-4 py-8 text-center text-sm"
+          style={{
+            background: theme.colors.background.panelSecondary,
+            borderColor: theme.colors.border.default,
+            color: theme.colors.text.secondary,
+          }}
+        >
+          {emptyMessage}
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+export function SkillingSection({
+  theme,
+  children,
+  className,
+  style,
+}: SkillingSectionProps) {
+  return (
+    <div
+      className={["rounded-xl border p-3", className].filter(Boolean).join(" ")}
+      style={{
+        background: theme.colors.background.panelSecondary,
+        borderColor: theme.colors.border.default,
+        boxShadow: "inset 0 1px 0 rgba(255, 255, 255, 0.03)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function getSkillingSelectableStyle(
+  theme: Theme,
+  selected: boolean,
+  disabled = false,
+): CSSProperties {
+  return {
+    background: selected
+      ? `${theme.colors.accent.primary}18`
+      : "rgba(8, 10, 14, 0.34)",
+    borderColor: selected
+      ? `${theme.colors.accent.primary}66`
+      : theme.colors.border.default,
+    boxShadow: selected
+      ? `0 0 0 1px ${theme.colors.accent.primary}33 inset`
+      : "none",
+    opacity: disabled ? 0.48 : 1,
+  };
+}
+
+export function getSkillingBadgeStyle(theme: Theme): CSSProperties {
+  return {
+    background: "rgba(6, 8, 12, 0.34)",
+    border: `1px solid ${theme.colors.border.default}`,
+    color: theme.colors.text.secondary,
+  };
+}
+
+export function SkillingQuantitySelector({
+  theme,
+  showCustomInput,
+  customQuantity,
+  lastCustomQuantity,
+  onCustomQuantityChange,
+  onCustomSubmit,
+  onCancelCustomInput,
+  onPresetQuantity,
+  allQuantity,
+  onShowCustomInput,
+}: SkillingQuantitySelectorProps) {
+  if (showCustomInput) {
+    return (
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="number"
+          value={customQuantity}
+          onChange={(e) => onCustomQuantityChange(e.target.value)}
+          className="flex-1 rounded-lg px-3 py-2 text-sm outline-none"
+          style={{
+            background: theme.colors.background.panelPrimary,
+            border: `1px solid ${theme.colors.border.default}`,
+            color: theme.colors.accent.primary,
+          }}
+          placeholder={`Amount (last: ${lastCustomQuantity})`}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onCustomSubmit();
+            if (e.key === "Escape") onCancelCustomInput();
+          }}
+        />
+        <div className="grid grid-cols-2 gap-2 sm:flex">
+          <button
+            onClick={onCustomSubmit}
+            className="rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:brightness-110"
+            style={{
+              background: `${theme.colors.state.success}2b`,
+              border: `1px solid ${theme.colors.state.success}5e`,
+              color: theme.colors.state.success,
+            }}
+          >
+            OK
+          </button>
+          <button
+            onClick={onCancelCustomInput}
+            className="rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:brightness-110"
+            style={{
+              background: `${theme.colors.text.muted}16`,
+              border: `1px solid ${theme.colors.border.default}`,
+              color: theme.colors.text.secondary,
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+      {[1, 5, 10].map((qty) => (
+        <button
+          key={qty}
+          onClick={() => onPresetQuantity(qty)}
+          className="rounded-lg px-2 py-2 text-xs font-semibold transition-colors hover:brightness-110"
+          style={{
+            background: `${theme.colors.accent.primary}1e`,
+            border: `1px solid ${theme.colors.accent.primary}3a`,
+            color: theme.colors.accent.primary,
+          }}
+        >
+          {qty}
+        </button>
+      ))}
+      <button
+        onClick={() => onPresetQuantity(allQuantity)}
+        className="rounded-lg px-2 py-2 text-xs font-semibold transition-colors hover:brightness-110"
+        style={{
+          background: `${theme.colors.accent.primary}1e`,
+          border: `1px solid ${theme.colors.accent.primary}3a`,
+          color: theme.colors.accent.primary,
+        }}
+      >
+        All
+      </button>
+      <button
+        onClick={onShowCustomInput}
+        className="rounded-lg px-2 py-2 text-xs font-semibold transition-colors hover:brightness-110"
+        style={{
+          background: `${theme.colors.accent.primary}1e`,
+          border: `1px solid ${theme.colors.accent.primary}3a`,
+          color: theme.colors.accent.primary,
+        }}
+      >
+        X
+      </button>
+    </div>
+  );
+}

--- a/packages/client/src/hooks/useModalPanels.ts
+++ b/packages/client/src/hooks/useModalPanels.ts
@@ -445,6 +445,7 @@ function handleLegacyEconomyUIUpdate(
         maxSlots: bankUpdate.maxSlots ?? prev?.maxSlots ?? 480,
         bankId: bankUpdate.bankId ?? prev?.bankId ?? "spawn_bank",
       }));
+      setDialogueData(null);
       return;
     }
   }
@@ -468,6 +469,7 @@ function handleLegacyEconomyUIUpdate(
         npcEntityId: storeUpdate.npcEntityId,
         items: storeUpdate.items || [],
       });
+      setDialogueData(null);
     } else {
       setStoreData(null);
     }
@@ -1041,7 +1043,10 @@ export function useModalPanels(world: ClientWorld | null): ModalPanelsState {
     // Bank handlers
     const handleBankOpen = (data: unknown) => {
       const d = data as BankData;
-      if (d) setBankData({ ...d, visible: true });
+      if (d) {
+        setBankData({ ...d, visible: true });
+        setDialogueData(null);
+      }
     };
 
     const handleBankClose = () => setBankData(null);
@@ -1049,7 +1054,10 @@ export function useModalPanels(world: ClientWorld | null): ModalPanelsState {
     // Store handlers
     const handleStoreOpen = (data: unknown) => {
       const d = data as StoreData;
-      if (d) setStoreData({ ...d, visible: true });
+      if (d) {
+        setStoreData({ ...d, visible: true });
+        setDialogueData(null);
+      }
     };
 
     const handleStoreClose = () => setStoreData(null);

--- a/packages/client/src/ui/components/ModalWindow.tsx
+++ b/packages/client/src/ui/components/ModalWindow.tsx
@@ -84,6 +84,8 @@ export interface ModalWindowProps {
   className?: string;
   /** Additional style for the modal container */
   style?: CSSProperties;
+  /** Additional style for the modal content area */
+  contentStyle?: CSSProperties;
 }
 
 /**
@@ -121,6 +123,7 @@ export const ModalWindow = memo(function ModalWindow({
   showCloseButton = true,
   className,
   style,
+  contentStyle: contentStyleOverride,
 }: ModalWindowProps): React.ReactElement | null {
   const theme = useTheme();
   const resolvedZIndex = zIndex ?? theme.zIndex.modal;
@@ -328,6 +331,7 @@ export const ModalWindow = memo(function ModalWindow({
         ? "linear-gradient(180deg, rgba(255, 255, 255, 0.028) 0%, rgba(255, 255, 255, 0.014) 18%, rgba(0, 0, 0, 0.08) 100%)"
         : "transparent",
     pointerEvents: "auto",
+    ...contentStyleOverride,
   };
 
   return (

--- a/packages/shared/src/systems/shared/interaction/DialogueSystem.ts
+++ b/packages/shared/src/systems/shared/interaction/DialogueSystem.ts
@@ -36,6 +36,20 @@ export class DialogueSystem extends SystemBase {
   // Active dialogues per player
   private activeDialogues = new Map<string, DialogueState>();
 
+  private isImmediateHandoffEffect(effect?: string): boolean {
+    if (!effect) {
+      return false;
+    }
+
+    const [effectName] = effect.split(":");
+    return (
+      effectName === "openBank" ||
+      effectName === "openShop" ||
+      effectName === "openStore" ||
+      effectName === "openTanner"
+    );
+  }
+
   constructor(world: World) {
     super(world, {
       name: "dialogue",
@@ -271,6 +285,14 @@ export class DialogueSystem extends SystemBase {
     const nextNodeId = selectedResponse.nextNodeId;
     const effect = selectedResponse.effect;
 
+    // Service panel handoff responses should end the dialogue immediately.
+    // These are not real conversational branches; the next UI owns the flow.
+    if (effect && this.isImmediateHandoffEffect(effect)) {
+      this.executeEffect(playerId, npcId, effect, state.npcEntityId);
+      this.endDialogue(playerId, npcId);
+      return;
+    }
+
     // Execute effect if present (now from SERVER data, not client)
     if (effect) {
       this.executeEffect(playerId, npcId, effect, state.npcEntityId);
@@ -286,11 +308,14 @@ export class DialogueSystem extends SystemBase {
       return;
     }
 
+    const nextNodeIsTerminal =
+      !nextNode.responses || nextNode.responses.length === 0;
+
     // Update state
     state.currentNodeId = nextNodeId;
 
     // Check if this node has responses
-    if (!nextNode.responses || nextNode.responses.length === 0) {
+    if (nextNodeIsTerminal) {
       // Terminal node - store pending effect instead of executing immediately
       // Effect will execute when player clicks continue
       if (nextNode.effect) {


### PR DESCRIPTION
## Summary
- unify the skilling popups around a shared panel body and quantity selector
- redesign NPC dialogue into a dedicated in-world panel with portrait rendering and lighter shell chrome
- fix service dialogue handoffs so opening store/bank/tanner closes the dialogue instead of leaving a terminal continue step

## Testing
- bun run --cwd packages/client typecheck
- bun run --cwd packages/shared typecheck