### PR TITLE
fix(gathering): make resource respawn purely tick-based, use manifest…

### DIFF
--- a/packages/shared/src/constants/GatheringConstants.ts
+++ b/packages/shared/src/constants/GatheringConstants.ts
@@ -248,24 +248,6 @@ export const GATHERING_CONSTANTS = {
     redwood: 199, // ~119.4 seconds
   } as const,
 
-  // === Mining Depletion (OSRS: always depletes) ===
-  /**
-   * Mining rocks ALWAYS deplete after yielding one ore in OSRS.
-   * There is NO random chance - depletion is guaranteed (100%).
-   *
-   * The only exception is Mining gloves which can prevent depletion:
-   * - Mining gloves: 1 extra ore before depletion (silver, coal, gold)
-   * - Superior mining gloves: 1-2 extra ores (iron, silver, coal, gold, mithril)
-   * - Expert mining gloves: 1-3 extra ores (all ores)
-   * (Mining gloves not currently implemented)
-   *
-   * @see https://oldschool.runescape.wiki/w/Copper_rocks
-   * @see https://oldschool.runescape.wiki/w/Iron_rocks
-   * @see https://oldschool.runescape.wiki/w/Mining
-   */
-  MINING_DEPLETE_CHANCE: 1.0, // OSRS: Always depletes after one ore
-  MINING_REDWOOD_DEPLETE_CHANCE: 0.091, // 1/11 for redwood stumps (woodcutting)
-
   // === Timer Regeneration ===
   /**
    * Rate at which tree timers regenerate when no one is gathering.

--- a/packages/shared/src/entities/world/ResourceEntity.ts
+++ b/packages/shared/src/entities/world/ResourceEntity.ts
@@ -41,7 +41,6 @@ export type { ResourceEntityConfig } from "../../types/entities";
 
 export class ResourceEntity extends InteractableEntity {
   public config: ResourceEntityConfig;
-  private respawnTimer?: ReturnType<typeof setTimeout>;
 
   /** Tiles this resource occupies for collision (cached for cleanup) */
   private collisionTiles: TileCoord[] = [];
@@ -203,13 +202,8 @@ export class ResourceEntity extends InteractableEntity {
       interactionComponent.data.description = `${this.config.resourceType} - Depleted`;
     }
 
