### PR TITLE
[codex] polish home teleport cast effects and cooldown flow

### DIFF
--- a/packages/client/src/game/hud/HomeTeleportButton.tsx
+++ b/packages/client/src/game/hud/HomeTeleportButton.tsx
@@ -60,12 +60,29 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
     const onCastStart = () => {
       setState("casting");
       setCastStartTime(performance.now());
+      setCooldownEndTime(null);
+      setCooldownRemaining(0);
       setCastProgress(0);
     };
 
-    const onFailed = () => {
-      // Server rejected or cancelled - reset to ready
-      setState("ready");
+    const onFailed = (event?: unknown) => {
+      const remainingMs =
+        typeof event === "object" &&
+        event !== null &&
+        "remainingMs" in event &&
+        typeof event.remainingMs === "number"
+          ? event.remainingMs
+          : 0;
+      if (remainingMs > 0) {
+        setState("cooldown");
+        setCooldownEndTime(performance.now() + remainingMs);
+        setCooldownRemaining(remainingMs);
+      } else {
+        // Server rejected or cancelled - reset to ready
+        setState("ready");
+        setCooldownEndTime(null);
+        setCooldownRemaining(0);
+      }
       setCastStartTime(null);
       setCastProgress(0);
     };
@@ -74,6 +91,8 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
       // Server confirmed cancel - reset to ready
       setState("ready");
       setCastStartTime(null);
+      setCooldownEndTime(null);
+      setCooldownRemaining(0);
       setCastProgress(0);
     };
 
@@ -127,11 +146,14 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
       const now = performance.now();
 
       if (state === "casting" && castStartTimeRef.current !== null) {
-        const progress = Math.min(
-          100,
-          ((now - castStartTimeRef.current) /
-            HOME_TELEPORT_CONSTANTS.CAST_TIME_MS) *
+        const progress = Math.max(
+          0,
+          Math.min(
             100,
+            ((now - castStartTimeRef.current) /
+              HOME_TELEPORT_CONSTANTS.CAST_TIME_MS) *
+              100,
+          ),
         );
         setCastProgress(progress);
       } else if (state === "cooldown" && cooldownEndTimeRef.current !== null) {
@@ -188,6 +210,17 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
 
   const isCasting = state === "casting";
   const isDisabled = state === "cooldown";
+  const cooldownProgress = isDisabled
+    ? Math.max(
+        0,
+        Math.min(
+          100,
+          ((HOME_TELEPORT_CONSTANTS.COOLDOWN_MS - cooldownRemaining) /
+            HOME_TELEPORT_CONSTANTS.COOLDOWN_MS) *
+            100,
+        ),
+      )
+    : 0;
 
   const styles = useMemo(() => {
     const size = isMobile ? 48 : 56;
@@ -226,6 +259,22 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
         overflow: "hidden",
         transition: theme.transitions.normal,
       } as React.CSSProperties,
+      cooldownFill: {
+        position: "absolute" as const,
+        inset: 0,
+        top: `${100 - cooldownProgress}%`,
+        background: `linear-gradient(180deg, ${theme.colors.status.prayer}cc, ${theme.colors.accent.primary}f2)`,
+        transition: "top 0.1s linear",
+        pointerEvents: "none" as const,
+      } as React.CSSProperties,
+      content: {
+        position: "relative" as const,
+        zIndex: 1,
+        display: "flex",
+        flexDirection: "column" as const,
+        alignItems: "center",
+        justifyContent: "center",
+      } as React.CSSProperties,
       icon: {
         fontSize: isMobile ? "1.25rem" : "1.5rem",
         opacity: isDisabled ? 0.5 : 1,
@@ -251,7 +300,7 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
         transition: "width 0.05s linear",
       } as React.CSSProperties,
     };
-  }, [theme, isMobile, isDisabled, isCasting, castProgress]);
+  }, [theme, isMobile, isDisabled, isCasting, castProgress, cooldownProgress]);
 
   const label =
     state === "cooldown"
