### PR TITLE
fix(gathering): prevent cross-skill tool usage (pickaxe for woodcutting)

### DIFF
--- a/packages/shared/src/systems/shared/entities/ResourceSystem.ts
+++ b/packages/shared/src/systems/shared/entities/ResourceSystem.ts
@@ -1848,9 +1848,10 @@ export class ResourceSystem extends SystemBase {
       tickDurationMs: TICK_DURATION_MS,
     });
 
-    // OSRS-STYLE: Show gathering tool in hand during fishing (tool is in inventory, not equipped)
-    // For fishing, the rod appears in hand even though it's not wielded as a weapon
-    if (resource.skillRequired === "fishing" && toolInfo?.itemId) {
+    // OSRS-STYLE: Show gathering tool in hand during gathering (overrides equipped weapon)
+    // e.g., if player has a pickaxe equipped but a hatchet in inventory, the hatchet
+    // appears in hand while woodcutting. Applies to all gathering skills.
+    if (toolInfo?.itemId) {
       this.emitTypedEvent(EventType.GATHERING_TOOL_SHOW, {
         playerId: data.playerId,
         itemId: toolInfo.itemId,
@@ -1886,8 +1887,8 @@ export class ResourceSystem extends SystemBase {
       // Reset emote back to idle when gathering stops
       this.resetGatheringEmote(data.playerId);
 
-      // OSRS-STYLE: Hide gathering tool visual if fishing
-      if (session.skill === "fishing" && session.toolItemId) {
+      // OSRS-STYLE: Hide gathering tool visual and restore equipped weapon
+      if (session.toolItemId) {
         this.emitTypedEvent(EventType.GATHERING_TOOL_HIDE, {
           playerId: data.playerId,
           slot: "weapon",
@@ -1931,8 +1932,8 @@ export class ResourceSystem extends SystemBase {
       patterns.lastDisconnect = now;
       this.suspiciousPatterns.set(pid, patterns);
 
-      // OSRS-STYLE: Hide gathering tool visual if fishing
-      if (session.skill === "fishing" && session.toolItemId) {
+      // OSRS-STYLE: Hide gathering tool visual and restore equipped weapon
+      if (session.toolItemId) {
         this.emitTypedEvent(EventType.GATHERING_TOOL_HIDE, {
           playerId: playerId,
           slot: "weapon",
@@ -1981,8 +1982,8 @@ export class ResourceSystem extends SystemBase {
       // FORESTRY: Remove from active gatherers (timer will regenerate if no other gatherers)
       this.removeActiveGatherer(pid, session.resourceId);
 
-      // OSRS-STYLE: Hide gathering tool visual if fishing
-      if (session.skill === "fishing" && session.toolItemId) {
+      // OSRS-STYLE: Hide gathering tool visual and restore equipped weapon
+      if (session.toolItemId) {
         this.emitTypedEvent(EventType.GATHERING_TOOL_HIDE, {
           playerId: playerId,
           slot: "weapon",

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -25,11 +25,17 @@ export const EXACT_FISHING_TOOLS = [
 
 export type FishingToolId = (typeof EXACT_FISHING_TOOLS)[number];
 
+/** Known gathering tool categories */
+type ToolCategory = "hatchet" | "pickaxe";
+
+/** Skill types matching the manifest's GatheringToolData.skill union */
+type GatheringSkill = "woodcutting" | "mining" | "fishing";
+
 /**
  * Map from tool category to the skill it belongs to.
  * Used to look up tools in the manifest by category.
  */
-const CATEGORY_TO_SKILL: Record<string, string> = {
+const CATEGORY_TO_SKILL: Record<ToolCategory, GatheringSkill> = {
   hatchet: "woodcutting",
   pickaxe: "mining",
 };
@@ -146,9 +152,14 @@ export function itemMatchesToolCategory(
     }
   }
 
-  // Fallback for tools not in the manifest: check if item ID contains the category
-  // (e.g., future tools added to the game before the manifest is updated)
-  // Exclude cross-matches: if category is "hatchet", reject items containing "pickaxe"
+  // Fallback for tools not in the manifest — substring matching with cross-skill guards.
+  // Log a warning so we know to backfill the manifest for any tool hitting this path.
+  if (!toolData && (category === "hatchet" || category === "pickaxe")) {
+    console.warn(
+      `[ToolUtils] Item "${itemId}" not found in tools manifest — using fallback matching for category "${category}"`,
+    );
+  }
+
   if (category === "hatchet") {
     if (lowerItemId.includes("pickaxe") || lowerItemId.includes("pick")) {
       return false;

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -2,10 +2,14 @@
  * ToolUtils - Pure utility functions for tool validation and categorization
  *
  * Extracted from ResourceSystem.ts for SOLID compliance (Single Responsibility).
- * These are pure functions with no system dependencies.
+ *
+ * Tool validation uses the tools.json manifest as the single source of truth.
+ * Each tool has an explicit `skill` field ("woodcutting", "mining", "fishing")
+ * that determines which resources it can be used on — no substring matching.
  */
 
 import { isNotedItemId } from "../../../../data/NoteGenerator";
+import { getExternalTool } from "../../../../utils/ExternalAssetUtils";
 
 /**
  * OSRS fishing tools that require exact matching (not interchangeable)
@@ -20,6 +24,15 @@ export const EXACT_FISHING_TOOLS = [
 ] as const;
 
 export type FishingToolId = (typeof EXACT_FISHING_TOOLS)[number];
+
+/**
+ * Map from tool category to the skill it belongs to.
+ * Used to look up tools in the manifest by category.
+ */
+const CATEGORY_TO_SKILL: Record<string, string> = {
+  hatchet: "woodcutting",
+  pickaxe: "mining",
+};
 
 /**
  * Extract tool category from toolRequired field
@@ -93,10 +106,15 @@ export function isExactMatchFishingTool(category: string): boolean {
 }
 
 /**
- * Check if an item ID matches the required tool category
+ * Check if an item ID matches the required tool category.
  *
- * OSRS-ACCURACY: Fishing tools require EXACT matching.
- * Other tools (pickaxe, hatchet) use category matching (any tier works).
+ * Uses the tools.json manifest as the single source of truth:
+ * - Looks up the item in the manifest to get its declared skill
+ * - Compares the skill against the expected skill for the category
+ * - Fishing tools require exact ID match (not interchangeable)
+ *
+ * This prevents cross-skill tool usage (e.g., pickaxe for woodcutting)
+ * which was possible with the old substring-matching approach.
  *
  * @param itemId - The item ID from player inventory
  * @param category - The required tool category
@@ -118,14 +136,28 @@ export function itemMatchesToolCategory(
     return lowerItemId === category;
   }
 
-  // For hatchet/pickaxe categories, check if item contains the category
+  // Manifest-based validation: look up the item in tools.json
+  const toolData = getExternalTool(lowerItemId);
+  if (toolData) {
+    // Tool exists in manifest — check if its skill matches the required category
+    const expectedSkill = CATEGORY_TO_SKILL[category];
+    if (expectedSkill) {
+      return toolData.skill === expectedSkill;
+    }
+  }
+
+  // Fallback for tools not in the manifest: check if item ID contains the category
+  // (e.g., future tools added to the game before the manifest is updated)
+  // Exclude cross-matches: if category is "hatchet", reject items containing "pickaxe"
   if (category === "hatchet") {
+    if (lowerItemId.includes("pickaxe") || lowerItemId.includes("pick")) {
+      return false;
+    }
     return lowerItemId.includes("hatchet") || lowerItemId.includes("axe");
   }
   if (category === "pickaxe") {
     return lowerItemId.includes("pickaxe") || lowerItemId.includes("pick");
   }
 
-  // Fallback: check if item ID contains the category
   return lowerItemId.includes(category);
 }

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -33,9 +33,11 @@ type GatheringSkill = "woodcutting" | "mining" | "fishing";
 
 /**
  * Map from tool category to the skill it belongs to.
- * Used to look up tools in the manifest by category.
+ * When a new gathering category is added (e.g., "knife" for crafting),
+ * add an entry here so the manifest path handles it — otherwise the
+ * fallback path uses a direct category===skill comparison.
  */
-const CATEGORY_TO_SKILL: Record<ToolCategory, GatheringSkill> = {
+const CATEGORY_TO_SKILL: Partial<Record<string, GatheringSkill>> = {
   hatchet: "woodcutting",
   pickaxe: "mining",
 };
@@ -145,16 +147,16 @@ export function itemMatchesToolCategory(
   // Manifest-based validation: look up the item in tools.json
   const toolData = getExternalTool(lowerItemId);
   if (toolData) {
-    // Tool exists in manifest — check if its skill matches the required category
-    const expectedSkill = CATEGORY_TO_SKILL[category];
-    if (expectedSkill) {
-      return toolData.skill === expectedSkill;
-    }
+    // Tool exists in manifest — check if its skill matches the required category.
+    // For known categories (hatchet, pickaxe), compare via CATEGORY_TO_SKILL.
+    // For unknown categories, compare the skill directly against the category string.
+    const expectedSkill = CATEGORY_TO_SKILL[category] ?? category;
+    return toolData.skill === expectedSkill;
   }
 
   // Fallback for tools not in the manifest — substring matching with cross-skill guards.
   // Log a warning so we know to backfill the manifest for any tool hitting this path.
-  if (!toolData && (category === "hatchet" || category === "pickaxe")) {
+  if (category === "hatchet" || category === "pickaxe") {
     console.warn(
       `[ToolUtils] Item "${itemId}" not found in tools manifest — using fallback matching for category "${category}"`,
     );
@@ -167,6 +169,9 @@ export function itemMatchesToolCategory(
     return lowerItemId.includes("hatchet") || lowerItemId.includes("axe");
   }
   if (category === "pickaxe") {
+    if (lowerItemId.includes("hatchet")) {
+      return false;
+    }
     return lowerItemId.includes("pickaxe") || lowerItemId.includes("pick");
   }
 

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -25,11 +25,16 @@ export const EXACT_FISHING_TOOLS = [
 
 export type FishingToolId = (typeof EXACT_FISHING_TOOLS)[number];
 
-/** Known gathering tool categories */
-type ToolCategory = "hatchet" | "pickaxe";
-
 /** Skill types matching the manifest's GatheringToolData.skill union */
 type GatheringSkill = "woodcutting" | "mining" | "fishing";
+
+/** Track items that have already triggered the fallback warning (warn once per item) */
+const fallbackWarned = new Set<string>();
+
+/** Reset the fallback warning cache. Test-only. */
+export function _resetFallbackWarnings(): void {
+  fallbackWarned.clear();
+}
 
 /**
  * Map from tool category to the skill it belongs to.
@@ -155,8 +160,12 @@ export function itemMatchesToolCategory(
   }
 
   // Fallback for tools not in the manifest — substring matching with cross-skill guards.
-  // Log a warning so we know to backfill the manifest for any tool hitting this path.
-  if (category === "hatchet" || category === "pickaxe") {
+  // Warn once per item so manifest gaps are visible without flooding production logs.
+  if (
+    (category === "hatchet" || category === "pickaxe") &&
+    !fallbackWarned.has(lowerItemId)
+  ) {
+    fallbackWarned.add(lowerItemId);
     console.warn(
       `[ToolUtils] Item "${itemId}" not found in tools manifest — using fallback matching for category "${category}"`,
     );

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -30,7 +30,8 @@ type GatheringSkill = "woodcutting" | "mining" | "fishing";
 
 /**
  * Track items that have already triggered the fallback warning (warn once per item).
- * Capped at MAX_FALLBACK_WARNINGS to prevent unbounded growth on long-running servers.
+ * Once the Set reaches MAX_FALLBACK_WARNINGS, no new entries are added and no further
+ * warnings are logged. The Set entries persist for the lifetime of the process.
  */
 const MAX_FALLBACK_WARNINGS = 50;
 const fallbackWarned = new Set<string>();
@@ -50,7 +51,7 @@ export function _resetFallbackWarnings(): void {
  * fallback compares category===skill directly.
  *
  * NOTE: Fishing tools bypass this map via the exact-match path.
- * If you add a new gathering skill, you MUST add its category here.
+ * If you add a new category-matched gathering skill, you MUST add its category here.
  */
 const CATEGORY_TO_SKILL: Partial<Record<string, GatheringSkill>> = {
   hatchet: "woodcutting",
@@ -170,8 +171,7 @@ export function itemMatchesToolCategory(
   }
 
   // Fallback for tools not in the manifest — substring matching with cross-skill guards.
-  // Warn once per item. Both the warning count AND Set size are capped to prevent
-  // unbounded memory growth on long-running servers.
+  // Warn once per item, capped at MAX_FALLBACK_WARNINGS total unique items.
   if (
     fallbackWarned.size < MAX_FALLBACK_WARNINGS &&
     !fallbackWarned.has(lowerItemId)

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -28,10 +28,17 @@ export type FishingToolId = (typeof EXACT_FISHING_TOOLS)[number];
 /** Skill types matching the manifest's GatheringToolData.skill union */
 type GatheringSkill = "woodcutting" | "mining" | "fishing";
 
-/** Track items that have already triggered the fallback warning (warn once per item) */
+/**
+ * Track items that have already triggered the fallback warning (warn once per item).
+ * Capped at MAX_FALLBACK_WARNINGS to prevent unbounded growth on long-running servers.
+ */
+const MAX_FALLBACK_WARNINGS = 50;
 const fallbackWarned = new Set<string>();
 
-/** Reset the fallback warning cache. Test-only. */
+/**
+ * Reset the fallback warning cache.
+ * @internal Exported for test isolation only — do not call in production code.
+ */
 export function _resetFallbackWarnings(): void {
   fallbackWarned.clear();
 }
@@ -160,10 +167,10 @@ export function itemMatchesToolCategory(
   }
 
   // Fallback for tools not in the manifest — substring matching with cross-skill guards.
-  // Warn once per item so manifest gaps are visible without flooding production logs.
+  // Warn once per item (capped) so manifest gaps are visible without flooding logs.
   if (
-    (category === "hatchet" || category === "pickaxe") &&
-    !fallbackWarned.has(lowerItemId)
+    !fallbackWarned.has(lowerItemId) &&
+    fallbackWarned.size < MAX_FALLBACK_WARNINGS
   ) {
     fallbackWarned.add(lowerItemId);
     console.warn(
@@ -171,6 +178,10 @@ export function itemMatchesToolCategory(
     );
   }
 
+  // NOTE: The substring fallback below is inherently fragile. For example, a combat
+  // weapon like "battleaxe" would match the hatchet category because it contains "axe".
+  // This is acceptable as a safety net — the manifest path is the long-term solution
+  // and all known gathering tools should be in tools.json.
   if (category === "hatchet") {
     if (lowerItemId.includes("pickaxe") || lowerItemId.includes("pick")) {
       return false;

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -47,7 +47,10 @@ export function _resetFallbackWarnings(): void {
  * Map from tool category to the skill it belongs to.
  * When a new gathering category is added (e.g., "knife" for crafting),
  * add an entry here so the manifest path handles it — otherwise the
- * fallback path uses a direct category===skill comparison.
+ * fallback compares category===skill directly.
+ *
+ * NOTE: Fishing tools bypass this map via the exact-match path.
+ * If you add a new gathering skill, you MUST add its category here.
  */
 const CATEGORY_TO_SKILL: Partial<Record<string, GatheringSkill>> = {
   hatchet: "woodcutting",
@@ -196,5 +199,7 @@ export function itemMatchesToolCategory(
     return lowerItemId.includes("pickaxe") || lowerItemId.includes("pick");
   }
 
-  return lowerItemId.includes(category);
+  // Unknown category with no manifest entry — reject rather than substring match.
+  // All gathering tools must be in tools.json; this forces manifest completeness.
+  return false;
 }

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -167,10 +167,11 @@ export function itemMatchesToolCategory(
   }
 
   // Fallback for tools not in the manifest — substring matching with cross-skill guards.
-  // Warn once per item (capped) so manifest gaps are visible without flooding logs.
+  // Warn once per item. Both the warning count AND Set size are capped to prevent
+  // unbounded memory growth on long-running servers.
   if (
-    !fallbackWarned.has(lowerItemId) &&
-    fallbackWarned.size < MAX_FALLBACK_WARNINGS
+    fallbackWarned.size < MAX_FALLBACK_WARNINGS &&
+    !fallbackWarned.has(lowerItemId)
   ) {
     fallbackWarned.add(lowerItemId);
     console.warn(
@@ -178,18 +179,15 @@ export function itemMatchesToolCategory(
     );
   }
 
-  // Substring fallback with combat-weapon exclusions to prevent false positives.
-  // All known gathering tools should be in tools.json — this is a safety net only.
+  // Substring fallback — intentionally conservative to avoid false positives.
+  // All known gathering tools should be in tools.json; this is a safety net only.
+  // For hatchet, we only match "hatchet" (not bare "axe") to avoid combat weapons
+  // like battleaxe, greataxe, etc. that would otherwise false-positive.
   if (category === "hatchet") {
-    if (
-      lowerItemId.includes("pickaxe") ||
-      lowerItemId.includes("pick") ||
-      lowerItemId.includes("battleaxe") ||
-      lowerItemId.includes("greataxe")
-    ) {
+    if (lowerItemId.includes("pickaxe") || lowerItemId.includes("pick")) {
       return false;
     }
-    return lowerItemId.includes("hatchet") || lowerItemId.includes("axe");
+    return lowerItemId.includes("hatchet");
   }
   if (category === "pickaxe") {
     if (lowerItemId.includes("hatchet")) {

--- a/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/ToolUtils.ts
@@ -178,12 +178,15 @@ export function itemMatchesToolCategory(
     );
   }
 
-  // NOTE: The substring fallback below is inherently fragile. For example, a combat
-  // weapon like "battleaxe" would match the hatchet category because it contains "axe".
-  // This is acceptable as a safety net — the manifest path is the long-term solution
-  // and all known gathering tools should be in tools.json.
+  // Substring fallback with combat-weapon exclusions to prevent false positives.
+  // All known gathering tools should be in tools.json — this is a safety net only.
   if (category === "hatchet") {
-    if (lowerItemId.includes("pickaxe") || lowerItemId.includes("pick")) {
+    if (
+      lowerItemId.includes("pickaxe") ||
+      lowerItemId.includes("pick") ||
+      lowerItemId.includes("battleaxe") ||
+      lowerItemId.includes("greataxe")
+    ) {
       return false;
     }
     return lowerItemId.includes("hatchet") || lowerItemId.includes("axe");

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -9,7 +9,8 @@
  * @see https://oldschool.runescape.wiki/w/Noted_items
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import type { GatheringToolData } from "../../../../../data/DataManager";
 import {
   itemMatchesToolCategory,
   getToolCategory,
@@ -144,6 +145,59 @@ describe("ToolUtils", () => {
         expect(itemMatchesToolCategory("dragon_hatchet", "pickaxe")).toBe(
           false,
         );
+      });
+    });
+
+    describe("manifest-based validation", () => {
+      // Populate globalThis.EXTERNAL_TOOLS so the manifest path is exercised
+      const mockTools = new Map<string, GatheringToolData>();
+
+      function addMockTool(
+        itemId: string,
+        skill: "woodcutting" | "mining" | "fishing",
+      ) {
+        mockTools.set(itemId, {
+          itemId,
+          skill,
+          tier: "test",
+          levelRequired: 1,
+          priority: 1,
+        });
+      }
+
+      afterEach(() => {
+        mockTools.clear();
+        delete (globalThis as Record<string, unknown>).EXTERNAL_TOOLS;
+      });
+
+      it("accepts woodcutting tool for hatchet category via manifest", () => {
+        addMockTool("bronze_hatchet", "woodcutting");
+        (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
+
+        expect(itemMatchesToolCategory("bronze_hatchet", "hatchet")).toBe(true);
+      });
+
+      it("rejects mining tool for hatchet category via manifest", () => {
+        addMockTool("bronze_pickaxe", "mining");
+        (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
+
+        expect(itemMatchesToolCategory("bronze_pickaxe", "hatchet")).toBe(
+          false,
+        );
+      });
+
+      it("rejects woodcutting tool for pickaxe category via manifest", () => {
+        addMockTool("iron_hatchet", "woodcutting");
+        (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
+
+        expect(itemMatchesToolCategory("iron_hatchet", "pickaxe")).toBe(false);
+      });
+
+      it("accepts mining tool for pickaxe category via manifest", () => {
+        addMockTool("rune_pickaxe", "mining");
+        (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
+
+        expect(itemMatchesToolCategory("rune_pickaxe", "pickaxe")).toBe(true);
       });
     });
 

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -122,12 +122,28 @@ describe("ToolUtils", () => {
       });
 
       it("does not match pickaxe for hatchet category", () => {
-        // 'pickaxe' contains 'axe' but should not match hatchet category
-        // because pickaxe check happens first in getToolCategory
-        // However, itemMatchesToolCategory checks category, not extraction
-        // So "bronze_pickaxe" does contain "axe" and would match hatchet
-        // This is expected behavior - the category is determined by getToolCategory first
-        expect(itemMatchesToolCategory("bronze_pickaxe", "hatchet")).toBe(true);
+        // Pickaxes are mining tools — they must NOT match the hatchet (woodcutting) category.
+        // The manifest declares each tool's skill explicitly, preventing cross-skill usage.
+        expect(itemMatchesToolCategory("bronze_pickaxe", "hatchet")).toBe(
+          false,
+        );
+        expect(itemMatchesToolCategory("iron_pickaxe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("rune_pickaxe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("dragon_pickaxe", "hatchet")).toBe(
+          false,
+        );
+      });
+
+      it("does not match hatchet for pickaxe category", () => {
+        // Hatchets are woodcutting tools — they must NOT match the pickaxe (mining) category.
+        expect(itemMatchesToolCategory("bronze_hatchet", "pickaxe")).toBe(
+          false,
+        );
+        expect(itemMatchesToolCategory("iron_hatchet", "pickaxe")).toBe(false);
+        expect(itemMatchesToolCategory("rune_hatchet", "pickaxe")).toBe(false);
+        expect(itemMatchesToolCategory("dragon_hatchet", "pickaxe")).toBe(
+          false,
+        );
       });
     });
 

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -250,8 +250,9 @@ describe("ToolUtils", () => {
         );
       });
 
-      it("uses generic substring match for unknown categories", () => {
-        expect(itemMatchesToolCategory("bronze_hammer", "hammer")).toBe(true);
+      it("rejects unknown categories not in manifest", () => {
+        // Unknown categories default to false — forces manifest completeness
+        expect(itemMatchesToolCategory("bronze_hammer", "hammer")).toBe(false);
         expect(itemMatchesToolCategory("iron_chisel", "hammer")).toBe(false);
       });
     });

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -9,7 +9,7 @@
  * @see https://oldschool.runescape.wiki/w/Noted_items
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import type { GatheringToolData } from "../../../../../data/DataManager";
 import {
   itemMatchesToolCategory,
@@ -198,6 +198,48 @@ describe("ToolUtils", () => {
         (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
 
         expect(itemMatchesToolCategory("rune_pickaxe", "pickaxe")).toBe(true);
+      });
+
+      it("rejects manifest tool for unknown category via direct skill comparison", () => {
+        // Tool is in manifest with skill "mining", but category "hammer" isn't in CATEGORY_TO_SKILL.
+        // Falls back to direct comparison: toolData.skill ("mining") === category ("hammer") → false.
+        addMockTool("bronze_pickaxe", "mining");
+        (globalThis as Record<string, unknown>).EXTERNAL_TOOLS = mockTools;
+
+        expect(itemMatchesToolCategory("bronze_pickaxe", "hammer")).toBe(false);
+      });
+    });
+
+    describe("fallback path (no manifest)", () => {
+      beforeEach(() => {
+        // Ensure no manifest is loaded so fallback substring matching is exercised
+        delete (globalThis as Record<string, unknown>).EXTERNAL_TOOLS;
+      });
+
+      it("matches hatchet via fallback and logs warning", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(itemMatchesToolCategory("bronze_hatchet", "hatchet")).toBe(true);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("not found in tools manifest"),
+        );
+        warnSpy.mockRestore();
+      });
+
+      it("rejects pickaxe for hatchet via fallback", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(itemMatchesToolCategory("iron_pickaxe", "hatchet")).toBe(false);
+        warnSpy.mockRestore();
+      });
+
+      it("rejects hatchet for pickaxe via fallback", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        expect(itemMatchesToolCategory("iron_hatchet", "pickaxe")).toBe(false);
+        warnSpy.mockRestore();
+      });
+
+      it("uses generic substring match for unknown categories", () => {
+        expect(itemMatchesToolCategory("bronze_hammer", "hammer")).toBe(true);
+        expect(itemMatchesToolCategory("iron_chisel", "hammer")).toBe(false);
       });
     });
 

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -16,6 +16,7 @@ import {
   getToolCategory,
   isExactMatchFishingTool,
   getToolDisplayName,
+  _resetFallbackWarnings,
 } from "../ToolUtils";
 
 describe("ToolUtils", () => {
@@ -214,6 +215,8 @@ describe("ToolUtils", () => {
       beforeEach(() => {
         // Ensure no manifest is loaded so fallback substring matching is exercised
         delete (globalThis as Record<string, unknown>).EXTERNAL_TOOLS;
+        // Reset warn-once cache so each test can verify warnings independently
+        _resetFallbackWarnings();
       });
 
       it("matches hatchet via fallback and logs warning", () => {

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -69,7 +69,7 @@ describe("ToolUtils", () => {
         expect(itemMatchesToolCategory("bronze_pickaxe", "pickaxe")).toBe(true);
         expect(itemMatchesToolCategory("rune_pickaxe", "pickaxe")).toBe(true);
         expect(itemMatchesToolCategory("dragon_pickaxe", "pickaxe")).toBe(true);
-        expect(itemMatchesToolCategory("bronze_axe", "hatchet")).toBe(true);
+        expect(itemMatchesToolCategory("bronze_hatchet", "hatchet")).toBe(true);
         expect(itemMatchesToolCategory("rune_hatchet", "hatchet")).toBe(true);
       });
     });
@@ -110,10 +110,14 @@ describe("ToolUtils", () => {
         expect(itemMatchesToolCategory("rune_hatchet", "hatchet")).toBe(true);
       });
 
-      it("matches items containing 'axe'", () => {
-        expect(itemMatchesToolCategory("bronze_axe", "hatchet")).toBe(true);
-        expect(itemMatchesToolCategory("iron_axe", "hatchet")).toBe(true);
-        expect(itemMatchesToolCategory("dragon_axe", "hatchet")).toBe(true);
+      it("rejects bare 'axe' items without 'hatchet' in fallback", () => {
+        // Fallback only matches "hatchet" substring, not bare "axe",
+        // to avoid false positives with combat weapons (battleaxe, greataxe, etc.).
+        // Real tools like bronze_axe/dragon_axe go through the manifest path.
+        expect(itemMatchesToolCategory("bronze_axe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("iron_axe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("battleaxe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("greataxe", "hatchet")).toBe(false);
       });
 
       it("rejects non-hatchet items", () => {
@@ -121,17 +125,6 @@ describe("ToolUtils", () => {
           false,
         );
         expect(itemMatchesToolCategory("logs", "hatchet")).toBe(false);
-      });
-
-      it("rejects combat weapons containing 'axe'", () => {
-        expect(itemMatchesToolCategory("battleaxe", "hatchet")).toBe(false);
-        expect(itemMatchesToolCategory("iron_battleaxe", "hatchet")).toBe(
-          false,
-        );
-        expect(itemMatchesToolCategory("greataxe", "hatchet")).toBe(false);
-        expect(itemMatchesToolCategory("dragon_greataxe", "hatchet")).toBe(
-          false,
-        );
       });
 
       it("does not match pickaxe for hatchet category", () => {
@@ -228,36 +221,33 @@ describe("ToolUtils", () => {
         delete (globalThis as Record<string, unknown>).EXTERNAL_TOOLS;
         // Reset warn-once cache so each test can verify warnings independently
         _resetFallbackWarnings();
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
       });
 
       it("matches hatchet via fallback and logs warning", () => {
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         expect(itemMatchesToolCategory("bronze_hatchet", "hatchet")).toBe(true);
-        expect(warnSpy).toHaveBeenCalledWith(
+        expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining("not found in tools manifest"),
         );
-        warnSpy.mockRestore();
       });
 
       it("rejects pickaxe for hatchet via fallback", () => {
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         expect(itemMatchesToolCategory("iron_pickaxe", "hatchet")).toBe(false);
-        warnSpy.mockRestore();
       });
 
       it("rejects hatchet for pickaxe via fallback", () => {
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         expect(itemMatchesToolCategory("iron_hatchet", "pickaxe")).toBe(false);
-        warnSpy.mockRestore();
       });
 
       it("warns for any category, not just hatchet/pickaxe", () => {
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         itemMatchesToolCategory("bronze_hammer", "hammer");
-        expect(warnSpy).toHaveBeenCalledWith(
+        expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining("not found in tools manifest"),
         );
-        warnSpy.mockRestore();
       });
 
       it("uses generic substring match for unknown categories", () => {

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -123,6 +123,17 @@ describe("ToolUtils", () => {
         expect(itemMatchesToolCategory("logs", "hatchet")).toBe(false);
       });
 
+      it("rejects combat weapons containing 'axe'", () => {
+        expect(itemMatchesToolCategory("battleaxe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("iron_battleaxe", "hatchet")).toBe(
+          false,
+        );
+        expect(itemMatchesToolCategory("greataxe", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("dragon_greataxe", "hatchet")).toBe(
+          false,
+        );
+      });
+
       it("does not match pickaxe for hatchet category", () => {
         // Pickaxes are mining tools — they must NOT match the hatchet (woodcutting) category.
         // The manifest declares each tool's skill explicitly, preventing cross-skill usage.
@@ -298,6 +309,20 @@ describe("ToolUtils", () => {
           true,
         );
         expect(itemMatchesToolCategory("pot", "lobster_pot")).toBe(false);
+      });
+
+      it("fishing tools do not match hatchet or pickaxe categories", () => {
+        // Three-way invariant: fishing tools are never valid for woodcutting/mining
+        expect(itemMatchesToolCategory("fishing_rod", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("fishing_rod", "pickaxe")).toBe(false);
+        expect(itemMatchesToolCategory("harpoon", "hatchet")).toBe(false);
+        expect(itemMatchesToolCategory("harpoon", "pickaxe")).toBe(false);
+        expect(itemMatchesToolCategory("small_fishing_net", "hatchet")).toBe(
+          false,
+        );
+        expect(itemMatchesToolCategory("small_fishing_net", "pickaxe")).toBe(
+          false,
+        );
       });
     });
   });

--- a/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
+++ b/packages/shared/src/systems/shared/entities/gathering/__tests__/ToolUtils.test.ts
@@ -240,6 +240,15 @@ describe("ToolUtils", () => {
         warnSpy.mockRestore();
       });
 
+      it("warns for any category, not just hatchet/pickaxe", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        itemMatchesToolCategory("bronze_hammer", "hammer");
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("not found in tools manifest"),
+        );
+        warnSpy.mockRestore();
+      });
+
       it("uses generic substring match for unknown categories", () => {
         expect(itemMatchesToolCategory("bronze_hammer", "hammer")).toBe(true);
         expect(itemMatchesToolCategory("iron_chisel", "hammer")).toBe(false);


### PR DESCRIPTION
itemMatchesToolCategory used substring matching — "pickaxe" contains "axe" so it matched the hatchet category, allowing pickaxes to cut trees and hatchets to mine rocks.

Fix: use the tools.json manifest as the source of truth. Each tool declares its skill ("woodcutting", "mining", "fishing") explicitly. The manifest lookup prevents cross-skill usage. A substring fallback with explicit exclusions handles tools not yet in the manifest.

Adds cross-skill rejection tests for both directions.