### PR TITLE
fix(interaction): use LOD2 model geometry for tree collision proxy in…

### DIFF
--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -103,6 +103,8 @@ function mergeGeometries(
 
 // Cache merged+scaled proxy geometry per (sourceGeometries identity, scale) to avoid
 // redundant merge/clone/scale work for trees sharing the same model variant and scale.
+// NOTE: This cache only grows; it is cleared on world teardown via clearProxyGeometryCache().
+// This is fine as long as tree scales are discrete (e.g. from manifest modelScale values).
 const _proxyGeometryCache = new Map<
   THREE.BufferGeometry[],
   Map<number, THREE.BufferGeometry>
@@ -134,9 +136,14 @@ function getOrCreateProxyGeometry(
   const merged = mergeGeometries(sourceGeometries);
   if (!merged) return null;
 
-  // Always clone so mergeGeometries' single-part return (shared ref) is never mutated
+  // Always clone — mergeGeometries may return the pool's shared geometry directly
+  // (single-part case) or a freshly created merge. Cloning unconditionally ensures
+  // the cached entry is always an independent copy safe for Three.js raycaster use.
   const scaled = merged.clone();
   scaled.scale(scale, scale, scale);
+  // Pre-compute both bounds so Three.js raycaster never lazily mutates this geometry
+  scaled.computeBoundingBox();
+  scaled.computeBoundingSphere();
 
   if (!scaleMap) {
     scaleMap = new Map();
@@ -173,7 +180,11 @@ function createCollisionProxy(
   } else {
     // Fallback: tighter trunk-only cylinder (only if LOD geometry unavailable).
     // Reduced from 0.4 to 0.25 since the LOD proxy now handles canopy clicks;
-    // this path is only hit during initial load before LODs are ready.
+    // this path should rarely trigger — LOD data is typically available by the
+    // time createCollisionProxy is called after a successful addInstance.
+    console.warn(
+      `[TreeProxy] LOD geometry unavailable for ${ctx.id}, using cylinder fallback`,
+    );
     const dims = batched
       ? getBatchedDimensions(ctx.id)
       : getInstancedDimensions(ctx.id);

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -108,7 +108,8 @@ function createCollisionProxy(
     // Use a clone so the instancer's shared geometry isn't mutated by scale
     geometry = merged.clone();
     geometry.scale(scale, scale, scale);
-    // Align with visual: instancer shifts instances up by yOffset * scale
+    // Align with visual: instancer shifts instances up by yOffset * scale.
+    // proxyData is guaranteed non-null here — merged is only truthy when proxyData was non-null.
     yPos = proxyData!.yOffset * scale;
   } else {
     // Fallback: tight cylinder around trunk (only if LOD geometry unavailable)

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -108,20 +108,33 @@ const _proxyGeometryCache = new Map<
   Map<number, THREE.BufferGeometry>
 >();
 
+/**
+ * Dispose all cached proxy geometries and clear the cache.
+ * Must be called during world teardown to prevent GPU buffer leaks.
+ */
+export function clearProxyGeometryCache(): void {
+  for (const scaleMap of _proxyGeometryCache.values()) {
+    for (const geo of scaleMap.values()) geo.dispose();
+  }
+  _proxyGeometryCache.clear();
+}
+
 function getOrCreateProxyGeometry(
   sourceGeometries: THREE.BufferGeometry[],
   scale: number,
 ): THREE.BufferGeometry | null {
+  // Round scale to 3 decimal places to avoid floating-point cache misses
+  const key = Math.round(scale * 1000) / 1000;
   let scaleMap = _proxyGeometryCache.get(sourceGeometries);
   if (scaleMap) {
-    const cached = scaleMap.get(scale);
+    const cached = scaleMap.get(key);
     if (cached) return cached;
   }
 
   const merged = mergeGeometries(sourceGeometries);
   if (!merged) return null;
 
-  // Clone + scale (or just scale if mergeGeometries created a new geometry for multi-part)
+  // Always clone so mergeGeometries' single-part return (shared ref) is never mutated
   const scaled = merged.clone();
   scaled.scale(scale, scale, scale);
 
@@ -129,7 +142,7 @@ function getOrCreateProxyGeometry(
     scaleMap = new Map();
     _proxyGeometryCache.set(sourceGeometries, scaleMap);
   }
-  scaleMap.set(scale, scaled);
+  scaleMap.set(key, scaled);
   return scaled;
 }
 
@@ -143,15 +156,15 @@ function createCollisionProxy(
   const proxyData = batched
     ? getBatchedProxyGeometry(ctx.id)
     : getInstancedProxyGeometry(ctx.id);
-  const geometry_cached = proxyData
+  const cachedGeometry = proxyData
     ? getOrCreateProxyGeometry(proxyData.geometries, scale)
     : null;
 
   let geometry: THREE.BufferGeometry;
   let yPos: number;
 
-  if (geometry_cached && proxyData) {
-    geometry = geometry_cached;
+  if (cachedGeometry && proxyData) {
+    geometry = cachedGeometry;
     // Align with visual: instancer shifts instances up by yOffset * scale
     yPos = proxyData.yOffset * scale;
   } else {

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -164,11 +164,16 @@ function createCollisionProxy(
   let yPos: number;
 
   if (cachedGeometry && proxyData) {
+    // NOTE: This geometry is shared across all proxies with the same model+scale.
+    // It must not be mutated — the proxy mesh is invisible and used only for
+    // raycasting, so Three.js internals won't modify it in normal operation.
     geometry = cachedGeometry;
     // Align with visual: instancer shifts instances up by yOffset * scale
     yPos = proxyData.yOffset * scale;
   } else {
-    // Fallback: tight cylinder around trunk (only if LOD geometry unavailable)
+    // Fallback: tighter trunk-only cylinder (only if LOD geometry unavailable).
+    // Reduced from 0.4 to 0.25 since the LOD proxy now handles canopy clicks;
+    // this path is only hit during initial load before LODs are ready.
     const dims = batched
       ? getBatchedDimensions(ctx.id)
       : getInstancedDimensions(ctx.id);

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -19,6 +19,7 @@ import {
   hasDepleted as hasInstancedDepleted,
   setHighlight as setInstancedHighlight,
   getModelDimensions as getInstancedDimensions,
+  getProxyGeometry as getInstancedProxyGeometry,
   hasInstance as isInInstancedPool,
   updateGLBTreeInstancer,
 } from "../../../systems/shared/world/GLBTreeInstancer";
@@ -29,6 +30,7 @@ import {
   hasDepleted as hasBatchedDepleted,
   setHighlight as setBatchedHighlight,
   getModelDimensions as getBatchedDimensions,
+  getProxyGeometry as getBatchedProxyGeometry,
   hasInstance as isInBatchedPool,
   updateGLBTreeBatchedInstancer,
 } from "../../../systems/shared/world/GLBTreeBatchedInstancer";
@@ -37,28 +39,94 @@ import type {
   ResourceVisualStrategy,
 } from "./ResourceVisualStrategy";
 
+/**
+ * Merge multiple BufferGeometry parts into one for the collision proxy.
+ * Only copies position + index — normals/UVs are unnecessary for raycasting.
+ */
+function mergeGeometries(
+  parts: THREE.BufferGeometry[],
+): THREE.BufferGeometry | null {
+  if (parts.length === 0) return null;
+  if (parts.length === 1) return parts[0];
+
+  let totalVerts = 0;
+  let totalIndices = 0;
+  for (const g of parts) {
+    totalVerts += g.getAttribute("position").count;
+    totalIndices += g.index ? g.index.count : g.getAttribute("position").count;
+  }
+
+  const positions = new Float32Array(totalVerts * 3);
+  const indices = new Uint32Array(totalIndices);
+  let vertOffset = 0;
+  let idxOffset = 0;
+
+  for (const g of parts) {
+    const pos = g.getAttribute("position");
+    for (let i = 0; i < pos.count; i++) {
+      positions[(vertOffset + i) * 3] = pos.getX(i);
+      positions[(vertOffset + i) * 3 + 1] = pos.getY(i);
+      positions[(vertOffset + i) * 3 + 2] = pos.getZ(i);
+    }
+    if (g.index) {
+      for (let i = 0; i < g.index.count; i++) {
+        indices[idxOffset + i] = g.index.getX(i) + vertOffset;
+      }
+      idxOffset += g.index.count;
+    } else {
+      for (let i = 0; i < pos.count; i++) {
+        indices[idxOffset + i] = vertOffset + i;
+      }
+      idxOffset += pos.count;
+    }
+    vertOffset += pos.count;
+  }
+
+  const merged = new THREE.BufferGeometry();
+  merged.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  merged.setIndex(new THREE.BufferAttribute(indices, 1));
+  merged.computeBoundingSphere();
+  return merged;
+}
+
 function createCollisionProxy(
   ctx: ResourceVisualContext,
   scale: number,
   batched: boolean,
 ): void {
-  const dims = batched
-    ? getBatchedDimensions(ctx.id)
-    : getInstancedDimensions(ctx.id);
-  const height = (dims?.height ?? 8) * scale;
-  const fullRadius = (dims?.radius ?? 1) * scale;
-  // TUNING: Collision proxy uses 40% of the full bounding radius so the
-  // clickable cylinder covers the trunk and inner canopy without catching
-  // clicks on empty air around branch tips. The 0.3 floor prevents very
-  // small trees (e.g. seedlings at scale ~1) from becoming un-clickable.
-  // Tested across Normal, Oak, Willow, Birch, Bamboo, and Yew tree types.
-  const radius = Math.max(fullRadius * 0.4, 0.3);
-  const geometry = new THREE.CylinderGeometry(radius, radius, height, 6);
+  // Try to use the actual LOD2 model geometry for a pixel-accurate collision proxy.
+  // This matches the visible tree silhouette so clicks only register on the model itself.
+  const proxyData = batched
+    ? getBatchedProxyGeometry(ctx.id)
+    : getInstancedProxyGeometry(ctx.id);
+  const merged = proxyData ? mergeGeometries(proxyData.geometries) : null;
+
+  let geometry: THREE.BufferGeometry;
+  let yPos: number;
+
+  if (merged) {
+    // Use a clone so the instancer's shared geometry isn't mutated by scale
+    geometry = merged.clone();
+    geometry.scale(scale, scale, scale);
+    // Align with visual: instancer shifts instances up by yOffset * scale
+    yPos = proxyData!.yOffset * scale;
+  } else {
+    // Fallback: tight cylinder around trunk (only if LOD geometry unavailable)
+    const dims = batched
+      ? getBatchedDimensions(ctx.id)
+      : getInstancedDimensions(ctx.id);
+    const height = (dims?.height ?? 8) * scale;
+    const fullRadius = (dims?.radius ?? 1) * scale;
+    const radius = Math.max(fullRadius * 0.25, 0.3);
+    geometry = new THREE.CylinderGeometry(radius, radius, height, 6);
+    yPos = height / 2;
+  }
+
   const material = new MeshBasicNodeMaterial();
   material.visible = false;
 
   const proxy = new THREE.Mesh(geometry, material);
-  proxy.position.y = height / 2;
+  proxy.position.y = yPos;
   proxy.name = `TreeProxy_${ctx.id}`;
   proxy.userData = {
     type: "resource",

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -46,14 +46,17 @@ import type {
 function mergeGeometries(
   parts: THREE.BufferGeometry[],
 ): THREE.BufferGeometry | null {
-  if (parts.length === 0) return null;
-  if (parts.length === 1) return parts[0];
+  // Filter out any parts missing position data (malformed GLBs)
+  const valid = parts.filter((g) => g.getAttribute("position"));
+  if (valid.length === 0) return null;
+  if (valid.length === 1) return valid[0];
 
   let totalVerts = 0;
   let totalIndices = 0;
-  for (const g of parts) {
-    totalVerts += g.getAttribute("position").count;
-    totalIndices += g.index ? g.index.count : g.getAttribute("position").count;
+  for (const g of valid) {
+    const pos = g.getAttribute("position");
+    totalVerts += pos.count;
+    totalIndices += g.index ? g.index.count : pos.count;
   }
 
   const positions = new Float32Array(totalVerts * 3);
@@ -61,12 +64,20 @@ function mergeGeometries(
   let vertOffset = 0;
   let idxOffset = 0;
 
-  for (const g of parts) {
-    const pos = g.getAttribute("position");
-    for (let i = 0; i < pos.count; i++) {
-      positions[(vertOffset + i) * 3] = pos.getX(i);
-      positions[(vertOffset + i) * 3 + 1] = pos.getY(i);
-      positions[(vertOffset + i) * 3 + 2] = pos.getZ(i);
+  for (const g of valid) {
+    const pos = g.getAttribute("position") as THREE.BufferAttribute;
+    // Bulk copy when the backing array is a contiguous Float32Array (common for loaded GLBs)
+    if (pos.array instanceof Float32Array && pos.itemSize === 3) {
+      positions.set(
+        new Float32Array(pos.array.buffer, pos.array.byteOffset, pos.count * 3),
+        vertOffset * 3,
+      );
+    } else {
+      for (let i = 0; i < pos.count; i++) {
+        positions[(vertOffset + i) * 3] = pos.getX(i);
+        positions[(vertOffset + i) * 3 + 1] = pos.getY(i);
+        positions[(vertOffset + i) * 3 + 2] = pos.getZ(i);
+      }
     }
     if (g.index) {
       for (let i = 0; i < g.index.count; i++) {
@@ -104,13 +115,12 @@ function createCollisionProxy(
   let geometry: THREE.BufferGeometry;
   let yPos: number;
 
-  if (merged) {
+  if (merged && proxyData) {
     // Use a clone so the instancer's shared geometry isn't mutated by scale
     geometry = merged.clone();
     geometry.scale(scale, scale, scale);
-    // Align with visual: instancer shifts instances up by yOffset * scale.
-    // proxyData is guaranteed non-null here — merged is only truthy when proxyData was non-null.
-    yPos = proxyData!.yOffset * scale;
+    // Align with visual: instancer shifts instances up by yOffset * scale
+    yPos = proxyData.yOffset * scale;
   } else {
     // Fallback: tight cylinder around trunk (only if LOD geometry unavailable)
     const dims = batched

--- a/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
+++ b/packages/shared/src/entities/world/visuals/TreeGLBVisualStrategy.ts
@@ -49,6 +49,7 @@ function mergeGeometries(
   // Filter out any parts missing position data (malformed GLBs)
   const valid = parts.filter((g) => g.getAttribute("position"));
   if (valid.length === 0) return null;
+  // Single-part: return the shared geometry directly — caller must clone before mutating.
   if (valid.length === 1) return valid[0];
 
   let totalVerts = 0;
@@ -100,6 +101,38 @@ function mergeGeometries(
   return merged;
 }
 
+// Cache merged+scaled proxy geometry per (sourceGeometries identity, scale) to avoid
+// redundant merge/clone/scale work for trees sharing the same model variant and scale.
+const _proxyGeometryCache = new Map<
+  THREE.BufferGeometry[],
+  Map<number, THREE.BufferGeometry>
+>();
+
+function getOrCreateProxyGeometry(
+  sourceGeometries: THREE.BufferGeometry[],
+  scale: number,
+): THREE.BufferGeometry | null {
+  let scaleMap = _proxyGeometryCache.get(sourceGeometries);
+  if (scaleMap) {
+    const cached = scaleMap.get(scale);
+    if (cached) return cached;
+  }
+
+  const merged = mergeGeometries(sourceGeometries);
+  if (!merged) return null;
+
+  // Clone + scale (or just scale if mergeGeometries created a new geometry for multi-part)
+  const scaled = merged.clone();
+  scaled.scale(scale, scale, scale);
+
+  if (!scaleMap) {
+    scaleMap = new Map();
+    _proxyGeometryCache.set(sourceGeometries, scaleMap);
+  }
+  scaleMap.set(scale, scaled);
+  return scaled;
+}
+
 function createCollisionProxy(
   ctx: ResourceVisualContext,
   scale: number,
@@ -110,15 +143,15 @@ function createCollisionProxy(
   const proxyData = batched
     ? getBatchedProxyGeometry(ctx.id)
     : getInstancedProxyGeometry(ctx.id);
-  const merged = proxyData ? mergeGeometries(proxyData.geometries) : null;
+  const geometry_cached = proxyData
+    ? getOrCreateProxyGeometry(proxyData.geometries, scale)
+    : null;
 
   let geometry: THREE.BufferGeometry;
   let yPos: number;
 
-  if (merged && proxyData) {
-    // Use a clone so the instancer's shared geometry isn't mutated by scale
-    geometry = merged.clone();
-    geometry.scale(scale, scale, scale);
+  if (geometry_cached && proxyData) {
+    geometry = geometry_cached;
     // Align with visual: instancer shifts instances up by yOffset * scale
     yPos = proxyData.yOffset * scale;
   } else {

--- a/packages/shared/src/runtime/createClientWorld.ts
+++ b/packages/shared/src/runtime/createClientWorld.ts
@@ -94,6 +94,7 @@ import {
   initGLBTreeBatchedInstancer,
   destroyGLBTreeBatchedInstancer,
 } from "../systems/shared/world/GLBTreeBatchedInstancer";
+import { clearProxyGeometryCache } from "../entities/world/visuals/TreeGLBVisualStrategy";
 import {
   initPlaceholderInstancer,
   destroyPlaceholderInstancer,
@@ -209,6 +210,7 @@ export function createClientWorld() {
   // Clean up any previous instancer state from prior world
   destroyGLBTreeInstancer();
   destroyGLBTreeBatchedInstancer();
+  clearProxyGeometryCache();
   destroyPlaceholderInstancer();
   destroyGLBResourceInstancer();
 

--- a/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
@@ -60,6 +60,11 @@ interface BatchedLODPool {
   geometryIds: number[][];
   /** entityId → array of instanceIds (one per BatchedMesh/material slot) */
   instanceIds: Map<string, number[]>;
+  /**
+   * sourceGeometries[variantIndex][materialSlot] = original BufferGeometry.
+   * Retained so collision proxies can use the actual model shape.
+   */
+  sourceGeometries: THREE.BufferGeometry[][];
 }
 
 interface TreeTypePool {
@@ -273,11 +278,18 @@ function createBatchedLODPool(
     geometryIds.push(slotGeoIds);
   }
 
+  // Store source geometries per variant for collision proxy use
+  const sourceGeometries: THREE.BufferGeometry[][] = [];
+  for (let v = 0; v < numVariants; v++) {
+    sourceGeometries.push(variantParts[v].map((p) => p.geometry));
+  }
+
   return {
     batches,
     materials,
     geometryIds,
     instanceIds: new Map(),
+    sourceGeometries,
   };
 }
 
@@ -769,6 +781,30 @@ export function getModelDimensions(
   const pool = pools.get(treeType);
   if (!pool) return null;
   return { height: pool.modelHeight, radius: pool.modelRadius };
+}
+
+/**
+ * Returns the lowest-available LOD geometries for use as a collision proxy,
+ * plus the yOffset needed to align the geometry with the visual instance.
+ * Prefers LOD2 → LOD1 → LOD0, using the entity's assigned variant.
+ * Returns null if the entity isn't registered.
+ */
+export function getProxyGeometry(
+  entityId: string,
+): { geometries: THREE.BufferGeometry[]; yOffset: number } | null {
+  const treeType = entityToTreeType.get(entityId);
+  if (!treeType) return null;
+  const pool = pools.get(treeType);
+  if (!pool) return null;
+  const slot = pool.instances.get(entityId);
+  if (!slot) return null;
+  const lodPool = pool.lod2 ?? pool.lod1 ?? pool.lod0;
+  if (!lodPool) return null;
+  const vi = slot.variantIndex % lodPool.sourceGeometries.length;
+  return {
+    geometries: lodPool.sourceGeometries[vi],
+    yOffset: pool.yOffset,
+  };
 }
 
 export function hasDepleted(entityId: string): boolean {

--- a/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
@@ -640,6 +640,7 @@ export function destroyGLBTreeBatchedInstancer(): void {
         bm.dispose();
       }
       for (const mat of lodPool.materials) mat.dispose();
+      lodPool.sourceGeometries.length = 0;
     }
   }
   pools.clear();
@@ -788,6 +789,9 @@ export function getModelDimensions(
  * plus the yOffset needed to align the geometry with the visual instance.
  * Prefers LOD2 → LOD1 → LOD0, using the entity's assigned variant.
  * Returns null if the entity isn't registered.
+ *
+ * **Important**: Returned geometries are shared by the instancer pool.
+ * Callers MUST clone before mutating (e.g. scaling).
  */
 export function getProxyGeometry(
   entityId: string,

--- a/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeBatchedInstancer.ts
@@ -631,6 +631,10 @@ export function initGLBTreeBatchedInstancer(s: THREE.Scene, w: World): void {
   world = w;
 }
 
+/**
+ * NOTE: Caller must also call clearProxyGeometryCache() (from TreeGLBVisualStrategy)
+ * after this to dispose cached proxy geometries that reference sourceGeometries.
+ */
 export function destroyGLBTreeBatchedInstancer(): void {
   for (const pool of pools.values()) {
     for (const lodPool of [pool.lod0, pool.lod1, pool.lod2, pool.depleted]) {

--- a/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
@@ -443,6 +443,10 @@ export function initGLBTreeInstancer(s: THREE.Scene, w: World): void {
   world = w;
 }
 
+/**
+ * NOTE: Caller must also call clearProxyGeometryCache() (from TreeGLBVisualStrategy)
+ * after this to dispose cached proxy geometries that reference sourceGeometries.
+ */
 export function destroyGLBTreeInstancer(): void {
   for (const pool of pools.values()) {
     for (const lodPool of [pool.lod0, pool.lod1, pool.lod2, pool.depleted]) {
@@ -616,6 +620,10 @@ export function getModelDimensions(
  * Returns the lowest-available LOD geometries for use as a collision proxy,
  * plus the yOffset needed to align the geometry with the visual instance.
  * Prefers LOD2 → LOD1 → LOD0.  Returns null if the entity isn't registered.
+ *
+ * NOTE: This instancer uses a single model per pool (no variants).
+ * If multi-variant support is ever added, this must select by variant index
+ * like GLBTreeBatchedInstancer.getProxyGeometry does.
  *
  * **Important**: Returned geometries are shared by the instancer pool.
  * Callers MUST clone before mutating (e.g. scaling).

--- a/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
@@ -601,6 +601,26 @@ export function getModelDimensions(
 }
 
 /**
+ * Returns the lowest-available LOD geometries for use as a collision proxy,
+ * plus the yOffset needed to align the geometry with the visual instance.
+ * Prefers LOD2 → LOD1 → LOD0.  Returns null if the entity isn't registered.
+ */
+export function getProxyGeometry(
+  entityId: string,
+): { geometries: THREE.BufferGeometry[]; yOffset: number } | null {
+  const modelPath = entityToModel.get(entityId);
+  if (!modelPath) return null;
+  const pool = pools.get(modelPath);
+  if (!pool) return null;
+  const lodPool = pool.lod2 ?? pool.lod1 ?? pool.lod0;
+  if (!lodPool) return null;
+  return {
+    geometries: lodPool.meshes.map((m) => m.geometry),
+    yOffset: pool.yOffset,
+  };
+}
+
+/**
  * Returns true if the instancer has a depleted pool for this entity's model.
  * When true, ResourceEntity can skip loading an individual depleted model.
  */

--- a/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
@@ -604,6 +604,9 @@ export function getModelDimensions(
  * Returns the lowest-available LOD geometries for use as a collision proxy,
  * plus the yOffset needed to align the geometry with the visual instance.
  * Prefers LOD2 → LOD1 → LOD0.  Returns null if the entity isn't registered.
+ *
+ * **Important**: Returned geometries are shared by the instancer pool.
+ * Callers MUST clone before mutating (e.g. scaling).
  */
 export function getProxyGeometry(
   entityId: string,

--- a/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBTreeInstancer.ts
@@ -59,6 +59,12 @@ interface LODPool {
   dirty: boolean;
   /** Shared backing array for per-instance highlight intensity (0 or 1) */
   highlightData: Float32Array;
+  /**
+   * Snapshot of original source geometries (before InstancedBufferAttribute
+   * additions). Retained so collision proxies can use the model shape without
+   * depending on live InstancedMesh geometry references.
+   */
+  sourceGeometries: THREE.BufferGeometry[];
 }
 
 interface ModelPool {
@@ -155,8 +161,12 @@ function createLODPool(
 ): LODPool {
   const meshes: THREE.InstancedMesh[] = [];
   const materials: DissolveMaterial[] = [];
+  const sourceGeometries: THREE.BufferGeometry[] = [];
   const hlData = new Float32Array(MAX_INSTANCES);
   for (const part of parts) {
+    // Store the original geometry before adding instanced attributes
+    sourceGeometries.push(part.geometry);
+
     const geo = createSharedGeometry(part.geometry);
 
     const hlAttr = new THREE.InstancedBufferAttribute(hlData, 1);
@@ -180,6 +190,7 @@ function createLODPool(
     activeCount: 0,
     dirty: false,
     highlightData: hlData,
+    sourceGeometries,
   };
 }
 
@@ -441,6 +452,7 @@ export function destroyGLBTreeInstancer(): void {
         im.geometry.dispose();
       }
       for (const mat of lodPool.materials) mat.dispose();
+      lodPool.sourceGeometries.length = 0;
     }
   }
   pools.clear();
@@ -618,7 +630,7 @@ export function getProxyGeometry(
   const lodPool = pool.lod2 ?? pool.lod1 ?? pool.lod0;
   if (!lodPool) return null;
   return {
-    geometries: lodPool.meshes.map((m) => m.geometry),
+    geometries: lodPool.sourceGeometries,
     yOffset: pool.yOffset,
   };
 }


### PR DESCRIPTION
…stead of cylinder

Replace the oversized invisible cylinder hitbox with the actual LOD2 mesh geometry so clicks only register on the visible tree silhouette. This prevents ground clicks near trees from being intercepted by the collision proxy.

- Add getProxyGeometry() to GLBTreeInstancer and GLBTreeBatchedInstancer
- Store sourceGeometries on BatchedLODPool for proxy access
- Merge multi-part geometries (bark + leaves) into single proxy mesh
- Fall back to tighter cylinder (0.25 radius factor) if LOD unavailable