-    if (this.respawnTimer) clearTimeout(this.respawnTimer);
-
-    // Schedule respawn with tracked timer to prevent memory leaks
-    this.respawnTimer = setTimeout(() => {
-      this.respawn();
-      this.respawnTimer = undefined;
-    }, this.config.respawnTime);
+    // Respawn is handled by ResourceSystem.processRespawns() via tick-based timing.
+    // No setTimeout here — tick-based respawn is deterministic and OSRS-accurate.
   }
 
   public respawn(): void {
@@ -423,11 +417,6 @@ export class ResourceEntity extends InteractableEntity {
   destroy(local?: boolean): void {
     if (this.world.isServer && this.collisionTiles.length > 0) {
       this.unregisterCollision();
-    }
-
-    if (this.respawnTimer) {
-      clearTimeout(this.respawnTimer);
-      this.respawnTimer = undefined;
     }
 
     // Delegate visual cleanup to strategy

--- a/packages/shared/src/systems/shared/entities/ResourceSystem.ts
+++ b/packages/shared/src/systems/shared/entities/ResourceSystem.ts
@@ -2751,12 +2751,15 @@ export class ResourceSystem extends SystemBase {
           resource.type === "ore" ||
           resource.skillRequired === "mining"
         ) {
-          // MINING: Chance-based depletion (1/8 for most rocks)
-          const roll = Math.random();
-          shouldDeplete = roll < GATHERING_CONSTANTS.MINING_DEPLETE_CHANCE;
-          console.log(
-            `[Forestry] ⛏️ ${session.resourceId}: Mining roll=${roll.toFixed(3)} vs ${GATHERING_CONSTANTS.MINING_DEPLETE_CHANCE} → ${shouldDeplete ? "DEPLETE" : "continue"}`,
-          );
+          // MINING: Use manifest depleteChance (1.0 for most rocks, 0 for essence)
+          // OSRS: Rune essence rocks never deplete — continuous mining until inventory full.
+          const depletionChance = tuned.depleteChance;
+          if (depletionChance <= 0) {
+            shouldDeplete = false;
+          } else {
+            const roll = Math.random();
+            shouldDeplete = roll < depletionChance;
+          }
         } else if (
           resource.type === "fishing_spot" ||
           resource.skillRequired === "fishing"

--- a/packages/shared/src/systems/shared/entities/ResourceSystem.ts
+++ b/packages/shared/src/systems/shared/entities/ResourceSystem.ts
@@ -2753,12 +2753,15 @@ export class ResourceSystem extends SystemBase {
         ) {
           // MINING: Use manifest depleteChance (1.0 for most rocks, 0 for essence)
           // OSRS: Rune essence rocks never deplete — continuous mining until inventory full.
-          const depletionChance = tuned.depleteChance;
+          const depletionChance = tuned.depleteChance ?? 1.0;
           if (depletionChance <= 0) {
             shouldDeplete = false;
           } else {
             const roll = Math.random();
             shouldDeplete = roll < depletionChance;
+            console.log(
+              `[Mining] ⛏️ ${session.resourceId}: Chance roll=${roll.toFixed(3)} vs ${depletionChance} → ${shouldDeplete ? "DEPLETE" : "continue"}`,
+            );
           }
         } else if (
           resource.type === "fishing_spot" ||
@@ -2769,9 +2772,10 @@ export class ResourceSystem extends SystemBase {
         } else {
           // REGULAR TREES & FALLBACK: Use manifest depleteChance (1/8 for regular trees)
           const roll = Math.random();
-          shouldDeplete = roll < tuned.depleteChance;
+          const fallbackChance = tuned.depleteChance ?? 1.0;
+          shouldDeplete = roll < fallbackChance;
           console.log(
-            `[Forestry] 🌲 ${session.resourceId}: Chance roll=${roll.toFixed(3)} vs ${tuned.depleteChance} → ${shouldDeplete ? "DEPLETE" : "continue"}`,
+            `[Forestry] 🌲 ${session.resourceId}: Chance roll=${roll.toFixed(3)} vs ${fallbackChance} → ${shouldDeplete ? "DEPLETE" : "continue"}`,
           );
         }
 

--- a/packages/shared/src/systems/shared/entities/__tests__/ResourceSystem.integration.test.ts
+++ b/packages/shared/src/systems/shared/entities/__tests__/ResourceSystem.integration.test.ts
@@ -544,6 +544,251 @@ describe("ResourceSystem Integration", () => {
     });
   });
 
+  describe("Depletion Chance", () => {
+    it("should never deplete a resource with depleteChance: 0 (essence rock)", () => {
+      // Setup: Player with mining skill and pickaxe
+      const player = createTestPlayer("miner1", { mining: 1 });
+      player.position = { x: 10, y: 0, z: 10 };
+      mockWorld.addPlayer(player);
+      mockWorld.setInventory(
+        "miner1",
+        createTestInventory([{ itemId: "bronze_pickaxe", quantity: 1 }]),
+      );
+
+      const resourceId = "ore_essence_10_10";
+      const playerId = "miner1";
+      const startTick = 100;
+
+      // Inject resource into the resources map (type: "ore" triggers mining branch)
+      const resources = (
+        system as unknown as {
+          resources: Map<
+            string,
+            {
+              id: string;
+              type: string;
+              name: string;
+              position: { x: number; y: number; z: number };
+              skillRequired: string;
+              levelRequired: number;
+              toolRequired: string;
+              respawnTime: number;
+              isAvailable: boolean;
+              lastDepleted: number;
+              drops: Array<{
+                itemId: string;
+                itemName: string;
+                quantity: number;
+                chance: number;
+                xpAmount: number;
+              }>;
+            }
+          >;
+        }
+      ).resources;
+
+      resources.set(resourceId as never, {
+        id: resourceId,
+        type: "ore",
+        name: "Rune Essence",
+        position: { x: 11, y: 0, z: 10 },
+        skillRequired: "mining",
+        levelRequired: 1,
+        toolRequired: "pickaxe",
+        respawnTime: 0,
+        isAvailable: true,
+        lastDepleted: 0,
+        drops: [
+          {
+            itemId: "rune_essence",
+            itemName: "Rune essence",
+            quantity: 1,
+            chance: 1,
+            xpAmount: 5,
+          },
+        ],
+      });
+
+      // Inject gathering session with depleteChance: 0
+      const activeGathering = (
+        system as {
+          activeGathering: Map<string, Record<string, unknown>>;
+        }
+      ).activeGathering;
+
+      activeGathering.set(playerId, {
+        playerId,
+        resourceId,
+        startTick,
+        nextAttemptTick: startTick, // Ready to process immediately
+        cycleTickInterval: 4,
+        attempts: 0,
+        successes: 0,
+        cachedTuning: {
+          levelRequired: 1,
+          xpPerLog: 5,
+          depleteChance: 0, // KEY: essence rocks never deplete
+          respawnTicks: 0,
+        },
+        cachedSuccessRate: 1.0, // Always succeed to force depletion checks
+        cachedDrops: [
+          {
+            itemId: "rune_essence",
+            itemName: "Rune essence",
+            quantity: 1,
+            chance: 1,
+            xpAmount: 5,
+          },
+        ],
+        cachedResourceName: "Rune Essence",
+        cachedStartPosition: { ...player.position },
+      });
+
+      // Run 10 gather cycles — resource should never deplete
+      for (let tick = 0; tick < 10; tick++) {
+        const currentTick = startTick + tick * 4;
+        (mockWorld as { currentTick: number }).currentTick = currentTick;
+
+        // Reset nextAttemptTick so each call processes a gather
+        const session = activeGathering.get(playerId);
+        if (session) {
+          session.nextAttemptTick = currentTick;
+        }
+
+        system.processGatheringTick(currentTick);
+      }
+
+      // Resource should still be available (never depleted)
+      const resource = resources.get(resourceId as never);
+      expect(resource?.isAvailable).toBe(true);
+
+      // No RESOURCE_DEPLETED events should have been emitted via eventBus
+      const emitCalls = (
+        mockWorld.$eventBus.emitEvent as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const depleteEvents = emitCalls.filter(
+        (call: unknown[]) => call[0] === EventType.RESOURCE_DEPLETED,
+      );
+      expect(depleteEvents).toHaveLength(0);
+    });
+
+    it("should deplete a resource with depleteChance: 1.0 (regular ore)", () => {
+      // Setup: Player with mining skill and pickaxe
+      const player = createTestPlayer("miner2", { mining: 1 });
+      player.position = { x: 20, y: 0, z: 20 };
+      mockWorld.addPlayer(player);
+      mockWorld.setInventory(
+        "miner2",
+        createTestInventory([{ itemId: "bronze_pickaxe", quantity: 1 }]),
+      );
+
+      const resourceId = "ore_copper_20_20";
+      const playerId = "miner2";
+      const startTick = 200;
+
+      // Inject resource
+      const resources = (
+        system as unknown as {
+          resources: Map<
+            string,
+            {
+              id: string;
+              type: string;
+              name: string;
+              position: { x: number; y: number; z: number };
+              skillRequired: string;
+              levelRequired: number;
+              toolRequired: string;
+              respawnTime: number;
+              isAvailable: boolean;
+              lastDepleted: number;
+              drops: Array<{
+                itemId: string;
+                itemName: string;
+                quantity: number;
+                chance: number;
+                xpAmount: number;
+              }>;
+            }
+          >;
+        }
+      ).resources;
+
+      resources.set(resourceId as never, {
+        id: resourceId,
+        type: "ore",
+        name: "Copper Rock",
+        position: { x: 21, y: 0, z: 20 },
+        skillRequired: "mining",
+        levelRequired: 1,
+        toolRequired: "pickaxe",
+        respawnTime: 2400,
+        isAvailable: true,
+        lastDepleted: 0,
+        drops: [
+          {
+            itemId: "copper_ore",
+            itemName: "Copper ore",
+            quantity: 1,
+            chance: 1,
+            xpAmount: 17.5,
+          },
+        ],
+      });
+
+      // Inject gathering session with depleteChance: 1.0
+      const activeGathering = (
+        system as {
+          activeGathering: Map<string, Record<string, unknown>>;
+        }
+      ).activeGathering;
+
+      activeGathering.set(playerId, {
+        playerId,
+        resourceId,
+        startTick,
+        nextAttemptTick: startTick,
+        cycleTickInterval: 4,
+        attempts: 0,
+        successes: 0,
+        cachedTuning: {
+          levelRequired: 1,
+          xpPerLog: 17.5,
+          depleteChance: 1.0, // Always deplete on success
+          respawnTicks: 4,
+        },
+        cachedSuccessRate: 1.0, // Always succeed
+        cachedDrops: [
+          {
+            itemId: "copper_ore",
+            itemName: "Copper ore",
+            quantity: 1,
+            chance: 1,
+            xpAmount: 17.5,
+          },
+        ],
+        cachedResourceName: "Copper Rock",
+        cachedStartPosition: { ...player.position },
+      });
+
+      (mockWorld as { currentTick: number }).currentTick = startTick;
+      system.processGatheringTick(startTick);
+
+      // Resource should be depleted after first successful gather
+      const resource = resources.get(resourceId as never);
+      expect(resource?.isAvailable).toBe(false);
+
+      // RESOURCE_DEPLETED event should have been emitted via eventBus
+      const emitCalls = (
+        mockWorld.$eventBus.emitEvent as ReturnType<typeof vi.fn>
+      ).mock.calls;
+      const depleteEvents = emitCalls.filter(
+        (call: unknown[]) => call[0] === EventType.RESOURCE_DEPLETED,
+      );
+      expect(depleteEvents).toHaveLength(1);
+    });
+  });
+
   it("REGRESSION: should ignore duplicate gather requests (spam click exploit)", () => {
     // Setup: Create player and add to world
     const player = createTestPlayer("spam_clicker", { woodcutting: 99 });


### PR DESCRIPTION
… depleteChance for mining

- Remove legacy setTimeout-based respawn from ResourceEntity.deplete() — respawn is now exclusively handled by ResourceSystem.processRespawns() via deterministic tick counting (OSRS-accurate)
- Mining depletion now reads depleteChance from manifest instead of using hardcoded MINING_DEPLETE_CHANCE constant, allowing rune essence rocks (depleteChance: 0) to never deplete per OSRS behavior