@@ -269,8 +318,11 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
   return (
     <div className="fixed pointer-events-auto z-50" style={styles.container}>
       <button onClick={handleClick} style={styles.button} title={title}>
-        <span style={styles.icon}>🏠</span>
-        <span style={styles.label}>{label}</span>
+        {isDisabled && <div style={styles.cooldownFill} />}
+        <div style={styles.content}>
+          <span style={styles.icon}>🏠</span>
+          <span style={styles.label}>{label}</span>
+        </div>
         {isCasting && <div style={styles.progress} />}
       </button>
     </div>

--- a/packages/client/src/game/hud/HomeTeleportButton.tsx
+++ b/packages/client/src/game/hud/HomeTeleportButton.tsx
@@ -13,6 +13,10 @@ import React, {
 import { useThemeStore } from "@/ui";
 import { HOME_TELEPORT_CONSTANTS, EventType } from "@hyperscape/shared";
 import type { ClientWorld } from "../../types";
+import {
+  getHomeTeleportCooldownProgress,
+  readHomeTeleportRemainingMs,
+} from "./homeTeleportUi";
 
 type TeleportState = "ready" | "cooldown" | "casting";
 
@@ -66,13 +70,7 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
     };
 
     const onFailed = (event?: unknown) => {
-      const remainingMs =
-        typeof event === "object" &&
-        event !== null &&
-        "remainingMs" in event &&
-        typeof event.remainingMs === "number"
-          ? event.remainingMs
-          : 0;
+      const remainingMs = readHomeTeleportRemainingMs(event);
       if (remainingMs > 0) {
         setState("cooldown");
         setCooldownEndTime(performance.now() + remainingMs);
@@ -211,15 +209,7 @@ export function HomeTeleportButton({ world }: { world: ClientWorld }) {
   const isCasting = state === "casting";
   const isDisabled = state === "cooldown";
   const cooldownProgress = isDisabled
-    ? Math.max(
-        0,
-        Math.min(
-          100,
-          ((HOME_TELEPORT_CONSTANTS.COOLDOWN_MS - cooldownRemaining) /
-            HOME_TELEPORT_CONSTANTS.COOLDOWN_MS) *
-            100,
-        ),
-      )
+    ? getHomeTeleportCooldownProgress(cooldownRemaining)
     : 0;
 
   const styles = useMemo(() => {

--- a/packages/client/src/game/hud/MinimapHomeTeleportOrb.tsx
+++ b/packages/client/src/game/hud/MinimapHomeTeleportOrb.tsx
@@ -85,13 +85,30 @@ export function MinimapHomeTeleportOrb({
   useEffect(() => {
     const onCastStart = () => {
       setState("casting");
-      setCastStartTime(Date.now());
+      setCastStartTime(performance.now());
+      setCooldownEndTime(null);
+      setCooldownRemaining(0);
       setCastProgress(0);
     };
 
-    const onFailed = () => {
-      // Server rejected or cancelled - reset to ready
-      setState("ready");
+    const onFailed = (event?: unknown) => {
+      const remainingMs =
+        typeof event === "object" &&
+        event !== null &&
+        "remainingMs" in event &&
+        typeof event.remainingMs === "number"
+          ? event.remainingMs
+          : 0;
+      if (remainingMs > 0) {
+        setState("cooldown");
+        setCooldownEndTime(performance.now() + remainingMs);
+        setCooldownRemaining(remainingMs);
+      } else {
+        // Server rejected or cancelled - reset to ready
+        setState("ready");
+        setCooldownEndTime(null);
+        setCooldownRemaining(0);
+      }
       setCastStartTime(null);
       setCastProgress(0);
     };
@@ -100,6 +117,8 @@ export function MinimapHomeTeleportOrb({
       // Server confirmed cancel - reset to ready
       setState("ready");
       setCastStartTime(null);
+      setCooldownEndTime(null);
+      setCooldownRemaining(0);
       setCastProgress(0);
     };
 
@@ -107,7 +126,9 @@ export function MinimapHomeTeleportOrb({
       // Use ref to get current state (avoids stale closure)
       if (stateRef.current === "casting") {
         setState("cooldown");
-        setCooldownEndTime(Date.now() + HOME_TELEPORT_CONSTANTS.COOLDOWN_MS);
+        setCooldownEndTime(
+          performance.now() + HOME_TELEPORT_CONSTANTS.COOLDOWN_MS,
+        );
         setCooldownRemaining(HOME_TELEPORT_CONSTANTS.COOLDOWN_MS);
         setCastStartTime(null);
         setCastProgress(0);
@@ -150,11 +171,14 @@ export function MinimapHomeTeleportOrb({
       const now = performance.now();
 
       if (state === "casting" && castStartTimeRef.current !== null) {
-        const progress = Math.min(
-          100,
-          ((now - castStartTimeRef.current) /
-            HOME_TELEPORT_CONSTANTS.CAST_TIME_MS) *
+        const progress = Math.max(
+          0,
+          Math.min(
             100,
+            ((now - castStartTimeRef.current) /
+              HOME_TELEPORT_CONSTANTS.CAST_TIME_MS) *
+              100,
+          ),
         );
         setCastProgress(progress);
       } else if (state === "cooldown" && cooldownEndTimeRef.current !== null) {
@@ -211,23 +235,34 @@ export function MinimapHomeTeleportOrb({
 
   const isCasting = state === "casting";
   const isDisabled = state === "cooldown";
+  const cooldownProgress = isDisabled
+    ? Math.max(
+        0,
+        Math.min(
+          100,
+          ((HOME_TELEPORT_CONSTANTS.COOLDOWN_MS - cooldownRemaining) /
+            HOME_TELEPORT_CONSTANTS.COOLDOWN_MS) *
+            100,
+        ),
+      )
+    : 0;
 
   // Color scheme based on state
-  // Ready: Warm purple/magenta (magical feel)
+  // Ready/cooldown fill: Warm purple/magenta (magical feel)
   // Casting: Bright blue (active)
-  // Cooldown: Muted gray
+  // Cooldown shell: Muted gray
   const fillColorStart = isDisabled
-    ? "#666666"
+    ? "#c084fc"
     : isCasting
       ? "#60a5fa"
       : "#c084fc";
   const fillColorMid = isDisabled
-    ? "#4a4a4a"
+    ? "#a855f7"
     : isCasting
       ? "#3b82f6"
       : "#a855f7";
   const fillColorEnd = isDisabled
-    ? "#333333"
+    ? "#7c3aed"
     : isCasting
       ? "#2563eb"
       : "#7c3aed";
@@ -254,7 +289,11 @@ export function MinimapHomeTeleportOrb({
   const outerBorderRadius = center - borderWidth / 2; // Border stroke centered on edge
 
   // Calculate fill percentage based on state
-  const fillPercent = isCasting ? castProgress : isDisabled ? 0 : 100;
+  const fillPercent = isCasting
+    ? Math.max(0, Math.min(100, castProgress))
+    : isDisabled
+      ? cooldownProgress
+      : 100;
 
   // Label text
   const label =
@@ -328,8 +367,13 @@ export function MinimapHomeTeleportOrb({
           </clipPath>
         </defs>
 
-        {/* Background (dark) */}
-        <circle cx={center} cy={center} r={fillRadius} fill="#1a1510" />
+        {/* Background shell */}
+        <circle
+          cx={center}
+          cy={center}
+          r={fillRadius}
+          fill={isDisabled ? "#2c2a31" : "#1a1510"}
+        />
 
         {/* Fill rectangle clipped to circle, height based on progress/state */}
         <g clipPath={`url(#${clipId})`}>

--- a/packages/client/src/game/hud/MinimapHomeTeleportOrb.tsx
+++ b/packages/client/src/game/hud/MinimapHomeTeleportOrb.tsx
@@ -7,6 +7,10 @@
 import React, { useEffect, useState, useCallback, useRef, useId } from "react";
 import { HOME_TELEPORT_CONSTANTS, EventType } from "@hyperscape/shared";
 import type { ClientWorld } from "../../types";
+import {
+  getHomeTeleportCooldownProgress,
+  readHomeTeleportRemainingMs,
+} from "./homeTeleportUi";
 
 type TeleportState = "ready" | "cooldown" | "casting";
 
@@ -92,13 +96,7 @@ export function MinimapHomeTeleportOrb({
     };
 
     const onFailed = (event?: unknown) => {
-      const remainingMs =
-        typeof event === "object" &&
-        event !== null &&
-        "remainingMs" in event &&
-        typeof event.remainingMs === "number"
-          ? event.remainingMs
-          : 0;
+      const remainingMs = readHomeTeleportRemainingMs(event);
       if (remainingMs > 0) {
         setState("cooldown");
         setCooldownEndTime(performance.now() + remainingMs);
@@ -236,15 +234,7 @@ export function MinimapHomeTeleportOrb({
   const isCasting = state === "casting";
   const isDisabled = state === "cooldown";
   const cooldownProgress = isDisabled
-    ? Math.max(
-        0,
-        Math.min(
-          100,
-          ((HOME_TELEPORT_CONSTANTS.COOLDOWN_MS - cooldownRemaining) /
-            HOME_TELEPORT_CONSTANTS.COOLDOWN_MS) *
-            100,
-        ),
-      )
+    ? getHomeTeleportCooldownProgress(cooldownRemaining)
     : 0;
 
   // Color scheme based on state

--- a/packages/client/src/game/hud/homeTeleportUi.ts
+++ b/packages/client/src/game/hud/homeTeleportUi.ts
@@ -1,0 +1,20 @@
+import { HOME_TELEPORT_CONSTANTS } from "@hyperscape/shared";
+
+export function readHomeTeleportRemainingMs(event?: unknown): number {
+  const payload = event as { remainingMs?: number } | undefined;
+  return payload?.remainingMs ?? 0;
+}
+
+export function getHomeTeleportCooldownProgress(
+  cooldownRemaining: number,
+): number {
+  return Math.max(
+    0,
+    Math.min(
+      100,
+      ((HOME_TELEPORT_CONSTANTS.COOLDOWN_MS - cooldownRemaining) /
+        HOME_TELEPORT_CONSTANTS.COOLDOWN_MS) *
+        100,
+    ),
+  );
+}

--- a/packages/server/src/systems/ServerNetwork/handlers/home-teleport.ts
+++ b/packages/server/src/systems/ServerNetwork/handlers/home-teleport.ts
@@ -209,7 +209,7 @@ class HomeTeleportManager {
   }
 }
 
-function formatCooldownRemaining(remainingMs: number): string {
+export function formatCooldownRemaining(remainingMs: number): string {
   const totalSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;

--- a/packages/server/src/systems/ServerNetwork/handlers/home-teleport.ts
+++ b/packages/server/src/systems/ServerNetwork/handlers/home-teleport.ts
@@ -2,7 +2,7 @@
  * Home Teleport Handler
  *
  * Allows players to return to spawn with:
- * - 15-minute cooldown
+ * - 30-second cooldown
  * - 10-second interruptible cast time
  * - Blocked by combat/death
  */
@@ -83,8 +83,8 @@ class HomeTeleportManager {
     if (this.isCasting(playerId)) return "Already casting home teleport";
 
     if (this.isOnCooldown(playerId)) {
-      const minutes = Math.ceil(this.getCooldownRemaining(playerId) / 60000);
-      return `Home teleport on cooldown (${minutes}m remaining)`;
+      const remainingMs = this.getCooldownRemaining(playerId);
+      return `Home teleport on cooldown (${formatCooldownRemaining(remainingMs)} remaining)`;
     }
 
     const combatSystem = this.world.getSystem("combat") as CombatSystem | null;
@@ -119,13 +119,6 @@ class HomeTeleportManager {
     socket.send("homeTeleportStart", {
       castTimeMs: HOME_TELEPORT_CONSTANTS.CAST_TIME_MS,
     });
-
-    // Use SQUAT emote for casting (kneeling/concentrating pose)
-    this.sendFn(
-      "entityModified",
-      { id: playerId, changes: { emote: Emotes.SQUAT } },
-      socket.id,
-    );
 
     return null;
   }
@@ -216,6 +209,22 @@ class HomeTeleportManager {
   }
 }
 
+function formatCooldownRemaining(remainingMs: number): string {
+  const totalSeconds = Math.max(1, Math.ceil(remainingMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes <= 0) {
+    return `${totalSeconds}s`;
+  }
+
+  if (seconds === 0) {
+    return `${minutes}m`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
 let homeTeleportManager: HomeTeleportManager | null = null;
 
 export function initHomeTeleportManager(
@@ -248,7 +257,13 @@ export function handleHomeTeleport(
 
   const error = homeTeleportManager.startCasting(socket, currentTick);
   if (error) {
-    socket.send("homeTeleportFailed", { reason: error });
+    const remainingMs = socket.player
+      ? homeTeleportManager.getCooldownRemaining(socket.player.id)
+      : 0;
+    socket.send("homeTeleportFailed", {
+      reason: error,
+      ...(remainingMs > 0 ? { remainingMs } : {}),
+    });
     socket.send("showToast", { message: error, type: "error" });
   }
 }

--- a/packages/server/tests/unit/teleport/HomeTeleportManager.test.ts
+++ b/packages/server/tests/unit/teleport/HomeTeleportManager.test.ts
@@ -178,11 +178,11 @@ describe("Home Teleport Manager", () => {
       );
     });
 
-    it("broadcasts emote change to other players", () => {
+    it("does not broadcast a cast emote on teleport start", () => {
       const manager = getManager();
       manager.startCasting(mockSocket as never, 0);
 
-      expect(mockSendFn).toHaveBeenCalledWith(
+      expect(mockSendFn).not.toHaveBeenCalledWith(
         "entityModified",
         { id: "player-123", changes: { emote: Emotes.SQUAT } },
         mockSocket.id,
@@ -372,7 +372,25 @@ describe("Home Teleport Manager", () => {
       expect(error).toContain("cooldown");
     });
 
-    it("cooldown expires after 15 minutes", () => {
+    it("handleHomeTeleport sends remainingMs when blocked by cooldown", () => {
+      const manager = getManager();
+      manager.startCasting(mockSocket as never, 0);
+      manager.processTick(CAST_TICKS, () => mockSocket as never);
+
+      mockSocket.send.mockClear();
+
+      handleHomeTeleport(mockSocket as never, {}, mockWorld as never, 999);
+
+      expect(mockSocket.send).toHaveBeenCalledWith(
+        "homeTeleportFailed",
+        expect.objectContaining({
+          reason: expect.stringContaining("cooldown"),
+          remainingMs: expect.any(Number),
+        }),
+      );
+    });
+
+    it("cooldown expires after 30 seconds", () => {
       const manager = getManager();
       // Complete first teleport
       manager.startCasting(mockSocket as never, 0);
@@ -799,8 +817,8 @@ describe("Home Teleport Manager", () => {
 
   describe("Constants", () => {
     it("cooldown matches HOME_TELEPORT_CONSTANTS", () => {
-      // Production value: 15 minutes
-      expect(HOME_TELEPORT_CONSTANTS.COOLDOWN_MS).toBe(15 * 60 * 1000);
+      // Production value: 30 seconds
+      expect(HOME_TELEPORT_CONSTANTS.COOLDOWN_MS).toBe(30 * 1000);
     });
 
     it("cast time is exactly 10 seconds in milliseconds", () => {

--- a/packages/server/tests/unit/teleport/HomeTeleportManager.test.ts
+++ b/packages/server/tests/unit/teleport/HomeTeleportManager.test.ts
@@ -20,6 +20,7 @@ import {
   getHomeTeleportManager,
   handleHomeTeleport,
   handleHomeTeleportCancel,
+  formatCooldownRemaining,
 } from "../../../src/systems/ServerNetwork/handlers/home-teleport";
 
 // ============================================================================
@@ -827,6 +828,22 @@ describe("Home Teleport Manager", () => {
 
     it("cast time ticks matches 10s / 600ms per tick", () => {
       expect(HOME_TELEPORT_CONSTANTS.CAST_TIME_TICKS).toBe(17);
+    });
+  });
+
+  describe("formatCooldownRemaining", () => {
+    it("rounds sub-second values up to 1s", () => {
+      expect(formatCooldownRemaining(0)).toBe("1s");
+      expect(formatCooldownRemaining(999)).toBe("1s");
+    });
+
+    it("formats exact minutes without seconds", () => {
+      expect(formatCooldownRemaining(60_000)).toBe("1m");
+    });
+
+    it("formats minutes and seconds when needed", () => {
+      expect(formatCooldownRemaining(61_000)).toBe("1m 1s");
+      expect(formatCooldownRemaining(90_500)).toBe("1m 31s");
     });
   });
 

--- a/packages/shared/src/constants/GameConstants.ts
+++ b/packages/shared/src/constants/GameConstants.ts
@@ -40,8 +40,8 @@ export const PLAYER_CONSTANTS = {
 
 // === HOME TELEPORT ===
 export const HOME_TELEPORT_CONSTANTS = {
-  /** Cooldown in milliseconds (15 minutes) */
-  COOLDOWN_MS: 15 * 60 * 1000,
+  /** Cooldown in milliseconds (30 seconds) */
+  COOLDOWN_MS: 30 * 1000,
   /** Cast time in milliseconds (10 seconds - can be interrupted by movement/combat) */
   CAST_TIME_MS: 10 * 1000,
   /** Cast time in ticks (for server-side processing, 10s = ~17 ticks at 600ms/tick) */

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -4767,9 +4767,12 @@ export class ClientNetwork extends SystemBase {
    * Handle home teleport failed
    * Server rejected teleport request (combat, cooldown, etc.)
    */
-  onHomeTeleportFailed = (data: { reason: string }) => {
+  onHomeTeleportFailed = (data: { reason: string; remainingMs?: number }) => {
     this.world.emit(EventType.HOME_TELEPORT_FAILED, {
       reason: data.reason,
+      ...(typeof data.remainingMs === "number"
+        ? { remainingMs: data.remainingMs }
+        : {}),
     });
   };
 

--- a/packages/shared/src/systems/client/ClientTeleportEffectsSystem.ts
+++ b/packages/shared/src/systems/client/ClientTeleportEffectsSystem.ts
@@ -18,6 +18,7 @@ import THREE, {
 } from "../../extras/three/three";
 import type { ShaderNode } from "../../extras/three/three";
 import { World } from "../../core/World";
+import { HOME_TELEPORT_CONSTANTS } from "../../constants/GameConstants";
 import { SystemBase } from "../shared/infrastructure/SystemBase";
 import { EventType } from "../../types/events/event-types";
 import { Curve } from "../../extras/animation/Curve";
@@ -37,6 +38,26 @@ const SUSTAIN_END = 0.68;
 // Pre-allocated colors (shared, never disposed)
 const COLOR_CYAN = new THREE.Color(0x66ccff);
 const COLOR_WHITE = new THREE.Color(0xffffff);
+const COLOR_PORTAL_VIOLET = new THREE.Color(0x8e7a59);
+const COLOR_PORTAL_INDIGO = new THREE.Color(0x231f1a);
+const COLOR_PORTAL_GOLD = new THREE.Color(0xbea57b);
+const COLOR_PORTAL_ROSE = new THREE.Color(0xd7c7ab);
+const PORTAL_ENDGAME_START = 0.8;
+const PORTAL_GROUND_CLEARANCE = 0.015;
+const TELEPORT_GROUND_CONTACT_BONES = [
+  "leftFoot",
+  "rightFoot",
+  "leftToes",
+  "rightToes",
+  "leftLowerLeg",
+  "rightLowerLeg",
+  "leftUpperLeg",
+  "rightUpperLeg",
+  "hips",
+  "spine",
+  "chest",
+  "upperChest",
+] as const;
 
 // ─── Pooled particle state ──────────────────────────────────────────────────
 interface HelixParticle {
@@ -58,6 +79,8 @@ interface BurstParticle {
 
 interface PooledEffect {
   group: THREE.Group;
+  mode: "burst" | "channel";
+  channelDurationMs: number;
 
   // Structural meshes (pre-allocated)
   runeCircle: THREE.Mesh;
@@ -67,8 +90,12 @@ interface PooledEffect {
   coreFlash: THREE.Mesh;
   shockwave1: THREE.Mesh;
   shockwave2: THREE.Mesh;
+  portalVeil: THREE.Mesh;
+  portalBandLower: THREE.Mesh;
+  portalBandUpper: THREE.Mesh;
+  portalCrown: THREE.Mesh;
 
-  // Per-effect materials with own uniforms (7 per pool entry)
+  // Per-effect materials with own uniforms
   perEffectMaterials: InstanceType<typeof MeshBasicNodeMaterial>[];
   uRuneOpacity: ReturnType<typeof uniform>;
   uGlowOpacity: ReturnType<typeof uniform>;
@@ -77,6 +104,10 @@ interface PooledEffect {
   uFlashOpacity: ReturnType<typeof uniform>;
   uShock1Opacity: ReturnType<typeof uniform>;
   uShock2Opacity: ReturnType<typeof uniform>;
+  uPortalVeilOpacity: ReturnType<typeof uniform>;
+  uPortalBandLowerOpacity: ReturnType<typeof uniform>;
+  uPortalBandUpperOpacity: ReturnType<typeof uniform>;
+  uPortalCrownOpacity: ReturnType<typeof uniform>;
 
   // Particles (share materials across pool, fade via scale)
   helixParticles: HelixParticle[];
@@ -111,6 +142,8 @@ export class ClientTeleportEffectsSystem extends SystemBase {
   private runeCircleGeo: THREE.CircleGeometry | null = null;
   private shockwaveGeo: THREE.RingGeometry | null = null;
   private sphereGeo: THREE.SphereGeometry | null = null;
+  private portalVeilGeo: THREE.CylinderGeometry | null = null;
+  private portalRingGeo: THREE.TorusGeometry | null = null;
 
   // ─── Shared textures ────────────────────────────────────────────────────
   private runeTexture: THREE.CanvasTexture | null = null;
@@ -123,6 +156,9 @@ export class ClientTeleportEffectsSystem extends SystemBase {
 
   // ─── Shared Hermite curves ──────────────────────────────────────────────
   private beamElasticCurve: Curve | null = null;
+  private readonly localPlayerTeleportAnchor = new THREE.Vector3();
+  private readonly teleportBoneWorldPosition = new THREE.Vector3();
+  private homeTeleportCastEffect: PooledEffect | null = null;
 
   constructor(world: World) {
     super(world, {
@@ -135,6 +171,15 @@ export class ClientTeleportEffectsSystem extends SystemBase {
   async init(options?: WorldOptions): Promise<void> {
     await super.init(options as WorldOptions);
 
+    this.world.on(
+      EventType.HOME_TELEPORT_CAST_START,
+      this.onHomeTeleportCastStart,
+    );
+    this.world.on(EventType.HOME_TELEPORT_FAILED, this.onHomeTeleportStopped);
+    this.world.on(
+      EventType.HOME_TELEPORT_CAST_CANCEL,
+      this.onHomeTeleportStopped,
+    );
     this.world.on(EventType.PLAYER_TELEPORTED, this.onPlayerTeleported);
   }
 
@@ -158,6 +203,16 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     this.runeCircleGeo = new THREE.CircleGeometry(1.5, 32);
     this.shockwaveGeo = new THREE.RingGeometry(0.15, 0.4, 24);
     this.sphereGeo = new THREE.SphereGeometry(0.4, 8, 6);
+    this.portalVeilGeo = new THREE.CylinderGeometry(
+      0.9,
+      0.72,
+      3.05,
+      24,
+      1,
+      true,
+    );
+    this.portalVeilGeo.translate(0, 1.525, 0);
+    this.portalRingGeo = new THREE.TorusGeometry(0.84, 0.04, 8, 32);
 
     // ─── Shared textures ────────────────────────────────────────────────
     this.runeTexture = this.createRuneTexture();
@@ -298,6 +353,61 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     shockwave2.frustumCulled = false;
     group.add(shockwave2);
 
+    // ─── 8. Cast Portal Veil + Orbit Rings ───────────────────────────────
+    const uPortalVeilOpacity = uniform(0.0);
+    const portalVeilMat = this.createBeamMaterial(
+      COLOR_PORTAL_INDIGO,
+      COLOR_PORTAL_GOLD,
+      uPortalVeilOpacity,
+    );
+    perEffectMaterials.push(portalVeilMat);
+    const portalVeil = new THREE.Mesh(this.portalVeilGeo!, portalVeilMat);
+    portalVeil.renderOrder = 997;
+    portalVeil.frustumCulled = false;
+    group.add(portalVeil);
+
+    const uPortalBandLowerOpacity = uniform(0.0);
+    const portalBandLowerMat = this.createBasicAdditiveMaterial(
+      COLOR_PORTAL_VIOLET,
+      uPortalBandLowerOpacity,
+    );
+    perEffectMaterials.push(portalBandLowerMat);
+    const portalBandLower = new THREE.Mesh(
+      this.portalRingGeo!,
+      portalBandLowerMat,
+    );
+    portalBandLower.rotation.x = Math.PI / 2;
+    portalBandLower.renderOrder = 1006;
+    portalBandLower.frustumCulled = false;
+    group.add(portalBandLower);
+
+    const uPortalBandUpperOpacity = uniform(0.0);
+    const portalBandUpperMat = this.createBasicAdditiveMaterial(
+      COLOR_PORTAL_GOLD,
+      uPortalBandUpperOpacity,
+    );
+    perEffectMaterials.push(portalBandUpperMat);
+    const portalBandUpper = new THREE.Mesh(
+      this.portalRingGeo!,
+      portalBandUpperMat,
+    );
+    portalBandUpper.rotation.x = Math.PI / 2;
+    portalBandUpper.renderOrder = 1007;
+    portalBandUpper.frustumCulled = false;
+    group.add(portalBandUpper);
+
+    const uPortalCrownOpacity = uniform(0.0);
+    const portalCrownMat = this.createBasicAdditiveMaterial(
+      COLOR_PORTAL_ROSE,
+      uPortalCrownOpacity,
+    );
+    perEffectMaterials.push(portalCrownMat);
+    const portalCrown = new THREE.Mesh(this.portalRingGeo!, portalCrownMat);
+    portalCrown.rotation.x = Math.PI / 2;
+    portalCrown.renderOrder = 1008;
+    portalCrown.frustumCulled = false;
+    group.add(portalCrown);
+
     // ─── 9. Helix Spiral Particles (8: 2 strands of 4) ────────────────
     const helixParticles: HelixParticle[] = [];
     for (let i = 0; i < HELIX_COUNT; i++) {
@@ -341,6 +451,8 @@ export class ClientTeleportEffectsSystem extends SystemBase {
 
     return {
       group,
+      mode: "burst",
+      channelDurationMs: HOME_TELEPORT_CONSTANTS.CAST_TIME_MS,
       runeCircle,
       baseGlow,
       innerBeam,
@@ -348,6 +460,10 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       coreFlash,
       shockwave1,
       shockwave2,
+      portalVeil,
+      portalBandLower,
+      portalBandUpper,
+      portalCrown,
       perEffectMaterials,
       uRuneOpacity,
       uGlowOpacity,
@@ -356,6 +472,10 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       uFlashOpacity,
       uShock1Opacity,
       uShock2Opacity,
+      uPortalVeilOpacity,
+      uPortalBandLowerOpacity,
+      uPortalBandUpperOpacity,
+      uPortalCrownOpacity,
       helixParticles,
       burstParticles,
       active: false,
@@ -375,6 +495,11 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     if (!payload?.position) return;
     if (payload.suppressEffect) return;
 
+    const localPlayerId = this.getLocalPlayerId();
+    if (localPlayerId && payload.playerId === localPlayerId) {
+      this.stopHomeTeleportCastEffect();
+    }
+
     const pos = payload.position;
     const vec =
       pos instanceof THREE.Vector3
@@ -382,6 +507,30 @@ export class ClientTeleportEffectsSystem extends SystemBase {
         : new THREE.Vector3(pos.x, pos.y, pos.z);
 
     this.spawnTeleportEffect(vec);
+  };
+
+  private onHomeTeleportCastStart = (data: unknown): void => {
+    const payload = data as { castTimeMs?: number } | undefined;
+    const localPlayerAnchor = this.getLocalPlayerTeleportAnchor();
+    if (!localPlayerAnchor) return;
+    const channelDurationMs =
+      payload?.castTimeMs ?? HOME_TELEPORT_CONSTANTS.CAST_TIME_MS;
+
+    if (this.homeTeleportCastEffect) {
+      this.homeTeleportCastEffect.life = 0;
+      this.homeTeleportCastEffect.channelDurationMs = channelDurationMs;
+      this.homeTeleportCastEffect.group.position.copy(localPlayerAnchor);
+      return;
+    }
+
+    this.homeTeleportCastEffect = this.spawnChannelEffect(
+      localPlayerAnchor,
+      channelDurationMs,
+    );
+  };
+
+  private onHomeTeleportStopped = (): void => {
+    this.stopHomeTeleportCastEffect();
   };
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -399,6 +548,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     // Reset timeline
     fx.active = true;
     fx.life = 0;
+    fx.mode = "burst";
 
     // Position the group
     fx.group.position.copy(position);
@@ -415,12 +565,29 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     fx.innerBeam.visible = false; // Hidden until ERUPT
     fx.outerBeam.scale.set(1, 0, 1);
     fx.outerBeam.visible = false; // Hidden until ERUPT
+    fx.coreFlash.position.y = 0.5;
     fx.coreFlash.scale.setScalar(0);
     fx.coreFlash.visible = false; // Hidden until ERUPT
+    fx.shockwave1.position.y = 0;
     fx.shockwave1.scale.setScalar(1);
     fx.shockwave1.visible = false; // Hidden until ERUPT
+    fx.shockwave2.position.y = 0;
     fx.shockwave2.scale.setScalar(1);
     fx.shockwave2.visible = false; // Hidden until ERUPT
+    fx.portalVeil.scale.set(1, 0.01, 1);
+    fx.portalVeil.visible = false;
+    fx.portalBandLower.position.y = 0;
+    fx.portalBandLower.scale.setScalar(0.5);
+    fx.portalBandLower.rotation.z = 0;
+    fx.portalBandLower.visible = false;
+    fx.portalBandUpper.position.y = 0;
+    fx.portalBandUpper.scale.setScalar(0.5);
+    fx.portalBandUpper.rotation.z = 0;
+    fx.portalBandUpper.visible = false;
+    fx.portalCrown.position.y = 0;
+    fx.portalCrown.scale.setScalar(0.5);
+    fx.portalCrown.rotation.z = 0;
+    fx.portalCrown.visible = false;
 
     // Reset uniforms
     fx.uRuneOpacity.value = 0;
@@ -430,6 +597,10 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     fx.uFlashOpacity.value = 0;
     fx.uShock1Opacity.value = 0;
     fx.uShock2Opacity.value = 0;
+    fx.uPortalVeilOpacity.value = 0;
+    fx.uPortalBandLowerOpacity.value = 0;
+    fx.uPortalBandUpperOpacity.value = 0;
+    fx.uPortalCrownOpacity.value = 0;
 
     // Reset helix particles
     for (const p of fx.helixParticles) {
@@ -460,6 +631,89 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     }
   }
 
+  private spawnChannelEffect(
+    position: THREE.Vector3,
+    channelDurationMs: number,
+  ): PooledEffect | null {
+    if (!this.world.stage?.scene) return null;
+
+    this.ensurePoolInitialized();
+
+    const fx = this.pool.find((entry) => !entry.active);
+    if (!fx) return null;
+
+    fx.active = true;
+    fx.life = 0;
+    fx.mode = "channel";
+    fx.channelDurationMs = channelDurationMs;
+    fx.group.position.copy(position);
+    fx.group.position.y += 0.05;
+    fx.group.visible = true;
+
+    fx.runeCircle.scale.setScalar(0.92);
+    fx.runeCircle.rotation.z = 0;
+    fx.runeCircle.visible = true;
+    fx.baseGlow.scale.setScalar(1.02);
+    fx.baseGlow.visible = true;
+    fx.innerBeam.scale.set(0.72, 0.22, 0.72);
+    fx.innerBeam.visible = false;
+    fx.outerBeam.scale.set(0.94, 0.18, 0.94);
+    fx.outerBeam.visible = false;
+    fx.coreFlash.position.y = 0.85;
+    fx.coreFlash.scale.setScalar(0.55);
+    fx.coreFlash.visible = false;
+    fx.shockwave1.position.y = 0;
+    fx.shockwave1.visible = false;
+    fx.shockwave2.position.y = 0;
+    fx.shockwave2.visible = false;
+    fx.portalVeil.scale.set(0.72, 0.1, 0.72);
+    fx.portalVeil.visible = true;
+    fx.portalBandLower.position.y = 0.03;
+    fx.portalBandLower.scale.setScalar(0.88);
+    fx.portalBandLower.rotation.z = 0;
+    fx.portalBandLower.visible = true;
+    fx.portalBandUpper.position.y = 0.58;
+    fx.portalBandUpper.scale.setScalar(0.56);
+    fx.portalBandUpper.rotation.z = Math.PI * 0.12;
+    fx.portalBandUpper.visible = true;
+    fx.portalCrown.position.y = 1.08;
+    fx.portalCrown.scale.setScalar(0.5);
+    fx.portalCrown.rotation.z = Math.PI * 0.2;
+    fx.portalCrown.visible = true;
+
+    fx.uRuneOpacity.value = 0.12;
+    fx.uGlowOpacity.value = 0.08;
+    fx.uInnerBeamOpacity.value = 0;
+    fx.uOuterBeamOpacity.value = 0;
+    fx.uFlashOpacity.value = 0;
+    fx.uShock1Opacity.value = 0;
+    fx.uShock2Opacity.value = 0;
+    fx.uPortalVeilOpacity.value = 0.06;
+    fx.uPortalBandLowerOpacity.value = 0.15;
+    fx.uPortalBandUpperOpacity.value = 0.09;
+    fx.uPortalCrownOpacity.value = 0.06;
+
+    for (const p of fx.helixParticles) {
+      p.mesh.visible = false;
+      p.mesh.position.set(0, 0, 0);
+      p.mesh.scale.setScalar(p.baseScale * 0.55);
+      p.angle = p.helixIndex * Math.PI + (p.particleIndex / 4) * Math.PI * 2;
+    }
+
+    for (const p of fx.burstParticles) {
+      p.mesh.visible = false;
+      p.mesh.position.set(0, 0.5, 0);
+      p.mesh.scale.setScalar(0);
+      p.velocity.set(0, 0, 0);
+    }
+
+    if (!fx.group.parent) {
+      this.world.stage.scene.add(fx.group);
+    }
+
+    return fx;
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // UPDATE LOOP
   // ═══════════════════════════════════════════════════════════════════════════
@@ -472,6 +726,11 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       if (!fx.active) continue;
 
       fx.life += dt;
+      if (fx.mode === "channel") {
+        this.updateChannelEffect(fx, dt);
+        continue;
+      }
+
       const t = Math.min(fx.life / EFFECT_DURATION, 1.0);
 
       if (t >= 1) {
@@ -491,6 +750,94 @@ export class ClientTeleportEffectsSystem extends SystemBase {
         this.updateHelixParticles(fx, dt, camQuat);
         this.updateBurstParticles(fx, t, dt, camQuat);
       }
+    }
+  }
+
+  private updateChannelEffect(fx: PooledEffect, dt: number): void {
+    const localPlayerAnchor = this.getLocalPlayerTeleportAnchor();
+    if (!localPlayerAnchor) {
+      this.stopHomeTeleportCastEffect();
+      return;
+    }
+
+    fx.group.position.copy(localPlayerAnchor);
+
+    const progress = Math.min(
+      1,
+      (fx.life * 1000) / Math.max(1, fx.channelDurationMs),
+    );
+    const portalRise = easeOutExpo(progress);
+    const portalCinch = easeInQuad(progress);
+    const portalAnticipation = easeInQuad(progress);
+    const endgameCharge =
+      progress > PORTAL_ENDGAME_START
+        ? (progress - PORTAL_ENDGAME_START) / (1 - PORTAL_ENDGAME_START)
+        : 0;
+    const finalTighten = easeInQuad(endgameCharge);
+    const pulse = 0.5 + 0.5 * Math.sin(fx.life * 3.2);
+    const secondaryPulse = 0.5 + 0.5 * Math.sin(fx.life * 1.8 + 1.2);
+    fx.runeCircle.visible = true;
+    fx.baseGlow.visible = true;
+    fx.innerBeam.visible = false;
+    fx.outerBeam.visible = false;
+    fx.coreFlash.visible = false;
+    fx.shockwave1.visible = false;
+    fx.shockwave2.visible = false;
+    fx.uRuneOpacity.value = 0.08 + portalRise * 0.08 + endgameCharge * 0.08;
+    fx.uGlowOpacity.value = 0.05 + portalRise * 0.05 + pulse * 0.015;
+    fx.uInnerBeamOpacity.value = 0;
+    fx.uOuterBeamOpacity.value = 0;
+    fx.uFlashOpacity.value = 0;
+    fx.uShock1Opacity.value = 0;
+    fx.uShock2Opacity.value = 0;
+
+    fx.portalVeil.visible = true;
+    fx.portalVeil.scale.set(
+      0.68 + portalCinch * 0.08 - finalTighten * 0.025,
+      0.06 + portalRise * 0.42 + endgameCharge * 0.08,
+      0.68 + portalCinch * 0.08 - finalTighten * 0.025,
+    );
+    fx.uPortalVeilOpacity.value =
+      0.035 + portalRise * 0.065 + endgameCharge * 0.08 + pulse * 0.012;
+
+    fx.portalBandLower.visible = true;
+    fx.portalBandLower.position.y = 0.02 + portalRise * 0.12;
+    fx.portalBandLower.scale.setScalar(
+      0.92 + portalAnticipation * 0.16 + pulse * 0.03 - finalTighten * 0.06,
+    );
+    fx.portalBandLower.rotation.z +=
+      dt * (0.58 + portalRise * 1.2 + endgameCharge * 0.35);
+    fx.uPortalBandLowerOpacity.value =
+      0.11 + portalRise * 0.08 + endgameCharge * 0.08;
+
+    fx.portalBandUpper.visible = progress > 0.1;
+    fx.portalBandUpper.position.y = 0.4 + portalRise * 0.9;
+    fx.portalBandUpper.scale.setScalar(
+      0.52 + portalRise * 0.18 + secondaryPulse * 0.025 - finalTighten * 0.04,
+    );
+    fx.portalBandUpper.rotation.z -=
+      dt * (0.52 + portalRise * 0.92 + endgameCharge * 0.3);
+    fx.uPortalBandUpperOpacity.value = fx.portalBandUpper.visible
+      ? 0.05 + portalRise * 0.06 + endgameCharge * 0.09
+      : 0;
+
+    fx.portalCrown.visible = progress > 0.28;
+    fx.portalCrown.position.y = 0.76 + portalRise * 0.92;
+    fx.portalCrown.scale.setScalar(
+      0.44 + portalRise * 0.12 + endgameCharge * 0.08,
+    );
+    fx.portalCrown.rotation.z +=
+      dt * (0.85 + portalRise * 1.25 + endgameCharge * 0.35);
+    fx.uPortalCrownOpacity.value = fx.portalCrown.visible
+      ? 0.045 + portalRise * 0.04 + endgameCharge * 0.08 + pulse * 0.01
+      : 0;
+
+    for (const particle of fx.burstParticles) {
+      particle.mesh.visible = false;
+    }
+
+    for (const particle of fx.helixParticles) {
+      particle.mesh.visible = false;
     }
   }
 
@@ -753,7 +1100,75 @@ export class ClientTeleportEffectsSystem extends SystemBase {
   // ═══════════════════════════════════════════════════════════════════════════
   private deactivateEffect(fx: PooledEffect): void {
     fx.active = false;
+    fx.mode = "burst";
     fx.group.visible = false;
+    if (this.homeTeleportCastEffect === fx) {
+      this.homeTeleportCastEffect = null;
+    }
+  }
+
+  private stopHomeTeleportCastEffect(): void {
+    if (!this.homeTeleportCastEffect) return;
+    this.deactivateEffect(this.homeTeleportCastEffect);
+  }
+
+  private getLocalPlayerId(): string | null {
+    const player = this.world.entities.player as { id?: string } | null;
+    return player?.id ?? null;
+  }
+
+  private getLocalPlayerTeleportAnchor(): THREE.Vector3 | null {
+    const player = this.world.entities.player as {
+      position?: THREE.Vector3;
+      avatar?: {
+        getBoneTransform?: (boneName: string) => THREE.Matrix4 | null;
+      };
+    } | null;
+    if (!player?.position) {
+      return null;
+    }
+
+    const anchor = this.localPlayerTeleportAnchor.copy(player.position);
+    let lowestBoneY = Number.POSITIVE_INFINITY;
+
+    const getBoneTransform = player.avatar?.getBoneTransform;
+    if (getBoneTransform) {
+      for (const boneName of TELEPORT_GROUND_CONTACT_BONES) {
+        const boneMatrix = getBoneTransform(boneName);
+        if (!boneMatrix) {
+          continue;
+        }
+
+        const boneWorldPos =
+          this.teleportBoneWorldPosition.setFromMatrixPosition(boneMatrix);
+        lowestBoneY = Math.min(lowestBoneY, boneWorldPos.y);
+      }
+    }
+
+    const terrain = this.world.getSystem("terrain") as {
+      getHeightAt?: (x: number, z: number) => number;
+    } | null;
+    const terrainHeight = terrain?.getHeightAt?.(anchor.x, anchor.z);
+    const safeTerrainHeight: number | null =
+      typeof terrainHeight === "number" && Number.isFinite(terrainHeight)
+        ? terrainHeight
+        : null;
+
+    if (safeTerrainHeight !== null) {
+      anchor.y = safeTerrainHeight + PORTAL_GROUND_CLEARANCE;
+      if (
+        Number.isFinite(lowestBoneY) &&
+        Math.abs(lowestBoneY - safeTerrainHeight) <= 0.18
+      ) {
+        anchor.y = lowestBoneY + PORTAL_GROUND_CLEARANCE;
+      }
+    } else if (Number.isFinite(lowestBoneY)) {
+      anchor.y = lowestBoneY + PORTAL_GROUND_CLEARANCE;
+    } else {
+      anchor.y += PORTAL_GROUND_CLEARANCE;
+    }
+
+    return anchor;
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -851,7 +1266,9 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     material.side = THREE.DoubleSide;
     material.fog = false;
 
-    const yNorm = positionLocal.y;
+    // Use UV space rather than local position so the gradient remains stable
+    // across translated / differently sized cylinders (beams and portal veil).
+    const yNorm = uv().y;
     const baseVec = vec3(
       float(baseColor.r),
       float(baseColor.g),
@@ -865,11 +1282,8 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     const gradientColor = mix(baseVec, topVec, yNorm) as ShaderNode;
 
     const pulse = add(
-      float(0.8),
-      mul(
-        sin(add(mul(positionLocal.y, float(3.0)), mul(time, float(4.0)))),
-        float(0.2),
-      ),
+      float(0.86),
+      mul(sin(add(mul(yNorm, float(6.0)), mul(time, float(2.6)))), float(0.14)),
     );
 
     // Soft fade at beam base so it emerges from the rune circle, not through the floor
@@ -985,6 +1399,16 @@ export class ClientTeleportEffectsSystem extends SystemBase {
   // ═══════════════════════════════════════════════════════════════════════════
 
   destroy(): void {
+    this.stopHomeTeleportCastEffect();
+    this.world.off(
+      EventType.HOME_TELEPORT_CAST_START,
+      this.onHomeTeleportCastStart,
+    );
+    this.world.off(EventType.HOME_TELEPORT_FAILED, this.onHomeTeleportStopped);
+    this.world.off(
+      EventType.HOME_TELEPORT_CAST_CANCEL,
+      this.onHomeTeleportStopped,
+    );
     this.world.off(EventType.PLAYER_TELEPORTED, this.onPlayerTeleported);
 
     // Dispose all pool entries
@@ -1012,6 +1436,8 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     this.runeCircleGeo?.dispose();
     this.shockwaveGeo?.dispose();
     this.sphereGeo?.dispose();
+    this.portalVeilGeo?.dispose();
+    this.portalRingGeo?.dispose();
     this.particleGeo = null;
     this.beamInnerGeo = null;
     this.beamOuterGeo = null;
@@ -1019,6 +1445,8 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     this.runeCircleGeo = null;
     this.shockwaveGeo = null;
     this.sphereGeo = null;
+    this.portalVeilGeo = null;
+    this.portalRingGeo = null;
 
     // Dispose shared textures
     this.runeTexture?.dispose();

--- a/packages/shared/src/systems/client/ClientTeleportEffectsSystem.ts
+++ b/packages/shared/src/systems/client/ClientTeleportEffectsSystem.ts
@@ -34,14 +34,15 @@ const BURST_COUNT = 6;
 const GATHER_END = 0.2;
 const ERUPT_END = 0.34;
 const SUSTAIN_END = 0.68;
+const CHANNEL_EFFECT_TIMEOUT_BUFFER_MS = 1500;
 
 // Pre-allocated colors (shared, never disposed)
 const COLOR_CYAN = new THREE.Color(0x66ccff);
 const COLOR_WHITE = new THREE.Color(0xffffff);
-const COLOR_PORTAL_VIOLET = new THREE.Color(0x8e7a59);
-const COLOR_PORTAL_INDIGO = new THREE.Color(0x231f1a);
+const COLOR_PORTAL_BRONZE = new THREE.Color(0x8e7a59);
+const COLOR_PORTAL_UMBER = new THREE.Color(0x231f1a);
 const COLOR_PORTAL_GOLD = new THREE.Color(0xbea57b);
-const COLOR_PORTAL_ROSE = new THREE.Color(0xd7c7ab);
+const COLOR_PORTAL_PARCHMENT = new THREE.Color(0xd7c7ab);
 const PORTAL_ENDGAME_START = 0.8;
 const PORTAL_GROUND_CLEARANCE = 0.015;
 const TELEPORT_GROUND_CONTACT_BONES = [
@@ -356,7 +357,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     // ─── 8. Cast Portal Veil + Orbit Rings ───────────────────────────────
     const uPortalVeilOpacity = uniform(0.0);
     const portalVeilMat = this.createBeamMaterial(
-      COLOR_PORTAL_INDIGO,
+      COLOR_PORTAL_UMBER,
       COLOR_PORTAL_GOLD,
       uPortalVeilOpacity,
     );
@@ -368,7 +369,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
 
     const uPortalBandLowerOpacity = uniform(0.0);
     const portalBandLowerMat = this.createBasicAdditiveMaterial(
-      COLOR_PORTAL_VIOLET,
+      COLOR_PORTAL_BRONZE,
       uPortalBandLowerOpacity,
     );
     perEffectMaterials.push(portalBandLowerMat);
@@ -398,7 +399,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
 
     const uPortalCrownOpacity = uniform(0.0);
     const portalCrownMat = this.createBasicAdditiveMaterial(
-      COLOR_PORTAL_ROSE,
+      COLOR_PORTAL_PARCHMENT,
       uPortalCrownOpacity,
     );
     perEffectMaterials.push(portalCrownMat);
@@ -520,6 +521,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       this.homeTeleportCastEffect.life = 0;
       this.homeTeleportCastEffect.channelDurationMs = channelDurationMs;
       this.homeTeleportCastEffect.group.position.copy(localPlayerAnchor);
+      this.resetChannelEffectState(this.homeTeleportCastEffect);
       return;
     }
 
@@ -650,6 +652,18 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     fx.group.position.y += 0.05;
     fx.group.visible = true;
 
+    this.resetChannelEffectState(fx);
+
+    if (!fx.group.parent) {
+      this.world.stage.scene.add(fx.group);
+    }
+
+    return fx;
+  }
+
+  private resetChannelEffectState(fx: PooledEffect): void {
+    fx.life = 0;
+
     fx.runeCircle.scale.setScalar(0.92);
     fx.runeCircle.rotation.z = 0;
     fx.runeCircle.visible = true;
@@ -706,12 +720,6 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       p.mesh.scale.setScalar(0);
       p.velocity.set(0, 0, 0);
     }
-
-    if (!fx.group.parent) {
-      this.world.stage.scene.add(fx.group);
-    }
-
-    return fx;
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -760,6 +768,14 @@ export class ClientTeleportEffectsSystem extends SystemBase {
       return;
     }
 
+    if (
+      fx.life * 1000 >
+      fx.channelDurationMs + CHANNEL_EFFECT_TIMEOUT_BUFFER_MS
+    ) {
+      this.deactivateEffect(fx);
+      return;
+    }
+
     fx.group.position.copy(localPlayerAnchor);
 
     const progress = Math.min(
@@ -768,7 +784,6 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     );
     const portalRise = easeOutExpo(progress);
     const portalCinch = easeInQuad(progress);
-    const portalAnticipation = easeInQuad(progress);
     const endgameCharge =
       progress > PORTAL_ENDGAME_START
         ? (progress - PORTAL_ENDGAME_START) / (1 - PORTAL_ENDGAME_START)
@@ -803,7 +818,7 @@ export class ClientTeleportEffectsSystem extends SystemBase {
     fx.portalBandLower.visible = true;
     fx.portalBandLower.position.y = 0.02 + portalRise * 0.12;
     fx.portalBandLower.scale.setScalar(
-      0.92 + portalAnticipation * 0.16 + pulse * 0.03 - finalTighten * 0.06,
+      0.92 + portalCinch * 0.16 + pulse * 0.03 - finalTighten * 0.06,
     );
     fx.portalBandLower.rotation.z +=
       dt * (0.58 + portalRise * 1.2 + endgameCharge * 0.35);
@@ -1133,15 +1148,19 @@ export class ClientTeleportEffectsSystem extends SystemBase {
 
     const getBoneTransform = player.avatar?.getBoneTransform;
     if (getBoneTransform) {
-      for (const boneName of TELEPORT_GROUND_CONTACT_BONES) {
-        const boneMatrix = getBoneTransform(boneName);
-        if (!boneMatrix) {
-          continue;
-        }
+      try {
+        for (const boneName of TELEPORT_GROUND_CONTACT_BONES) {
+          const boneMatrix = getBoneTransform(boneName);
+          if (!boneMatrix) {
+            continue;
+          }
 
-        const boneWorldPos =
-          this.teleportBoneWorldPosition.setFromMatrixPosition(boneMatrix);
-        lowestBoneY = Math.min(lowestBoneY, boneWorldPos.y);
+          const boneWorldPos =
+            this.teleportBoneWorldPosition.setFromMatrixPosition(boneMatrix);
+          lowestBoneY = Math.min(lowestBoneY, boneWorldPos.y);
+        }
+      } catch {
+        lowestBoneY = Number.POSITIVE_INFINITY;
       }
     }
 


### PR DESCRIPTION
## Summary

This PR overhauls home teleport behavior across the client and server so the spell feels reliable, readable, and much more intentional in play.

On the gameplay side, the cooldown flow now stays in sync between server and HUD, the cooldown is reduced to 30 seconds, and failed teleport attempts can return authoritative remaining cooldown time back to the client. That lets the teleport button and minimap orb enter a true cooldown state instead of snapping back to a misleading ready state.

On the presentation side, the old cast emote was removed and replaced with a dedicated cast-time portal effect that starts immediately when the cast begins, remains active during the channel, and stays visually distinct from the post-teleport arrival burst. The cast effect was then tuned further so it reads as a grounded portal forming around the avatar rather than a generic teleport replay or oversized translucent cone.

## Root Cause

There were a few separate issues contributing to the bad experience:

First, the client HUD did not always receive enough server-authoritative cooldown information to represent the real state after a failed home teleport. That created a disconnect where teleport looked ready again on the frontend even though the backend still had it on cooldown.

Second, the cast visuals were either missing, reusing the wrong visual language, or firing too late in the teleport lifecycle. That made home teleport feel abrupt and visually underdeveloped.

Third, the cast effect needed tighter grounding against the player presentation system. The local player uses a grounded avatar pipeline with world position, avatar transforms, and terrain-aware placement, so the cast effect needed to align with that system rather than drift independently.

## Fix

The server now formats short cooldown messaging correctly, reports remaining cooldown milliseconds on cooldown rejection, and no longer broadcasts the old squat emote for home teleport start. The client network layer forwards that cooldown payload, and both home teleport HUD components consume it to show a proper recharge state with timers and refill visuals.

The client teleport effects system now supports a dedicated channel mode alongside the burst mode. The home teleport channel starts on cast begin, stops cleanly on fail, cancel, or completion, and hands off to the arrival burst only when the teleport actually happens. The cast portal uses its own veil and ring stack, its own palette, and its own timing rather than replaying the arrival effect.

The latest tuning pass shortens the veil silhouette, strengthens the floor signature, lowers the upper ring stack, and keeps the effect anchored to the players stable world position while still using grounded avatar/terrain data to refine vertical placement. That keeps the cast effect aligned to the bottom of the avatar without letting the portal disappear off-axis.

## Validation

I validated this work with:

- `packages/shared`: `bun run typecheck`
- `packages/client`: `bun run typecheck`
- `packages/server`: `bunx vitest run tests/unit/teleport/HomeTeleportManager.test.ts`
- `packages/shared`: `bunx vitest run src/extras/three/__tests__/vrmGrounding.test.ts`

The PR is intentionally scoped to the teleport-related client/server/shared files only and leaves unrelated dirty worktree changes out of the commit.
