### PR TITLE
fix(ui): unify panel tooltips and bank equipment layout

### DIFF
--- a/packages/client/src/game/panels/ActionBarPanel/ActionBarSlot.tsx
+++ b/packages/client/src/game/panels/ActionBarPanel/ActionBarSlot.tsx
@@ -2,9 +2,20 @@
  * ActionBarPanel - Individual slot component
  */
 
-import React, { memo, useMemo, useCallback, useRef, useEffect } from "react";
+import React, {
+  memo,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  useState,
+} from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { useTheme } from "@/ui";
+import { CursorTooltip, useTheme } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { getInteractiveTileStyle, getPanelInsetStyle } from "@/ui/theme/themes";
 import type { ActionBarSlotContent } from "./types";
 import { getSlotIcon, SLOT_SIZE } from "./utils";
@@ -136,6 +147,9 @@ export const ActionBarSlot = memo(function ActionBarSlot({
   onContextMenu,
 }: ActionBarSlotProps) {
   const theme = useTheme();
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
   const isEmpty = slot.type === "empty";
   const isPrayer = slot.type === "prayer";
   const isCombatStyle = slot.type === "combatstyle";
@@ -297,93 +311,129 @@ export const ActionBarSlot = memo(function ActionBarSlot({
     ],
   );
 
+  const tooltipLabel = isEmpty
+    ? `Empty slot (${shortcut})`
+    : isUnavailable
+      ? `${slot.label || slot.itemId || "Unknown"} - Not in inventory (${shortcut})`
+      : `${slot.label || slot.itemId || slot.skillId || "Unknown"} (${shortcut})`;
+
   return (
-    <button
-      ref={combinedRef}
-      onClick={handleClick}
-      onContextMenu={onContextMenu}
-      onMouseEnter={onHover}
-      onMouseLeave={onLeave}
-      className="relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
-      title={
-        isEmpty
-          ? `Empty slot (${shortcut})`
-          : isUnavailable
-            ? `${slot.label || slot.itemId || "Unknown"} - Not in inventory (${shortcut})`
-            : `${slot.label || slot.itemId || slot.skillId || "Unknown"} (${shortcut})`
-      }
-      style={slotStyle}
-      {...attributes}
-      {...wrappedListeners}
-    >
-      {/* Icon */}
-      {!isEmpty && (
+    <>
+      <button
+        ref={combinedRef}
+        onClick={handleClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={(e) => {
+          onHover();
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseMove={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseLeave={() => {
+          onLeave();
+          setHoverState(null);
+        }}
+        className="relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+        style={slotStyle}
+        {...attributes}
+        {...wrappedListeners}
+      >
+        {/* Icon */}
+        {!isEmpty && (
+          <div
+            className="flex items-center justify-center h-full"
+            style={{
+              fontSize: 16,
+              filter: "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5))",
+            }}
+          >
+            {isCombatStyle && slot.combatStyleId ? (
+              <CombatStyleIcon
+                styleId={slot.combatStyleId}
+                size={18}
+                isActive={isActive}
+              />
+            ) : (
+              icon
+            )}
+          </div>
+        )}
+
+        {/* Quantity Badge - RS3 style: shows actual inventory quantity */}
+        {slot.type === "item" &&
+          (() => {
+            // Use inventory quantity if provided, otherwise fall back to slot quantity
+            const qty = inventoryQuantity ?? slot.quantity ?? 0;
+            if (qty <= 0) return null;
+            return (
+              <div
+                className="absolute font-bold"
+                style={{
+                  bottom: 1,
+                  right: 1,
+                  background: theme.colors.background.overlay,
+                  color: isUnavailable
+                    ? theme.colors.state.danger
+                    : theme.colors.text.primary,
+                  fontSize: 8,
+                  padding: "0px 2px",
+                  borderRadius: 2,
+                  lineHeight: 1.1,
+                }}
+              >
+                {qty > 999999
+                  ? `${Math.floor(qty / 1000000)}M`
+                  : qty > 999
+                    ? `${Math.floor(qty / 1000)}K`
+                    : qty}
+              </div>
+            );
+          })()}
+
+        {/* Shortcut Key */}
         <div
-          className="flex items-center justify-center h-full"
+          className="absolute font-bold"
           style={{
-            fontSize: 16,
-            filter: "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5))",
+            top: 1,
+            left: 2,
+            color: isEmpty
+              ? `${theme.colors.text.secondary}80`
+              : `${theme.colors.text.secondary}A6`,
+            fontSize: 7,
+            textShadow: "0 1px 1px rgba(0, 0, 0, 0.6)",
           }}
         >
-          {isCombatStyle && slot.combatStyleId ? (
-            <CombatStyleIcon
-              styleId={slot.combatStyleId}
-              size={18}
-              isActive={isActive}
-            />
-          ) : (
-            icon
-          )}
+          {shortcut}
         </div>
-      )}
+      </button>
 
-      {/* Quantity Badge - RS3 style: shows actual inventory quantity */}
-      {slot.type === "item" &&
-        (() => {
-          // Use inventory quantity if provided, otherwise fall back to slot quantity
-          const qty = inventoryQuantity ?? slot.quantity ?? 0;
-          if (qty <= 0) return null;
-          return (
-            <div
-              className="absolute font-bold"
-              style={{
-                bottom: 1,
-                right: 1,
-                background: theme.colors.background.overlay,
-                color: isUnavailable
-                  ? theme.colors.state.danger
-                  : theme.colors.text.primary,
-                fontSize: 8,
-                padding: "0px 2px",
-                borderRadius: 2,
-                lineHeight: 1.1,
-              }}
-            >
-              {qty > 999999
-                ? `${Math.floor(qty / 1000000)}M`
-                : qty > 999
-                  ? `${Math.floor(qty / 1000)}K`
-                  : qty}
+      {hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 180, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "140px",
+            maxWidth: "260px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {tooltipLabel}
+          </div>
+          {!isEmpty && (
+            <div style={{ ...getTooltipMetaStyle(theme), marginTop: "4px" }}>
+              Drag to reorder
             </div>
-          );
-        })()}
-
-      {/* Shortcut Key */}
-      <div
-        className="absolute font-bold"
-        style={{
-          top: 1,
-          left: 2,
-          color: isEmpty
-            ? `${theme.colors.text.secondary}80`
-            : `${theme.colors.text.secondary}A6`,
-          fontSize: 7,
-          textShadow: "0 1px 1px rgba(0, 0, 0, 0.6)",
-        }}
-      >
-        {shortcut}
-      </div>
-    </button>
+          )}
+        </CursorTooltip>
+      )}
+    </>
   );
 });
 
@@ -396,45 +446,76 @@ export const RubbishBin = memo(function RubbishBin({
   isDragging: boolean;
 }) {
   const theme = useTheme();
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
   const { setNodeRef, isOver } = useDroppable({
     id: "actionbar-rubbish-bin",
     data: { target: "rubbish-bin" },
   });
 
   return (
-    <button
-      ref={setNodeRef}
-      onContextMenu={onContextMenu}
-      title="Drag items here to remove them"
-      className="relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
-      style={{
-        width: SLOT_SIZE,
-        height: SLOT_SIZE,
-        ...getInteractiveTileStyle(theme, {
-          active: false,
-          hovered: isDragging,
-          dropTarget: isOver,
-          radius: 4,
-          accentColor: theme.colors.state.danger,
-        }),
-        border: isOver
-          ? `2px solid ${theme.colors.state.danger}B3`
-          : isDragging
-            ? `1px dashed ${theme.colors.state.warning}80`
-            : `1px solid ${theme.colors.border.default}66`,
-        cursor: "default",
-        opacity: isDragging ? 1 : 0.6,
-        transform: isOver ? "scale(1.1)" : "scale(1)",
-        boxShadow: isOver
-          ? `0 0 12px ${theme.colors.state.danger}80, inset 0 0 15px ${theme.colors.state.danger}33`
-          : `inset 0 2px 4px rgba(0, 0, 0, 0.4)`,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        fontSize: 14,
-      }}
-    >
-      🗑️
-    </button>
+    <>
+      <button
+        ref={setNodeRef}
+        onContextMenu={onContextMenu}
+        onMouseEnter={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseMove={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseLeave={() => setHoverState(null)}
+        className="relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+        style={{
+          width: SLOT_SIZE,
+          height: SLOT_SIZE,
+          ...getInteractiveTileStyle(theme, {
+            active: false,
+            hovered: isDragging,
+            dropTarget: isOver,
+            radius: 4,
+            accentColor: theme.colors.state.danger,
+          }),
+          border: isOver
+            ? `2px solid ${theme.colors.state.danger}B3`
+            : isDragging
+              ? `1px dashed ${theme.colors.state.warning}80`
+              : `1px solid ${theme.colors.border.default}66`,
+          cursor: "default",
+          opacity: isDragging ? 1 : 0.6,
+          transform: isOver ? "scale(1.1)" : "scale(1)",
+          boxShadow: isOver
+            ? `0 0 12px ${theme.colors.state.danger}80, inset 0 0 15px ${theme.colors.state.danger}33`
+            : `inset 0 2px 4px rgba(0, 0, 0, 0.4)`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 14,
+        }}
+      >
+        🗑️
+      </button>
+
+      {hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 170, height: 44 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "140px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            Drag items here to remove them
+          </div>
+        </CursorTooltip>
+      )}
+    </>
   );
 });

--- a/packages/client/src/game/panels/ActionPanel.tsx
+++ b/packages/client/src/game/panels/ActionPanel.tsx
@@ -19,7 +19,11 @@ import {
   type DragStartEvent,
   type DragEndEvent,
 } from "@dnd-kit/core";
-import { useThemeStore } from "@/ui";
+import { CursorTooltip, useThemeStore } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { breakpoints, gameUI } from "../../constants";
 import {
   getItem,
@@ -89,6 +93,9 @@ const DraggableSlot = memo(function DraggableSlot({
 }) {
   const theme = useThemeStore((s) => s.theme);
   const isEmpty = !item;
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
 
   const {
     attributes,
@@ -113,111 +120,149 @@ const DraggableSlot = memo(function DraggableSlot({
     setDropRef(node);
   };
 
-  return (
-    <button
-      ref={combinedRef}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      onMouseEnter={onHover}
-      onMouseLeave={onLeave}
-      className="relative"
-      title={
-        item
-          ? `Slot ${slotNumber + 1}: ${item.itemId} (${item.quantity})`
-          : `Empty slot ${slotNumber + 1}`
-      }
-      style={{
-        width: `${slotSize}px`,
-        height: `${slotSize}px`,
-        background: isEmpty
-          ? theme.colors.slot.empty
-          : isOver
-            ? `linear-gradient(180deg, ${theme.colors.accent.primary}40 0%, ${theme.colors.border.decorative}4d 100%)`
-            : isHovered
-              ? `linear-gradient(180deg, ${theme.colors.accent.primary}26 0%, ${theme.colors.border.decorative}33 100%)`
-              : theme.colors.slot.filled,
-        border: isEmpty
-          ? `1px solid ${theme.colors.border.default}`
-          : isOver
-            ? `2px solid ${theme.colors.accent.primary}b3`
-            : isHovered
-              ? `1px solid ${theme.colors.accent.primary}80`
-              : `1px solid ${theme.colors.border.decorative}80`,
-        borderRadius: `${theme.borderRadius.sm}px`,
-        cursor: isEmpty ? "default" : isDragging ? "grabbing" : "grab",
-        opacity: isDragging ? 0.3 : 1,
-        transform: isOver
-          ? "scale(1.05)"
-          : isDragging
-            ? "scale(0.95)"
-            : "scale(1)",
-        transition: theme.transitions.fast,
-        touchAction: "none",
-        boxShadow: isOver ? `0 0 8px ${theme.colors.accent.primary}66` : "none",
-      }}
-      {...attributes}
-      {...listeners}
-    >
-      {/* Item Icon */}
-      {!isEmpty ? (
-        <div
-          className="flex items-center justify-center h-full"
-          style={{
-            fontSize: isMobile ? "14px" : "16px",
-            filter: "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5))",
-          }}
-        >
-          <ItemIcon itemId={item.itemId} size={isMobile ? 32 : 36} />
-        </div>
-      ) : (
-        <div
-          className="flex items-center justify-center h-full"
-          style={{
-            color: theme.colors.border.default,
-            fontSize: "6px",
-          }}
-        >
-          •
-        </div>
-      )}
+  const tooltipLabel = item
+    ? `Slot ${slotNumber + 1}: ${getItem(item.itemId)?.name || item.itemId}${item.quantity > 1 ? ` x${item.quantity}` : ""}`
+    : `Empty slot ${slotNumber + 1}`;
 
-      {/* Quantity Badge */}
-      {item && item.quantity > 1 && (
+  return (
+    <>
+      <button
+        ref={combinedRef}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={(e) => {
+          onHover();
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseMove={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseLeave={() => {
+          onLeave();
+          setHoverState(null);
+        }}
+        className="relative"
+        style={{
+          width: `${slotSize}px`,
+          height: `${slotSize}px`,
+          background: isEmpty
+            ? theme.colors.slot.empty
+            : isOver
+              ? `linear-gradient(180deg, ${theme.colors.accent.primary}40 0%, ${theme.colors.border.decorative}4d 100%)`
+              : isHovered
+                ? `linear-gradient(180deg, ${theme.colors.accent.primary}26 0%, ${theme.colors.border.decorative}33 100%)`
+                : theme.colors.slot.filled,
+          border: isEmpty
+            ? `1px solid ${theme.colors.border.default}`
+            : isOver
+              ? `2px solid ${theme.colors.accent.primary}b3`
+              : isHovered
+                ? `1px solid ${theme.colors.accent.primary}80`
+                : `1px solid ${theme.colors.border.decorative}80`,
+          borderRadius: `${theme.borderRadius.sm}px`,
+          cursor: isEmpty ? "default" : isDragging ? "grabbing" : "grab",
+          opacity: isDragging ? 0.3 : 1,
+          transform: isOver
+            ? "scale(1.05)"
+            : isDragging
+              ? "scale(0.95)"
+              : "scale(1)",
+          transition: theme.transitions.fast,
+          touchAction: "none",
+          boxShadow: isOver
+            ? `0 0 8px ${theme.colors.accent.primary}66`
+            : "none",
+        }}
+        {...attributes}
+        {...listeners}
+      >
+        {/* Item Icon */}
+        {!isEmpty ? (
+          <div
+            className="flex items-center justify-center h-full"
+            style={{
+              fontSize: isMobile ? "14px" : "16px",
+              filter: "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5))",
+            }}
+          >
+            <ItemIcon itemId={item.itemId} size={isMobile ? 32 : 36} />
+          </div>
+        ) : (
+          <div
+            className="flex items-center justify-center h-full"
+            style={{
+              color: theme.colors.border.default,
+              fontSize: "6px",
+            }}
+          >
+            •
+          </div>
+        )}
+
+        {/* Quantity Badge */}
+        {item && item.quantity > 1 && (
+          <div
+            className="absolute font-bold"
+            style={{
+              bottom: "1px",
+              right: "1px",
+              background: theme.colors.accent.primary,
+              color: theme.colors.background.primary,
+              fontSize: theme.typography.fontSize.xs,
+              padding: "0px 2px",
+              borderRadius: `${theme.borderRadius.sm}px`,
+              lineHeight: 1.1,
+            }}
+          >
+            {item.quantity > 999
+              ? `${Math.floor(item.quantity / 1000)}K`
+              : item.quantity}
+          </div>
+        )}
+
+        {/* Slot Number (1-based for display) */}
         <div
           className="absolute font-bold"
           style={{
-            bottom: "1px",
-            right: "1px",
-            background: theme.colors.accent.primary,
-            color: theme.colors.background.primary,
-            fontSize: theme.typography.fontSize.xs,
-            padding: "0px 2px",
-            borderRadius: `${theme.borderRadius.sm}px`,
-            lineHeight: 1.1,
+            top: "1px",
+            left: "2px",
+            color: isEmpty
+              ? theme.colors.text.muted
+              : theme.colors.text.secondary,
+            fontSize: "7px",
+            textShadow: "0 1px 1px rgba(0, 0, 0, 0.6)",
           }}
         >
-          {item.quantity > 999
-            ? `${Math.floor(item.quantity / 1000)}K`
-            : item.quantity}
+          {slotNumber + 1}
         </div>
-      )}
+      </button>
 
-      {/* Slot Number (1-based for display) */}
-      <div
-        className="absolute font-bold"
-        style={{
-          top: "1px",
-          left: "2px",
-          color: isEmpty
-            ? theme.colors.text.muted
-            : theme.colors.text.secondary,
-          fontSize: "7px",
-          textShadow: "0 1px 1px rgba(0, 0, 0, 0.6)",
-        }}
-      >
-        {slotNumber + 1}
-      </div>
-    </button>
+      {hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 180, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "140px",
+            maxWidth: "220px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {tooltipLabel}
+          </div>
+          {item && (
+            <div style={{ ...getTooltipMetaStyle(theme), marginTop: "4px" }}>
+              Drag to reorder • Right-click for options
+            </div>
+          )}
+        </CursorTooltip>
+      )}
+    </>
   );
 });
 

--- a/packages/client/src/game/panels/BankPanel.tsx
+++ b/packages/client/src/game/panels/BankPanel.tsx
@@ -21,7 +21,12 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { getItem } from "@hyperscape/shared";
-import { useThemeStore, useMobileLayout } from "@/ui";
+import { CursorTooltip, useThemeStore, useMobileLayout } from "@/ui";
+import {
+  getTooltipBodyStyle,
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { getPanelSurfaceStyle } from "@/ui/theme/themes";
 
 // Types
@@ -67,6 +72,69 @@ import { useBankActions, useDragDrop } from "./BankPanel/hooks";
 // NOTE: Distance validation is now SERVER-AUTHORITATIVE
 // The server tracks interaction sessions and sends bankClose packets
 // when the player moves too far away. The client no longer polls distance.
+
+interface BankItemHoverState {
+  item: BankItem;
+  position: { x: number; y: number };
+}
+
+function renderBankItemHoverTooltip(
+  itemHover: BankItemHoverState,
+  theme: ReturnType<typeof useThemeStore.getState>["theme"],
+): React.ReactNode {
+  const hoveredItemData = getItem(itemHover.item.itemId);
+  const itemName = hoveredItemData?.name || itemHover.item.itemId;
+  const itemValue = hoveredItemData?.value ?? 0;
+  const isPlaceholder = itemHover.item.quantity === 0;
+
+  return (
+    <CursorTooltip
+      visible={true}
+      position={itemHover.position}
+      estimatedSize={{ width: 160, height: 72 }}
+      style={{
+        zIndex: theme.zIndex.tooltip,
+        minWidth: "140px",
+        maxWidth: "240px",
+      }}
+    >
+      <div
+        style={{
+          ...getTooltipTitleStyle(theme),
+          marginBottom: "4px",
+        }}
+      >
+        {itemName}
+        {!isPlaceholder && itemHover.item.quantity > 1 && (
+          <span
+            style={{
+              ...getTooltipMetaStyle(theme),
+              fontWeight: "normal",
+            }}
+          >
+            {" "}
+            x{itemHover.item.quantity.toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      <div
+        style={{
+          ...getTooltipBodyStyle(theme),
+        }}
+      >
+        {isPlaceholder ? (
+          <div>Placeholder item</div>
+        ) : (
+          <>
+            <div>Stored in tab {itemHover.item.tabIndex}</div>
+            <div>Value: {itemValue.toLocaleString()} gp</div>
+          </>
+        )}
+      </div>
+    </CursorTooltip>
+  );
+}
 
 export function BankPanel({
   items, // RS3-style: includes qty=0 items (placeholders)
@@ -115,6 +183,8 @@ export function BankPanel({
     message: "",
     onConfirm: () => {},
   });
+  const [hoveredBankItem, setHoveredBankItem] =
+    useState<BankItemHoverState | null>(null);
 
   // ========== TAB STATE ==========
   // -1 = "All" view (shows all items across all tabs)
@@ -304,6 +374,26 @@ export function BankPanel({
     setContextMenu((prev) => ({ ...prev, visible: false }));
   }, []);
 
+  const handleBankItemHoverStart = useCallback(
+    (item: BankItem, position: { x: number; y: number }) => {
+      if (contextMenu.visible) return;
+      setHoveredBankItem({ item, position });
+    },
+    [contextMenu.visible],
+  );
+
+  const handleBankItemHoverMove = useCallback(
+    (position: { x: number; y: number }) => {
+      if (contextMenu.visible) return;
+      setHoveredBankItem((prev) => (prev ? { ...prev, position } : null));
+    },
+    [contextMenu.visible],
+  );
+
+  const handleBankItemHoverEnd = useCallback(() => {
+    setHoveredBankItem(null);
+  }, []);
+
   const openContextMenu = (
     e: React.MouseEvent,
     itemId: string,
@@ -380,6 +470,10 @@ export function BankPanel({
         onClose={closeContextMenu}
         rightPanelMode={rightPanelMode}
       />
+
+      {!contextMenu.visible &&
+        hoveredBankItem &&
+        renderBankItemHoverTooltip(hoveredBankItem, theme)}
 
       <CoinAmountModal
         modal={coinModal}
@@ -627,6 +721,9 @@ export function BankPanel({
                               onDragEnd={handleSlotDragEnd}
                               onClick={handleSlotClick}
                               onContextMenu={handleSlotContextMenu}
+                              onHoverStart={handleBankItemHoverStart}
+                              onHoverMove={handleBankItemHoverMove}
+                              onHoverEnd={handleBankItemHoverEnd}
                             />
                           );
                         })}
@@ -783,6 +880,9 @@ export function BankPanel({
                       onDragEnd={handleSlotDragEnd}
                       onClick={handleSlotClick}
                       onContextMenu={handleSlotContextMenu}
+                      onHoverStart={handleBankItemHoverStart}
+                      onHoverMove={handleBankItemHoverMove}
+                      onHoverEnd={handleBankItemHoverEnd}
                     />
                   );
                 })}
@@ -883,6 +983,7 @@ export function BankPanel({
           onChangeMode={setRightPanelMode}
           inventory={inventory}
           coins={coins}
+          world={world}
           equipment={equipment}
           onDeposit={handleDeposit}
           onDepositAll={handleDepositAll}

--- a/packages/client/src/game/panels/BankPanel/components/BankFooter.tsx
+++ b/packages/client/src/game/panels/BankPanel/components/BankFooter.tsx
@@ -5,6 +5,7 @@
  * RS3-style bank footer displaying stats and quick-access toggles.
  */
 
+import { useState } from "react";
 import { useThemeStore } from "@/ui";
 import { getInteractiveTileStyle, getPanelInsetStyle } from "@/ui/theme/themes";
 import { TAB_INDEX_ALL } from "../constants";
@@ -37,6 +38,10 @@ export function BankFooter({
 }: BankFooterProps) {
   const theme = useThemeStore((s) => s.theme);
   const placeholderCount = items.filter((i) => i.quantity === 0).length;
+  const [hoveredNoteMode, setHoveredNoteMode] = useState<
+    "item" | "note" | null
+  >(null);
+  const [isClearAllHovered, setIsClearAllHovered] = useState(false);
 
   return (
     <div
@@ -87,12 +92,25 @@ export function BankFooter({
                       radius: theme.borderRadius.sm,
                     }).background,
                   )
-                : "transparent",
+                : hoveredNoteMode === "item"
+                  ? String(
+                      getInteractiveTileStyle(theme, {
+                        hovered: true,
+                        radius: theme.borderRadius.sm,
+                      }).background,
+                    )
+                  : "transparent",
               color: !withdrawAsNote
                 ? theme.colors.accent.primary
-                : theme.colors.text.muted,
+                : hoveredNoteMode === "item"
+                  ? theme.colors.text.primary
+                  : theme.colors.text.muted,
               borderRight: `1px solid ${theme.colors.border.decorative}`,
             }}
+            onMouseEnter={() => setHoveredNoteMode("item")}
+            onMouseLeave={() =>
+              setHoveredNoteMode((prev) => (prev === "item" ? null : prev))
+            }
             title="Withdraw items as-is (1 slot per item)"
           >
             Item
@@ -108,11 +126,24 @@ export function BankFooter({
                       radius: theme.borderRadius.sm,
                     }).background,
                   )
-                : "transparent",
+                : hoveredNoteMode === "note"
+                  ? String(
+                      getInteractiveTileStyle(theme, {
+                        hovered: true,
+                        radius: theme.borderRadius.sm,
+                      }).background,
+                    )
+                  : "transparent",
               color: withdrawAsNote
                 ? theme.colors.accent.primary
-                : theme.colors.text.muted,
+                : hoveredNoteMode === "note"
+                  ? theme.colors.text.primary
+                  : theme.colors.text.muted,
             }}
+            onMouseEnter={() => setHoveredNoteMode("note")}
+            onMouseLeave={() =>
+              setHoveredNoteMode((prev) => (prev === "note" ? null : prev))
+            }
             title="Withdraw items as bank notes (stackable, all fit in 1 slot)"
           >
             Note
@@ -154,18 +185,15 @@ export function BankFooter({
             className="px-2 py-0.5 rounded text-[10px] font-medium transition-all"
             style={{
               ...getInteractiveTileStyle(theme, {
-                active: true,
+                active: !isClearAllHovered,
+                hovered: isClearAllHovered,
                 accentColor: theme.colors.state.danger,
                 radius: theme.borderRadius.sm,
               }),
               color: theme.colors.text.primary,
             }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = `${theme.colors.state.danger}b3`;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = `${theme.colors.state.danger}80`;
-            }}
+            onMouseEnter={() => setIsClearAllHovered(true)}
+            onMouseLeave={() => setIsClearAllHovered(false)}
             title="Release all placeholders"
           >
             Clear All

--- a/packages/client/src/game/panels/BankPanel/components/BankSlotItem.tsx
+++ b/packages/client/src/game/panels/BankPanel/components/BankSlotItem.tsx
@@ -11,7 +11,7 @@
  * DO NOT REMOVE React.memo - it is essential for performance!
  */
 
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 import { useThemeStore } from "@/ui";
 import { getInteractiveTileStyle } from "@/ui/theme/themes";
 import type { BankItem } from "../types";
@@ -41,6 +41,9 @@ export interface BankSlotItemProps {
   onDragEnd: () => void;
   onClick: (itemId: string, tabIndex: number, slot: number) => void;
   onContextMenu: (e: React.MouseEvent, item: BankItem) => void;
+  onHoverStart: (item: BankItem, position: { x: number; y: number }) => void;
+  onHoverMove: (position: { x: number; y: number }) => void;
+  onHoverEnd: () => void;
 }
 
 /**
@@ -67,9 +70,21 @@ export const BankSlotItem = memo(function BankSlotItem({
   onDragEnd,
   onClick,
   onContextMenu,
+  onHoverStart,
+  onHoverMove,
+  onHoverEnd,
 }: BankSlotItemProps) {
   const theme = useThemeStore((s) => s.theme);
   const isPlaceholder = item.quantity === 0;
+  const [isHovered, setIsHovered] = useState(false);
+  const tileStyle = getInteractiveTileStyle(theme, {
+    hovered: isHovered && !isDragging && !isPlaceholder,
+    dragging: isDragging,
+    dropTarget: showSwapHighlight,
+    disabled: isPlaceholder,
+    radius: theme.borderRadius.sm,
+    accentColor: theme.colors.accent.primary,
+  });
 
   return (
     <div
@@ -77,27 +92,15 @@ export const BankSlotItem = memo(function BankSlotItem({
       style={{
         width: slotSize,
         height: slotSize,
-        ...getInteractiveTileStyle(theme, {
-          active: !isPlaceholder,
-          dragging: isDragging,
-          dropTarget: showSwapHighlight,
-          disabled: isPlaceholder,
-          radius: theme.borderRadius.sm,
-          accentColor: theme.colors.accent.primary,
-        }),
+        ...tileStyle,
         transform: isDragging ? "scale(0.9)" : "scale(1)",
         opacity: isDragging ? 0.4 : isPlaceholder ? 0.6 : 1,
         transition:
           "transform 0.15s ease, opacity 0.15s ease, background 0.1s ease, border 0.1s ease",
         boxShadow: showSwapHighlight
-          ? `0 0 12px rgba(${dropColor}, 0.5)`
-          : "none",
+          ? `${tileStyle.boxShadow ?? ""}, 0 0 12px rgba(${dropColor}, 0.5)`
+          : tileStyle.boxShadow,
       }}
-      title={
-        isPlaceholder
-          ? `${formatItemName(item.itemId)} (placeholder)`
-          : `${formatItemName(item.itemId)} x${item.quantity} (Tab ${itemTabIndex})`
-      }
       draggable={true}
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = "move";
@@ -109,6 +112,17 @@ export const BankSlotItem = memo(function BankSlotItem({
       onDragEnd={onDragEnd}
       onClick={() => onClick(item.itemId, itemTabIndex, slotIndex)}
       onContextMenu={(e) => onContextMenu(e, item)}
+      onMouseEnter={(e) => {
+        setIsHovered(true);
+        onHoverStart(item, { x: e.clientX, y: e.clientY });
+      }}
+      onMouseMove={(e) => {
+        onHoverMove({ x: e.clientX, y: e.clientY });
+      }}
+      onMouseLeave={() => {
+        setIsHovered(false);
+        onHoverEnd();
+      }}
     >
       {/* Single INSERT LINE on left edge */}
       {(showInsertLine || showFaintGuide) && (
@@ -131,7 +145,13 @@ export const BankSlotItem = memo(function BankSlotItem({
           }}
         />
       )}
-      <span className="select-none pointer-events-none">
+      <span
+        className="select-none pointer-events-none"
+        style={{
+          transform: isHovered && !isPlaceholder ? "scale(1.03)" : "scale(1)",
+          transition: "transform 0.15s ease",
+        }}
+      >
         <ItemIcon itemId={item.itemId} size={38} />
       </span>
       {item.quantity > 1 && (

--- a/packages/client/src/game/panels/BankPanel/components/BankTabBar.tsx
+++ b/packages/client/src/game/panels/BankPanel/components/BankTabBar.tsx
@@ -10,7 +10,9 @@
  * - Delete tabs via right-click
  */
 
-import { useThemeStore } from "@/ui";
+import { useState } from "react";
+import { CursorTooltip, useThemeStore } from "@/ui";
+import { getTooltipTitleStyle } from "@/ui/core/tooltip/tooltipStyles";
 import { getInteractiveTileStyle, getPanelInsetStyle } from "@/ui/theme/themes";
 import type { BankItem, BankTab, ConfirmModalState } from "../types";
 import type { DragState } from "../hooks";
@@ -64,6 +66,41 @@ export function BankTabBar({
 }: BankTabBarProps) {
   const theme = useThemeStore((s) => s.theme);
   const { draggedSlot, draggedTabIndex, hoveredTabIndex } = dragState;
+  const [hoveredButton, setHoveredButton] = useState<string | null>(null);
+  const [hoverTooltip, setHoverTooltip] = useState<{
+    label: string;
+    position: { x: number; y: number };
+  } | null>(null);
+
+  const getTabIconSlotStyle = (
+    state: "idle" | "hovered" | "active" | "success",
+  ): React.CSSProperties => {
+    const accentColor =
+      state === "success"
+        ? theme.colors.state.success
+        : theme.colors.accent.primary;
+    const hovered = state === "hovered" || state === "success";
+    const active = state === "active";
+
+    return {
+      ...getInteractiveTileStyle(theme, {
+        hovered,
+        active,
+        radius: theme.borderRadius.sm,
+        accentColor,
+      }),
+      width: 36,
+      height: 36,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      boxShadow: active
+        ? `${theme.shadows.sm}, inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -10px 14px rgba(0,0,0,0.16)`
+        : hovered
+          ? `${theme.shadows.sm}, inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -10px 14px rgba(0,0,0,0.12)`
+          : "inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -8px 12px rgba(0,0,0,0.14)",
+    };
+  };
 
   // Get the next available tab index for creating new tabs
   // RS3-STYLE: Always append at end (max + 1), never fill gaps
@@ -87,7 +124,7 @@ export function BankTabBar({
       {/* All Tab (∞) - RS3 style */}
       <button
         onClick={() => onSelectTab(TAB_INDEX_ALL)}
-        className="px-3 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
+        className="px-2 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
         style={{
           background:
             selectedTab === TAB_INDEX_ALL
@@ -97,14 +134,23 @@ export function BankTabBar({
                     radius: theme.borderRadius.sm,
                   }).background,
                 )
-              : String(
-                  getPanelInsetStyle(theme, { radius: theme.borderRadius.sm })
-                    .background,
-                ),
+              : hoveredButton === "all"
+                ? String(
+                    getInteractiveTileStyle(theme, {
+                      hovered: true,
+                      radius: theme.borderRadius.sm,
+                    }).background,
+                  )
+                : String(
+                    getPanelInsetStyle(theme, { radius: theme.borderRadius.sm })
+                      .background,
+                  ),
           color:
             selectedTab === TAB_INDEX_ALL
               ? theme.colors.text.primary
-              : theme.colors.text.secondary,
+              : hoveredButton === "all"
+                ? theme.colors.text.primary
+                : theme.colors.text.secondary,
           borderTop:
             selectedTab === TAB_INDEX_ALL
               ? `1px solid ${theme.colors.border.default}`
@@ -119,9 +165,41 @@ export function BankTabBar({
               : `1px solid ${theme.colors.border.decorative}`,
           borderBottom: "none",
         }}
-        title="View all items across all tabs"
+        onMouseEnter={(e) => {
+          setHoveredButton("all");
+          setHoverTooltip({
+            label: "View all items across all tabs",
+            position: { x: e.clientX, y: e.clientY },
+          });
+        }}
+        onMouseMove={(e) => {
+          setHoverTooltip((prev) =>
+            prev?.label === "View all items across all tabs"
+              ? {
+                  label: prev.label,
+                  position: { x: e.clientX, y: e.clientY },
+                }
+              : prev,
+          );
+        }}
+        onMouseLeave={() => {
+          setHoveredButton((prev) => (prev === "all" ? null : prev));
+          setHoverTooltip((prev) =>
+            prev?.label === "View all items across all tabs" ? null : prev,
+          );
+        }}
       >
-        ∞
+        <div
+          style={getTabIconSlotStyle(
+            selectedTab === TAB_INDEX_ALL
+              ? "active"
+              : hoveredButton === "all"
+                ? "hovered"
+                : "idle",
+          )}
+        >
+          <span style={{ fontSize: 20, lineHeight: 1 }}>∞</span>
+        </div>
       </button>
 
       {/* All Tabs (0-9) - RS3 style: Tab 0 is just another tab, icon = first item */}
@@ -196,10 +274,15 @@ export function BankTabBar({
                 setDraggedTabIndex(null);
                 setHoveredTabIndex(null);
               }}
-              className="px-3 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
+              className="px-2 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
               style={{
                 background: isHovered
-                  ? `${theme.colors.accent.primary}4d` // 30% opacity
+                  ? String(
+                      getInteractiveTileStyle(theme, {
+                        hovered: true,
+                        radius: theme.borderRadius.sm,
+                      }).background,
+                    )
                   : isSelected
                     ? String(
                         getInteractiveTileStyle(theme, {
@@ -207,27 +290,64 @@ export function BankTabBar({
                           radius: theme.borderRadius.sm,
                         }).background,
                       )
-                    : String(
-                        getPanelInsetStyle(theme, {
-                          radius: theme.borderRadius.sm,
-                        }).background,
-                      ),
+                    : hoveredButton === `tab-${tabIndex}`
+                      ? String(
+                          getInteractiveTileStyle(theme, {
+                            hovered: true,
+                            radius: theme.borderRadius.sm,
+                          }).background,
+                        )
+                      : String(
+                          getPanelInsetStyle(theme, {
+                            radius: theme.borderRadius.sm,
+                          }).background,
+                        ),
                 color: isSelected
                   ? theme.colors.text.primary
-                  : theme.colors.text.secondary,
+                  : hoveredButton === `tab-${tabIndex}`
+                    ? theme.colors.text.primary
+                    : theme.colors.text.secondary,
                 borderTop: borderColor,
                 borderLeft: borderColor,
                 borderRight: borderColor,
                 borderBottom: "none",
                 opacity: isPlaceholderIcon && !isSelected ? 0.6 : 1,
               }}
-              title={
-                iconItem
-                  ? `${formatItemName(iconItem.itemId)}${isPlaceholderIcon ? " (empty)" : ""}${canDelete ? " - Right-click to delete" : ""}`
-                  : `Tab ${tabIndex}${canDelete ? " - Right-click to delete" : ""}`
-              }
+              onMouseEnter={() => setHoveredButton(`tab-${tabIndex}`)}
+              onMouseEnter={(e) => {
+                setHoveredButton(`tab-${tabIndex}`);
+                setHoverTooltip({
+                  label: iconItem
+                    ? `${formatItemName(iconItem.itemId)}${isPlaceholderIcon ? " (empty)" : ""}${canDelete ? " - Right-click to delete" : ""}`
+                    : `Tab ${tabIndex}${canDelete ? " - Right-click to delete" : ""}`,
+                  position: { x: e.clientX, y: e.clientY },
+                });
+              }}
+              onMouseMove={(e) => {
+                setHoverTooltip((prev) =>
+                  prev
+                    ? { ...prev, position: { x: e.clientX, y: e.clientY } }
+                    : prev,
+                );
+              }}
+              onMouseLeave={() => {
+                setHoveredButton((prev) =>
+                  prev === `tab-${tabIndex}` ? null : prev,
+                );
+                setHoverTooltip(null);
+              }}
             >
-              {tabIcon}
+              <div
+                style={getTabIconSlotStyle(
+                  isSelected
+                    ? "active"
+                    : isHovered || hoveredButton === `tab-${tabIndex}`
+                      ? "hovered"
+                      : "idle",
+                )}
+              >
+                {tabIcon}
+              </div>
             </button>
           );
         });
@@ -259,35 +379,109 @@ export function BankTabBar({
             setDraggedTabIndex(null);
             setHoveredTabIndex(null);
           }}
-          className="px-3 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
+          className="px-2 py-1.5 rounded-t text-xs font-bold transition-colors flex-shrink-0"
           style={{
             background:
               hoveredTabIndex === TAB_INDEX_NEW_TAB_HOVER
-                ? `${theme.colors.state.success}4d` // 30% opacity
-                : String(
-                    getPanelInsetStyle(theme, {
+                ? String(
+                    getInteractiveTileStyle(theme, {
+                      hovered: true,
                       radius: theme.borderRadius.sm,
+                      accentColor: theme.colors.state.success,
                     }).background,
-                  ),
+                  )
+                : hoveredButton === "new-tab"
+                  ? String(
+                      getInteractiveTileStyle(theme, {
+                        hovered: true,
+                        radius: theme.borderRadius.sm,
+                        accentColor: theme.colors.state.success,
+                      }).background,
+                    )
+                  : String(
+                      getPanelInsetStyle(theme, {
+                        radius: theme.borderRadius.sm,
+                      }).background,
+                    ),
             color: theme.colors.state.success,
             borderTop:
               hoveredTabIndex === TAB_INDEX_NEW_TAB_HOVER
                 ? `1px solid ${theme.colors.state.success}`
-                : `1px dashed ${theme.colors.state.success}66`,
+                : hoveredButton === "new-tab"
+                  ? `1px solid ${theme.colors.state.success}`
+                  : `1px dashed ${theme.colors.state.success}66`,
             borderLeft:
               hoveredTabIndex === TAB_INDEX_NEW_TAB_HOVER
                 ? `1px solid ${theme.colors.state.success}`
-                : `1px dashed ${theme.colors.state.success}66`,
+                : hoveredButton === "new-tab"
+                  ? `1px solid ${theme.colors.state.success}`
+                  : `1px dashed ${theme.colors.state.success}66`,
             borderRight:
               hoveredTabIndex === TAB_INDEX_NEW_TAB_HOVER
                 ? `1px solid ${theme.colors.state.success}`
-                : `1px dashed ${theme.colors.state.success}66`,
+                : hoveredButton === "new-tab"
+                  ? `1px solid ${theme.colors.state.success}`
+                  : `1px dashed ${theme.colors.state.success}66`,
             borderBottom: "none",
           }}
-          title="Drag an item here to create a new tab"
+          onMouseEnter={(e) => {
+            setHoveredButton("new-tab");
+            setHoverTooltip({
+              label: "Drag an item here to create a new tab",
+              position: { x: e.clientX, y: e.clientY },
+            });
+          }}
+          onMouseMove={(e) => {
+            setHoverTooltip((prev) =>
+              prev?.label === "Drag an item here to create a new tab"
+                ? {
+                    label: prev.label,
+                    position: { x: e.clientX, y: e.clientY },
+                  }
+                : prev,
+            );
+          }}
+          onMouseLeave={() => {
+            setHoveredButton((prev) => (prev === "new-tab" ? null : prev));
+            setHoverTooltip((prev) =>
+              prev?.label === "Drag an item here to create a new tab"
+                ? null
+                : prev,
+            );
+          }}
         >
-          +
+          <div
+            style={getTabIconSlotStyle(
+              hoveredTabIndex === TAB_INDEX_NEW_TAB_HOVER ||
+                hoveredButton === "new-tab"
+                ? "success"
+                : "idle",
+            )}
+          >
+            <span style={{ fontSize: 22, lineHeight: 1 }}>+</span>
+          </div>
         </button>
+      )}
+
+      {hoverTooltip && (
+        <CursorTooltip
+          visible={true}
+          position={hoverTooltip.position}
+          estimatedSize={{ width: 220, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "160px",
+            maxWidth: "260px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {hoverTooltip.label}
+          </div>
+        </CursorTooltip>
       )}
     </div>
   );

--- a/packages/client/src/game/panels/BankPanel/components/RightPanel.tsx
+++ b/packages/client/src/game/panels/BankPanel/components/RightPanel.tsx
@@ -5,7 +5,7 @@
  * RS3-style tab switcher between backpack and worn equipment.
  */
 
-import React, { useCallback } from "react";
+import React, { useState } from "react";
 import { useThemeStore, useMobileLayout } from "@/ui";
 import {
   getInteractiveTileStyle,
@@ -13,12 +13,11 @@ import {
   getPanelInsetStyle,
   getPanelSurfaceStyle,
 } from "@/ui/theme/themes";
-import type { PlayerEquipmentItems } from "@hyperscape/shared";
 import { INV_SLOTS_PER_ROW, INV_SLOT_SIZE } from "../constants";
-import { formatItemName } from "../utils";
-import { ItemIcon } from "@/ui/components/ItemIcon";
 import type { InventorySlotViewItem, RightPanelMode } from "../types";
 import { InventoryPanel } from "../../InventoryPanel";
+import { EquipmentPanel } from "../../EquipmentPanel";
+import type { ClientWorld } from "../../../types";
 
 export interface RightPanelProps {
   mode: RightPanelMode;
@@ -27,9 +26,10 @@ export interface RightPanelProps {
   // Inventory data
   inventory: InventorySlotViewItem[];
   coins: number;
+  world: ClientWorld;
 
   // Equipment data
-  equipment?: PlayerEquipmentItems | null;
+  equipment?: import("@hyperscape/shared").PlayerEquipmentItems | null;
 
   // Inventory actions
   onDeposit: (itemId: string, quantity: number) => void;
@@ -55,6 +55,7 @@ export function RightPanel({
   inventory,
   coins,
   equipment,
+  world,
   onDeposit,
   onDepositAll,
   onOpenCoinModal,
@@ -64,117 +65,29 @@ export function RightPanel({
 }: RightPanelProps) {
   const theme = useThemeStore((s) => s.theme);
   const { shouldUseMobileUI } = useMobileLayout();
+  const [hoveredModeButton, setHoveredModeButton] =
+    useState<RightPanelMode | null>(null);
+  const [isDepositCoinsHovered, setIsDepositCoinsHovered] = useState(false);
+  const [isDepositInventoryHovered, setIsDepositInventoryHovered] =
+    useState(false);
+  const [isDepositEquipmentHovered, setIsDepositEquipmentHovered] =
+    useState(false);
 
   // Responsive sizing
   const responsiveSlotSize = shouldUseMobileUI ? 34 : INV_SLOT_SIZE;
-
-  /**
-   * Render a single equipment slot for the paperdoll layout
-   */
-  const renderEquipmentSlot = useCallback(
-    (key: string, label: string, icon: string) => {
-      const item = equipment?.[key as keyof PlayerEquipmentItems] ?? null;
-      const hasItem = !!item;
-
-      return (
-        <button
-          key={key}
-          onClick={() => hasItem && onDepositEquipment(key)}
-          className="w-full h-full rounded transition-all duration-200 cursor-pointer group relative"
-          style={{
-            ...getInteractiveTileStyle(theme, {
-              active: hasItem,
-              radius: theme.borderRadius.md,
-              accentColor: theme.colors.state.success,
-            }),
-            boxShadow: hasItem
-              ? `0 4px 12px rgba(0, 0, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -8px 14px rgba(0, 0, 0, 0.14)`
-              : "inset 0 1px 0 rgba(255, 255, 255, 0.04), inset 0 -8px 12px rgba(0, 0, 0, 0.12)",
-          }}
-          onMouseEnter={(e) => {
-            if (hasItem) {
-              e.currentTarget.style.borderColor = theme.colors.state.success;
-              e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, ${theme.colors.state.success}1f 18%, rgba(24, 28, 34, 0.98) 100%)`;
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (hasItem) {
-              e.currentTarget.style.borderColor = theme.colors.border.hover;
-              e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.012) 18%, rgba(22, 26, 31, 0.99) 100%)`;
-            }
-          }}
-          title={
-            hasItem
-              ? `${formatItemName(item.id)} - Click to deposit`
-              : `${label} (empty)`
-          }
-        >
-          {/* Slot Label */}
-          <div
-            className="absolute top-0.5 left-1 text-[8px] font-medium uppercase tracking-wider"
-            style={{
-              color: theme.colors.text.secondary,
-              textShadow: "0 1px 2px rgba(0, 0, 0, 0.8)",
-            }}
-          >
-            {label}
-          </div>
-
-          {/* Slot Content */}
-          <div className="flex flex-col items-center justify-center h-full pt-2">
-            {!hasItem ? (
-              <span
-                className="transition-transform duration-200 group-hover:scale-110"
-                style={{
-                  fontSize: "1.25rem",
-                  filter: "grayscale(100%) opacity(0.3)",
-                }}
-              >
-                {icon}
-              </span>
-            ) : (
-              <>
-                <span
-                  className="transition-transform duration-200 group-hover:scale-110"
-                  style={{
-                    filter: "drop-shadow(0 2px 4px rgba(0, 0, 0, 0.8))",
-                  }}
-                >
-                  <ItemIcon itemId={item.id} size={32} />
-                </span>
-                <div
-                  className="text-center px-0.5 mt-0.5"
-                  style={{
-                    fontSize: "8px",
-                    color: theme.colors.text.secondary,
-                    lineHeight: "1.1",
-                    maxWidth: "100%",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {formatItemName(item.id).slice(0, 10)}
-                </div>
-              </>
-            )}
-          </div>
-        </button>
-      );
-    },
-    [equipment, onDepositEquipment, theme],
+  const inventoryPanelWidth = Math.max(
+    INV_SLOTS_PER_ROW * (responsiveSlotSize + 4) + 24,
+    248,
   );
-
+  const desktopPanelWidth = inventoryPanelWidth;
   return (
     <div
       className="flex flex-col rounded-lg"
       style={{
         ...getPanelSurfaceStyle(theme, { emphasis: "strong" }),
         boxShadow: `${theme.shadows.xl}, inset 0 1px 0 rgba(255,248,236,0.06), inset 0 -14px 22px rgba(0,0,0,0.1)`,
-        width: shouldUseMobileUI
-          ? "100%"
-          : `${INV_SLOTS_PER_ROW * (responsiveSlotSize + 4) + 24}px`,
-        minWidth: shouldUseMobileUI ? undefined : "180px",
+        width: shouldUseMobileUI ? "100%" : `${desktopPanelWidth}px`,
+        minWidth: shouldUseMobileUI ? undefined : `${desktopPanelWidth}px`,
       }}
     >
       {/* RS3-style Tab Header with view switcher */}
@@ -199,20 +112,37 @@ export function RightPanel({
                         radius: theme.borderRadius.sm,
                       }).background,
                     )
-                  : String(
-                      getPanelInsetStyle(theme, {
-                        radius: theme.borderRadius.sm,
-                      }).background,
-                    ),
+                  : hoveredModeButton === "inventory"
+                    ? String(
+                        getInteractiveTileStyle(theme, {
+                          hovered: true,
+                          radius: theme.borderRadius.sm,
+                        }).background,
+                      )
+                    : String(
+                        getPanelInsetStyle(theme, {
+                          radius: theme.borderRadius.sm,
+                        }).background,
+                      ),
               color:
                 mode === "inventory"
                   ? theme.colors.accent.primary
-                  : theme.colors.text.secondary,
+                  : hoveredModeButton === "inventory"
+                    ? theme.colors.text.primary
+                    : theme.colors.text.secondary,
               border:
                 mode === "inventory"
                   ? `1px solid ${theme.colors.accent.primary}50`
-                  : `1px solid ${theme.colors.border.default}50`,
+                  : hoveredModeButton === "inventory"
+                    ? `1px solid ${theme.colors.border.hover}`
+                    : `1px solid ${theme.colors.border.default}50`,
             }}
+            onMouseEnter={() => setHoveredModeButton("inventory")}
+            onMouseLeave={() =>
+              setHoveredModeButton((prev) =>
+                prev === "inventory" ? null : prev,
+              )
+            }
             title="View Backpack"
           >
             🎒
@@ -229,20 +159,37 @@ export function RightPanel({
                         radius: theme.borderRadius.sm,
                       }).background,
                     )
-                  : String(
-                      getPanelInsetStyle(theme, {
-                        radius: theme.borderRadius.sm,
-                      }).background,
-                    ),
+                  : hoveredModeButton === "equipment"
+                    ? String(
+                        getInteractiveTileStyle(theme, {
+                          hovered: true,
+                          radius: theme.borderRadius.sm,
+                        }).background,
+                      )
+                    : String(
+                        getPanelInsetStyle(theme, {
+                          radius: theme.borderRadius.sm,
+                        }).background,
+                      ),
               color:
                 mode === "equipment"
                   ? theme.colors.accent.primary
-                  : theme.colors.text.secondary,
+                  : hoveredModeButton === "equipment"
+                    ? theme.colors.text.primary
+                    : theme.colors.text.secondary,
               border:
                 mode === "equipment"
                   ? `1px solid ${theme.colors.accent.primary}50`
-                  : `1px solid ${theme.colors.border.default}50`,
+                  : hoveredModeButton === "equipment"
+                    ? `1px solid ${theme.colors.border.hover}`
+                    : `1px solid ${theme.colors.border.default}50`,
             }}
+            onMouseEnter={() => setHoveredModeButton("equipment")}
+            onMouseLeave={() =>
+              setHoveredModeButton((prev) =>
+                prev === "equipment" ? null : prev,
+              )
+            }
             title="View Worn Equipment"
           >
             ⚔️
@@ -256,9 +203,19 @@ export function RightPanel({
         </span>
       </div>
 
-      {/* Content Area - switches between inventory and equipment */}
-      {mode === "inventory" ? (
-        <>
+      {/* Content Area - keep both views mounted so the paperdoll preview stays warm across tab switches */}
+      <div
+        className="relative flex-1"
+        style={{ minHeight: shouldUseMobileUI ? "200px" : "360px" }}
+      >
+        <div
+          className="absolute inset-0 flex flex-col"
+          style={{
+            opacity: mode === "inventory" ? 1 : 0,
+            pointerEvents: mode === "inventory" ? "auto" : "none",
+            visibility: mode === "inventory" ? "visible" : "hidden",
+          }}
+        >
           {/* Modern Inventory Panel in bank mode */}
           <div
             className="flex-1"
@@ -303,19 +260,15 @@ export function RightPanel({
               className="px-2 py-1 rounded text-xs font-bold transition-colors disabled:opacity-30"
               style={{
                 ...getInteractiveTileStyle(theme, {
-                  active: true,
+                  active: !isDepositCoinsHovered,
+                  hovered: isDepositCoinsHovered,
                   accentColor: theme.colors.state.success,
                   radius: theme.borderRadius.sm,
                 }),
                 color: theme.colors.text.primary,
               }}
-              onMouseEnter={(e) => {
-                if (coins > 0)
-                  e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, ${theme.colors.state.success}22 22%, rgba(20, 36, 25, 0.98) 100%)`;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, ${theme.colors.state.success}18 20%, rgba(20, 31, 24, 0.98) 100%)`;
-              }}
+              onMouseEnter={() => setIsDepositCoinsHovered(true)}
+              onMouseLeave={() => setIsDepositCoinsHovered(false)}
             >
               Deposit
             </button>
@@ -328,28 +281,32 @@ export function RightPanel({
               className="w-full py-2 rounded text-sm font-bold transition-colors"
               style={{
                 ...getInteractiveTileStyle(theme, {
-                  active: true,
+                  active: !isDepositInventoryHovered,
+                  hovered: isDepositInventoryHovered,
                   accentColor: theme.colors.accent.primary,
                   radius: theme.borderRadius.md,
                 }),
                 color: theme.colors.accent.primary,
               }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, ${theme.colors.accent.primary}18 20%, rgba(25, 29, 35, 0.98) 100%)`;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, ${theme.colors.accent.primary}14 20%, rgba(22, 26, 31, 0.98) 100%)`;
-              }}
+              onMouseEnter={() => setIsDepositInventoryHovered(true)}
+              onMouseLeave={() => setIsDepositInventoryHovered(false)}
             >
               Deposit Inventory
             </button>
           </div>
-        </>
-      ) : (
-        <>
-          {/* Equipment View - Paperdoll layout matching EquipmentPanel */}
+        </div>
+
+        <div
+          className="absolute inset-0 flex flex-col"
+          style={{
+            opacity: mode === "equipment" ? 1 : 0,
+            pointerEvents: mode === "equipment" ? "auto" : "none",
+            visibility: mode === "equipment" ? "visible" : "hidden",
+          }}
+        >
+          {/* Shared EquipmentPanel with bank-specific deposit actions */}
           <div
-            className="p-2 flex-1"
+            className="p-2 flex-1 overflow-hidden"
             style={{
               ...getPanelInsetStyle(theme, {
                 emphasis: "strong",
@@ -360,30 +317,16 @@ export function RightPanel({
               margin: "4px",
             }}
           >
-            {/* Paperdoll Grid: 3 columns x 3 rows (melee-only MVP) */}
-            <div
-              className="grid gap-1 h-full"
-              style={{
-                gridTemplateColumns: "repeat(3, 1fr)",
-                gridTemplateRows: "repeat(3, 1fr)",
-              }}
-            >
-              {/* Row 1: empty, helmet, empty */}
-              <div />
-              {renderEquipmentSlot("helmet", "Head", "⛑️")}
-              <div />
-
-              {/* Row 2: weapon, body, shield */}
-              {renderEquipmentSlot("weapon", "Weapon", "⚔️")}
-              {renderEquipmentSlot("body", "Body", "🎽")}
-              {renderEquipmentSlot("shield", "Shield", "🛡️")}
-
-              {/* Row 3: empty, legs, empty */}
-              <div />
-              {renderEquipmentSlot("legs", "Legs", "👖")}
-              <div />
-              {/* Row 4: Arrows slot hidden for melee-only MVP */}
-            </div>
+            <EquipmentPanel
+              equipment={equipment ?? null}
+              world={world}
+              slotActionLabel="Deposit"
+              onSlotAction={onDepositEquipment}
+              footerButtons={[]}
+              showBonuses={true}
+              layoutVariant="bank"
+              isVisible={mode === "equipment"}
+            />
           </div>
 
           {/* Deposit All Equipment Button */}
@@ -396,24 +339,21 @@ export function RightPanel({
               className="w-full py-2 rounded text-sm font-bold transition-colors disabled:opacity-30"
               style={{
                 ...getInteractiveTileStyle(theme, {
-                  active: true,
+                  active: !isDepositEquipmentHovered,
+                  hovered: isDepositEquipmentHovered,
                   accentColor: theme.colors.accent.primary,
                   radius: theme.borderRadius.md,
                 }),
                 color: theme.colors.accent.primary,
               }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, ${theme.colors.accent.primary}18 20%, rgba(25, 29, 35, 0.98) 100%)`;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, ${theme.colors.accent.primary}14 20%, rgba(22, 26, 31, 0.98) 100%)`;
-              }}
+              onMouseEnter={() => setIsDepositEquipmentHovered(true)}
+              onMouseLeave={() => setIsDepositEquipmentHovered(false)}
             >
               Deposit Worn Items
             </button>
           </div>
-        </>
-      )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/game/panels/DuelPanel/components/SlotItem.tsx
+++ b/packages/client/src/game/panels/DuelPanel/components/SlotItem.tsx
@@ -8,8 +8,9 @@
  * - Visual staked indicator
  */
 
-import type { CSSProperties } from "react";
-import type { Theme } from "@/ui";
+import { useState, type CSSProperties } from "react";
+import { CursorTooltip, type Theme } from "@/ui";
+import { getTooltipTitleStyle } from "@/ui/core/tooltip/tooltipStyles";
 import { ItemIcon } from "@/ui/components/ItemIcon";
 import { formatQuantity } from "../utils";
 
@@ -76,32 +77,73 @@ export function SlotItem({
   onClick,
   onContextMenu,
 }: SlotItemProps) {
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
   if (!hasItem) {
     return <div style={getSlotStyle(theme, false)} />;
   }
 
   return (
-    <div
-      style={{
-        ...getSlotStyle(theme, true, isStaked),
-        opacity: isStaked ? 0.4 : 1,
-      }}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
-      title={title}
-    >
-      {itemId ? (
-        <ItemIcon itemId={itemId} size={32} />
-      ) : (
-        <span
-          style={{ fontSize: "10px", textAlign: "center", overflow: "hidden" }}
+    <>
+      <div
+        style={{
+          ...getSlotStyle(theme, true, isStaked),
+          opacity: isStaked ? 0.4 : 1,
+        }}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={(e) => {
+          if (title) {
+            setHoverState({ x: e.clientX, y: e.clientY });
+          }
+        }}
+        onMouseMove={(e) => {
+          if (title) {
+            setHoverState({ x: e.clientX, y: e.clientY });
+          }
+        }}
+        onMouseLeave={() => setHoverState(null)}
+      >
+        {itemId ? (
+          <ItemIcon itemId={itemId} size={32} />
+        ) : (
+          <span
+            style={{
+              fontSize: "10px",
+              textAlign: "center",
+              overflow: "hidden",
+            }}
+          >
+            {displayName?.substring(0, 8)}
+          </span>
+        )}
+        {quantity !== undefined && quantity > 1 && (
+          <span style={quantityStyle}>{formatQuantity(quantity)}</span>
+        )}
+      </div>
+
+      {title && hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 180, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "140px",
+            maxWidth: "240px",
+          }}
         >
-          {displayName?.substring(0, 8)}
-        </span>
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {title}
+          </div>
+        </CursorTooltip>
       )}
-      {quantity !== undefined && quantity > 1 && (
-        <span style={quantityStyle}>{formatQuantity(quantity)}</span>
-      )}
-    </div>
+    </>
   );
 }

--- a/packages/client/src/game/panels/EquipmentPanel.tsx
+++ b/packages/client/src/game/panels/EquipmentPanel.tsx
@@ -43,12 +43,23 @@ import { EquipmentPaperdollPortrait } from "./equipment/EquipmentPaperdollPortra
 interface EquipmentPanelProps {
   equipment: PlayerEquipmentItems | null;
   world?: ClientWorld;
+  slotActionLabel?: string;
+  onSlotAction?: (slotKey: string) => void;
+  footerButtons?: Array<{
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+  }>;
+  showBonuses?: boolean;
+  layoutVariant?: "default" | "bank";
+  isVisible?: boolean;
 }
 
 type EquipmentSlot = EquipmentSlotData;
 
 interface DroppableEquipmentSlotProps {
   slot: EquipmentSlot;
+  slotActionLabel: string;
   onSlotClick: (slot: EquipmentSlot) => void;
   onHoverStart: (
     slot: EquipmentSlot,
@@ -61,6 +72,7 @@ interface DroppableEquipmentSlotProps {
 
 function DroppableEquipmentSlot({
   slot,
+  slotActionLabel,
   onSlotClick,
   onHoverStart,
   onHoverMove,
@@ -156,10 +168,10 @@ function DroppableEquipmentSlot({
 
         const items = [
           {
-            id: "unequip",
-            label: `Remove ${itemName}`,
+            id: "slotAction",
+            label: `${slotActionLabel} ${itemName}`,
             styledLabel: [
-              { text: "Remove " },
+              { text: `${slotActionLabel} ` },
               { text: itemName, color: CONTEXT_MENU_COLORS.ITEM },
             ],
             enabled: true,
@@ -331,9 +343,77 @@ const PAPERDOLL_PLACEMENTS: PaperdollSlotPlacement[] = [
   { area: "shield", key: EquipmentSlotName.SHIELD },
 ];
 
+interface EquipmentLayoutConfig {
+  slotWidth: number;
+  slotHeight: number;
+  centerMin?: number;
+  gap: number;
+  padding: number;
+  portraitMode: "overlay" | "area";
+  portraitPadding?: string;
+  portraitOffsetX?: number;
+  portraitBleedX?: number;
+  templateAreas: string;
+  rowCount: number;
+  portraitArea?: string;
+  emptyAreas?: string[];
+}
+
+function getEquipmentLayoutConfig(
+  isMobile: boolean,
+  variant: "default" | "bank",
+): EquipmentLayoutConfig {
+  if (variant === "bank") {
+    return {
+      slotWidth: isMobile ? 30 : 30,
+      slotHeight: isMobile ? 34 : 38,
+      centerMin: 0,
+      gap: isMobile ? 4 : 4,
+      padding: isMobile ? 4 : 4,
+      portraitMode: "area",
+      portraitPadding: isMobile ? "0" : "0",
+      portraitOffsetX: 0,
+      portraitBleedX: isMobile ? 10 : 18,
+      rowCount: 5,
+      portraitArea: "portrait",
+      emptyAreas: ["empty"],
+      templateAreas: `
+        "head portrait portrait cape"
+        "body portrait portrait amulet"
+        "legs portrait portrait ring"
+        "boots portrait portrait gloves"
+        "weapon ammo shield ."
+      `,
+    };
+  }
+
+  return {
+    slotWidth: isMobile ? 34 : 38,
+    slotHeight: isMobile ? 32 : 36,
+    gap: isMobile ? 5 : 8,
+    padding: isMobile ? 2 : 3,
+    portraitMode: "overlay",
+    portraitBleedX: isMobile ? 12 : 20,
+    rowCount: 5,
+    templateAreas: `
+      "head . . . cape"
+      "body . . . amulet"
+      "legs . . . ring"
+      "boots . . . gloves"
+      "ammo weapon . shield ."
+    `,
+  };
+}
+
 export const EquipmentPanel = React.memo(function EquipmentPanel({
   equipment,
   world,
+  slotActionLabel = "Remove",
+  onSlotAction,
+  footerButtons,
+  showBonuses = true,
+  layoutVariant = "default",
+  isVisible = true,
 }: EquipmentPanelProps) {
   const theme = useThemeStore((s) => s.theme);
   const { shouldUseMobileUI } = useMobileLayout();
@@ -461,6 +541,10 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   // RS3-style: Click immediately unequips
   const handleSlotClick = (slot: EquipmentSlot) => {
     if (!slot.item) return;
+    if (onSlotAction) {
+      onSlotAction(slot.key);
+      return;
+    }
     sendUnequip(slot.key);
   };
 
@@ -503,8 +587,12 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
 
       if (!slot || !slot.item) return;
 
-      if (ce.detail.actionId === "unequip") {
-        sendUnequip(slotKey);
+      if (ce.detail.actionId === "slotAction") {
+        if (onSlotAction) {
+          onSlotAction(slotKey);
+        } else {
+          sendUnequip(slotKey);
+        }
       }
 
       if (ce.detail.actionId === "examine") {
@@ -533,7 +621,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         "contextmenu:select",
         onCtxSelect as EventListener,
       );
-  }, [equipment, world]);
+  }, [onSlotAction, slots, world]);
 
   // Helper to find slot by key
   const getSlot = (key: string) => slots.find((s) => s.key === key) || null;
@@ -567,6 +655,7 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
     >
       <DroppableEquipmentSlot
         slot={getSlot(slotName)!}
+        slotActionLabel={slotActionLabel}
         onSlotClick={handleSlotClick}
         onHoverStart={handleHoverStart}
         onHoverMove={handleHoverMove}
@@ -577,27 +666,21 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
   );
 
   const renderEquipmentGrid = (isMobile: boolean) => {
-    const slotWidth = isMobile ? 34 : 38;
-    const slotHeight = isMobile ? 32 : 36;
-    const gap = isMobile ? 5 : 8;
-    const padding = isMobile ? 2 : 3;
+    const layout = getEquipmentLayoutConfig(isMobile, layoutVariant);
 
     return (
       <div
         data-equipment-grid="paperdoll"
-        className="grid h-full"
+        className="grid h-full w-full"
         style={{
-          gridTemplateColumns: `${slotWidth}px ${slotWidth}px 1fr ${slotWidth}px ${slotWidth}px`,
-          gridTemplateRows: `repeat(5, ${slotHeight}px)`,
-          gridTemplateAreas: `
-          "head . . . cape"
-          "body . . . amulet"
-          "legs . . . ring"
-          "boots . . . gloves"
-          "ammo weapon . shield ."
-        `,
-          gap,
-          padding,
+          gridTemplateColumns:
+            layout.portraitMode === "overlay"
+              ? `${layout.slotWidth}px ${layout.slotWidth}px 1fr ${layout.slotWidth}px ${layout.slotWidth}px`
+              : `${layout.slotWidth}px minmax(${layout.centerMin}px, 1fr) minmax(${layout.centerMin}px, 1fr) ${layout.slotWidth}px`,
+          gridTemplateRows: `repeat(${layout.rowCount}, ${layout.slotHeight}px)`,
+          gridTemplateAreas: layout.templateAreas,
+          gap: layout.gap,
+          padding: layout.padding,
           alignItems: "stretch",
           justifyItems: "stretch",
         }}
@@ -605,29 +688,73 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         <div
           data-equipment-center="portrait"
           style={{
-            gridColumn: "1 / -1",
-            gridRow: "1 / -1",
+            gridArea:
+              layout.portraitMode === "area" ? layout.portraitArea : undefined,
+            gridColumn:
+              layout.portraitMode === "overlay" ? "1 / -1" : undefined,
+            gridRow: layout.portraitMode === "overlay" ? "1 / -1" : undefined,
             minWidth: 0,
-            width: "100%",
-            height: "100%",
+            minHeight:
+              layout.portraitMode === "overlay"
+                ? layout.slotHeight * layout.rowCount +
+                  layout.gap * (layout.rowCount - 1)
+                : layout.slotHeight * (layout.rowCount - 1) + layout.gap * 4,
             zIndex: 0,
+            width: layout.portraitBleedX
+              ? `calc(100% + ${layout.portraitBleedX * 2}px)`
+              : "100%",
+            height: "100%",
+            padding: layout.portraitPadding,
+            marginLeft: layout.portraitBleedX
+              ? `-${layout.portraitBleedX}px`
+              : 0,
+            marginRight: layout.portraitBleedX
+              ? `-${layout.portraitBleedX}px`
+              : 0,
+            overflow: "visible",
+            transform:
+              layout.portraitMode === "area" && layout.portraitOffsetX
+                ? `translateX(${layout.portraitOffsetX}px)`
+                : undefined,
           }}
         >
           <EquipmentPaperdollPortrait
             world={world}
             equipment={equipment}
             equipmentSignature={equipmentSignature}
-            compact={isMobile}
+            compact={isMobile || layoutVariant === "bank"}
+            layoutVariant={layoutVariant}
+            isVisible={isVisible}
             className="h-full w-full"
           />
         </div>
 
         {PAPERDOLL_PLACEMENTS.map((placement) =>
-          renderSlotCell(placement.key, isMobile, slotHeight, placement.area),
+          renderSlotCell(
+            placement.key,
+            isMobile,
+            layout.slotHeight,
+            placement.area,
+          ),
         )}
+
+        {layout.emptyAreas?.map((area) => (
+          <div key={area} style={{ gridArea: area }} />
+        ))}
       </div>
     );
   };
+
+  const resolvedFooterButtons = footerButtons ?? [
+    {
+      label: "Stats",
+      onClick: handleOpenStats,
+    },
+    {
+      label: "On Death",
+      onClick: handleOpenDeath,
+    },
+  ];
 
   return (
     <>
@@ -635,90 +762,108 @@ export const EquipmentPanel = React.memo(function EquipmentPanel({
         className="flex flex-col h-full overflow-hidden"
         style={{
           ...getPanelSurfaceStyle(theme, { emphasis: "normal" }),
-          padding: shouldUseMobileUI ? "3px" : "4px",
-          gap: shouldUseMobileUI ? "3px" : "4px",
+          padding:
+            layoutVariant === "bank"
+              ? shouldUseMobileUI
+                ? "2px"
+                : "0"
+              : shouldUseMobileUI
+                ? "3px"
+                : "4px",
+          gap:
+            layoutVariant === "bank"
+              ? shouldUseMobileUI
+                ? "4px"
+                : "8px"
+              : shouldUseMobileUI
+                ? "3px"
+                : "4px",
           border: "none",
           borderRadius: 0,
           boxShadow: "none",
         }}
       >
         <div
-          className="flex-1 relative overflow-hidden"
+          className="flex-1 relative"
           style={{
             ...getPanelInsetStyle(theme, {
               emphasis: "strong",
               radius: 4,
             }),
-            padding: shouldUseMobileUI ? 0 : "3px",
+            padding:
+              layoutVariant === "bank"
+                ? shouldUseMobileUI
+                  ? "4px"
+                  : "8px"
+                : shouldUseMobileUI
+                  ? 0
+                  : "3px",
             boxShadow:
               "inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -18px 26px rgba(0,0,0,0.18)",
+            display: "flex",
+            alignItems: "stretch",
+            justifyContent: "stretch",
+            overflow: "visible",
           }}
         >
           {renderEquipmentGrid(shouldUseMobileUI)}
         </div>
 
-        <div
-          className="grid grid-cols-2 gap-1.5 px-0.5"
-          style={{
-            minHeight: shouldUseMobileUI ? 24 : 28,
-          }}
-        >
-          <button
-            type="button"
-            onClick={handleOpenStats}
-            className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 focus-visible:outline-none"
+        {resolvedFooterButtons.length > 0 && (
+          <div
+            className="grid gap-1.5 px-0.5"
             style={{
-              height: shouldUseMobileUI ? 24 : 28,
-              ...getInteractiveTileStyle(theme, { radius: 2 }),
-              fontSize: shouldUseMobileUI ? "9px" : "10px",
-              fontWeight: 600,
-              letterSpacing: "0.04em",
-              color: theme.colors.accent.primary,
-              textTransform: "uppercase",
+              gridTemplateColumns: `repeat(${resolvedFooterButtons.length}, minmax(0, 1fr))`,
+              minHeight: shouldUseMobileUI ? 24 : 28,
             }}
           >
-            Stats
-          </button>
-          <button
-            type="button"
-            onClick={handleOpenDeath}
-            className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 focus-visible:outline-none"
-            style={{
-              height: shouldUseMobileUI ? 24 : 28,
-              ...getInteractiveTileStyle(theme, { radius: 2 }),
-              fontSize: shouldUseMobileUI ? "9px" : "10px",
-              fontWeight: 600,
-              letterSpacing: "0.04em",
-              color: theme.colors.accent.primary,
-              textTransform: "uppercase",
-            }}
-          >
-            On Death
-          </button>
-        </div>
+            {resolvedFooterButtons.map((button) => (
+              <button
+                key={button.label}
+                type="button"
+                onClick={button.onClick}
+                disabled={button.disabled}
+                className="flex items-center justify-center transition-all duration-150 hover:scale-[1.02] active:scale-95 focus-visible:outline-none disabled:opacity-40"
+                style={{
+                  height: shouldUseMobileUI ? 24 : 28,
+                  ...getInteractiveTileStyle(theme, { radius: 2 }),
+                  fontSize: shouldUseMobileUI ? "9px" : "10px",
+                  fontWeight: 600,
+                  letterSpacing: "0.04em",
+                  color: theme.colors.accent.primary,
+                  textTransform: "uppercase",
+                }}
+              >
+                {button.label}
+              </button>
+            ))}
+          </div>
+        )}
 
-        <div
-          className="flex justify-center gap-3"
-          style={{
-            ...getPanelInsetStyle(theme, {
-              emphasis: "normal",
-              radius: 4,
-            }),
-            padding: shouldUseMobileUI ? "2px 6px" : "4px 8px",
-            fontSize: shouldUseMobileUI ? "8px" : "10px",
-            lineHeight: 1,
-          }}
-        >
-          <span style={{ color: theme.colors.status.hp }}>
-            {totalBonuses.attack}
-          </span>
-          <span style={{ color: theme.colors.status.energy }}>
-            {totalBonuses.defense}
-          </span>
-          <span style={{ color: theme.colors.status.prayer }}>
-            {totalBonuses.strength}
-          </span>
-        </div>
+        {showBonuses && (
+          <div
+            className="flex justify-center gap-3"
+            style={{
+              ...getPanelInsetStyle(theme, {
+                emphasis: "normal",
+                radius: 4,
+              }),
+              padding: shouldUseMobileUI ? "2px 6px" : "4px 8px",
+              fontSize: shouldUseMobileUI ? "8px" : "10px",
+              lineHeight: 1,
+            }}
+          >
+            <span style={{ color: theme.colors.status.hp }}>
+              {totalBonuses.attack}
+            </span>
+            <span style={{ color: theme.colors.status.energy }}>
+              {totalBonuses.defense}
+            </span>
+            <span style={{ color: theme.colors.status.prayer }}>
+              {totalBonuses.strength}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Enhanced hover tooltip - rendered via portal */}

--- a/packages/client/src/game/panels/InventoryPanel.tsx
+++ b/packages/client/src/game/panels/InventoryPanel.tsx
@@ -26,6 +26,12 @@ import {
   CursorTooltip,
 } from "@/ui";
 import {
+  getTooltipBodyStyle,
+  getTooltipDividerStyle,
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
+import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
@@ -171,6 +177,7 @@ const DraggableInventorySlot = memo(function DraggableInventorySlot({
   onEmbeddedContextMenu,
 }: DraggableItemProps) {
   const theme = useThemeStore((s) => s.theme);
+  const [isHovered, setIsHovered] = useState(false);
   // In embedded mode, disable drag-drop
   const isDragDisabled = !!embeddedMode || !item;
 
@@ -231,13 +238,13 @@ const DraggableInventorySlot = memo(function DraggableInventorySlot({
     () =>
       getInteractiveTileStyle(theme, {
         active: isSourceItem,
-        hovered: !isEmpty,
+        hovered: isHovered && !isEmpty,
         dragging: isDragging,
         dropTarget: isOver,
         radius: 4,
         accentColor: theme.colors.accent.secondary,
       }),
-    [theme, isSourceItem, isEmpty, isDragging, isOver],
+    [theme, isSourceItem, isHovered, isEmpty, isDragging, isOver],
   );
 
   return (
@@ -291,6 +298,7 @@ const DraggableInventorySlot = memo(function DraggableInventorySlot({
         }
       }}
       onMouseEnter={(e) => {
+        setIsHovered(true);
         // OSRS-style: show "Use X → Y" tooltip when hovering valid target
         if (isValidTarget && item && onTargetHover) {
           onTargetHover(item, { x: e.clientX, y: e.clientY });
@@ -300,6 +308,7 @@ const DraggableInventorySlot = memo(function DraggableInventorySlot({
         }
       }}
       onMouseLeave={() => {
+        setIsHovered(false);
         if (onTargetHoverEnd) {
           onTargetHoverEnd();
         }
@@ -697,17 +706,15 @@ function renderItemHoverTooltip(
       {/* Item name */}
       <div
         style={{
-          color: theme.colors.accent.secondary,
-          fontWeight: "bold",
+          ...getTooltipTitleStyle(theme),
           marginBottom: hasBonuses ? "6px" : "0",
-          fontSize: "13px",
         }}
       >
         {itemName}
         {itemHover.item.quantity > 1 && (
           <span
             style={{
-              color: theme.colors.text.muted,
+              ...getTooltipMetaStyle(theme),
               fontWeight: "normal",
             }}
           >
@@ -719,9 +726,9 @@ function renderItemHoverTooltip(
 
       {/* Bonuses (for equipment) */}
       {hasBonuses && (
-        <div style={{ fontSize: "11px" }}>
+        <div style={getTooltipDividerStyle(theme)}>
           {bonuses.attack !== undefined && bonuses.attack !== 0 && (
-            <div style={{ color: theme.colors.text.secondary }}>
+            <div style={getTooltipBodyStyle(theme)}>
               ⚔️ Attack:{" "}
               <span style={{ color: theme.colors.state.success }}>
                 +{bonuses.attack}
@@ -729,7 +736,7 @@ function renderItemHoverTooltip(
             </div>
           )}
           {bonuses.defense !== undefined && bonuses.defense !== 0 && (
-            <div style={{ color: theme.colors.text.secondary }}>
+            <div style={getTooltipBodyStyle(theme)}>
               🛡️ Defense:{" "}
               <span style={{ color: theme.colors.state.success }}>
                 +{bonuses.defense}
@@ -737,7 +744,7 @@ function renderItemHoverTooltip(
             </div>
           )}
           {bonuses.strength !== undefined && bonuses.strength !== 0 && (
-            <div style={{ color: theme.colors.text.secondary }}>
+            <div style={getTooltipBodyStyle(theme)}>
               💪 Strength:{" "}
               <span style={{ color: theme.colors.state.success }}>
                 +{bonuses.strength}

--- a/packages/client/src/game/panels/LootWindowPanel.tsx
+++ b/packages/client/src/game/panels/LootWindowPanel.tsx
@@ -7,7 +7,11 @@ import type {
 } from "@hyperscape/shared";
 import { EventType, generateTransactionId, getItem } from "@hyperscape/shared";
 import { ErrorBoundary } from "../../lib/ErrorBoundary";
-import { useThemeStore } from "@/ui";
+import { CursorTooltip, useThemeStore } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import {
   getInteractiveTileStyle,
   getPanelHeaderStyle,
@@ -42,6 +46,12 @@ function LootWindowPanelContent({
   const theme = useThemeStore((s) => s.theme);
   const closeButtonStyle = getShellControlButtonStyle(theme, "neutral");
   const [items, setItems] = useState<InventoryItem[]>(lootItems);
+  const [hoveredItem, setHoveredItem] = useState<{
+    item: InventoryItem;
+    displayName: string;
+    itemType: string;
+    position: { x: number; y: number };
+  } | null>(null);
 
   // Close confirmation state
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
@@ -516,12 +526,32 @@ function LootWindowPanelContent({
                   }),
                 }}
                 onClick={() => handleTakeItem(item, index)}
-                title={`Click to take ${displayName} (${item.quantity})`}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.borderColor = `${theme.colors.border.hover}80`;
+                  setHoveredItem({
+                    item,
+                    displayName,
+                    itemType,
+                    position: { x: e.clientX, y: e.clientY },
+                  });
+                }}
+                onMouseMove={(e) => {
+                  setHoveredItem((prev) =>
+                    prev?.item.id === item.id
+                      ? {
+                          item,
+                          displayName,
+                          itemType,
+                          position: { x: e.clientX, y: e.clientY },
+                        }
+                      : prev,
+                  );
                 }}
                 onMouseLeave={(e) => {
                   e.currentTarget.style.borderColor = `${theme.colors.border.default}30`;
+                  setHoveredItem((prev) =>
+                    prev?.item.id === item.id ? null : prev,
+                  );
                 }}
               >
                 <div className="text-center">
@@ -550,6 +580,39 @@ function LootWindowPanelContent({
             );
           })}
         </div>
+      )}
+
+      {hoveredItem && (
+        <CursorTooltip
+          visible={true}
+          position={hoveredItem.position}
+          estimatedSize={{ width: 220, height: 72 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "180px",
+            maxWidth: "260px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {hoveredItem.displayName}
+            {hoveredItem.item.quantity > 1
+              ? ` x${hoveredItem.item.quantity}`
+              : ""}
+          </div>
+          <div
+            style={{
+              ...getTooltipMetaStyle(theme),
+              marginTop: "4px",
+              textTransform: "capitalize",
+            }}
+          >
+            {hoveredItem.itemType} • Click to take
+          </div>
+        </CursorTooltip>
       )}
 
       {/* Instructions */}

--- a/packages/client/src/game/panels/PrayerPanel.tsx
+++ b/packages/client/src/game/panels/PrayerPanel.tsx
@@ -28,6 +28,14 @@ import {
   TOOLTIP_SIZE_ESTIMATES,
 } from "@/ui";
 import {
+  getTooltipBodyStyle,
+  getTooltipDividerStyle,
+  getTooltipMetaStyle,
+  getTooltipStatusStyle,
+  getTooltipTagStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
+import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
@@ -918,8 +926,8 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
               estimatedSize={{ width: 200, height: 100 }}
               style={{
                 zIndex: zIndex.tooltip,
-                border: `1px solid ${getCategoryColor(hoveredPrayer.category)}50`,
                 minWidth: 180,
+                maxWidth: 250,
               }}
             >
               {/* Header */}
@@ -937,19 +945,13 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
                 <div>
                   <div
                     style={{
+                      ...getTooltipTitleStyle(theme),
                       fontSize: 14,
-                      fontWeight: 700,
-                      color: getCategoryColor(hoveredPrayer.category),
                     }}
                   >
                     {hoveredPrayer.name}
                   </div>
-                  <div
-                    style={{
-                      fontSize: 10,
-                      color: theme.colors.text.muted,
-                    }}
-                  >
+                  <div style={getTooltipMetaStyle(theme)}>
                     Level {hoveredPrayer.level} Prayer
                   </div>
                 </div>
@@ -958,10 +960,8 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
               {/* Description */}
               <div
                 style={{
-                  fontSize: 11,
-                  color: theme.colors.text.secondary,
+                  ...getTooltipBodyStyle(theme),
                   marginBottom: 8,
-                  lineHeight: 1.4,
                 }}
               >
                 {hoveredPrayer.description}
@@ -970,14 +970,14 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
               {/* Drain rate */}
               <div
                 style={{
-                  fontSize: 10,
-                  color: theme.colors.text.muted,
+                  ...getTooltipDividerStyle(theme),
                   display: "flex",
                   justifyContent: "space-between",
+                  alignItems: "center",
                 }}
               >
-                <span>Drain rate:</span>
-                <span style={{ color: theme.colors.accent.secondary }}>
+                <span style={getTooltipMetaStyle(theme)}>Drain rate</span>
+                <span style={getTooltipTagStyle(theme)}>
                   {hoveredPrayer.drainRate} points/min
                 </span>
               </div>
@@ -986,13 +986,7 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
               {!isUnlocked && (
                 <div
                   style={{
-                    marginTop: 8,
-                    padding: "4px 8px",
-                    background: `${theme.colors.state.danger}26`,
-                    borderRadius: 4,
-                    fontSize: 10,
-                    color: theme.colors.state.danger,
-                    textAlign: "center",
+                    ...getTooltipStatusStyle(theme, "danger"),
                   }}
                 >
                   Requires level {hoveredPrayer.level} Prayer
@@ -1001,14 +995,7 @@ export function PrayerPanel({ stats, world }: PrayerPanelProps) {
               {hoveredPrayer.active && (
                 <div
                   style={{
-                    marginTop: 8,
-                    padding: "4px 8px",
-                    background: `${theme.colors.state.success}26`,
-                    borderRadius: 4,
-                    fontSize: 10,
-                    color: theme.colors.state.success,
-                    textAlign: "center",
-                    fontWeight: 600,
+                    ...getTooltipStatusStyle(theme, "success"),
                   }}
                 >
                   Currently Active

--- a/packages/client/src/game/panels/SkillsPanel.tsx
+++ b/packages/client/src/game/panels/SkillsPanel.tsx
@@ -11,6 +11,11 @@ import { createPortal } from "react-dom";
 import { useDraggable } from "@dnd-kit/core";
 import { CursorTooltip, useThemeStore, useMobileLayout } from "@/ui";
 import {
+  getTooltipMetaStyle,
+  getTooltipStatusStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
+import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
@@ -427,9 +432,8 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
                 <span style={{ fontSize: "14px" }}>{hoveredSkill.icon}</span>
                 <span
                   style={{
+                    ...getTooltipTitleStyle(theme),
                     fontSize: "11px",
-                    fontWeight: 600,
-                    color: theme.colors.text.accent,
                   }}
                 >
                   {hoveredSkill.label}
@@ -437,7 +441,7 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
                 <span
                   style={{
                     marginLeft: "auto",
-                    fontSize: "10px",
+                    ...getTooltipMetaStyle(theme),
                     fontWeight: 600,
                     color:
                       hoveredSkill.level >= 99
@@ -452,8 +456,7 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
               {/* XP Info */}
               <div
                 style={{
-                  fontSize: "9px",
-                  color: theme.colors.text.secondary,
+                  ...getTooltipMetaStyle(theme),
                   marginBottom: "2px",
                 }}
               >
@@ -461,8 +464,7 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
               </div>
               <div
                 style={{
-                  fontSize: "9px",
-                  color: theme.colors.text.muted,
+                  ...getTooltipMetaStyle(theme),
                   marginBottom: "4px",
                 }}
               >
@@ -472,7 +474,7 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
               </div>
 
               {/* Progress bar */}
-              {hoveredSkill.level < 99 && (
+              {hoveredSkill.level < 99 ? (
                 <div
                   style={{
                     height: "3px",
@@ -489,6 +491,10 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
                       borderRadius: theme.borderRadius.sm,
                     }}
                   />
+                </div>
+              ) : (
+                <div style={getTooltipStatusStyle(theme, "success")}>
+                  Max level reached
                 </div>
               )}
             </CursorTooltip>
@@ -508,8 +514,7 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
         >
           <div
             style={{
-              fontSize: "9px",
-              color: theme.colors.text.muted,
+              ...getTooltipMetaStyle(theme),
               textTransform: "uppercase",
               letterSpacing: "0.3px",
               marginBottom: "2px",
@@ -519,9 +524,8 @@ export function SkillsPanel({ stats }: SkillsPanelProps) {
           </div>
           <div
             style={{
+              ...getTooltipTitleStyle(theme),
               fontSize: "11px",
-              fontWeight: 600,
-              color: theme.colors.text.accent,
             }}
           >
             {totalXP.toLocaleString()}

--- a/packages/client/src/game/panels/SpellsPanel.tsx
+++ b/packages/client/src/game/panels/SpellsPanel.tsx
@@ -17,6 +17,14 @@ import React, {
 import { createPortal } from "react-dom";
 import { useThemeStore, useMobileLayout, CursorTooltip } from "@/ui";
 import {
+  getTooltipBodyStyle,
+  getTooltipDividerStyle,
+  getTooltipMetaStyle,
+  getTooltipStatusStyle,
+  getTooltipTagStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
+import {
   getInteractiveTileStyle,
   getPanelInsetStyle,
   getPanelSurfaceStyle,
@@ -576,27 +584,21 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
       <CursorTooltip
         visible={!!hoveredSpell && !contextMenu.visible}
         position={mousePos}
+        estimatedSize={{ width: 220, height: 140 }}
+        style={{
+          zIndex: zIndex.tooltip,
+          minWidth: 190,
+          maxWidth: 260,
+        }}
       >
         {hoveredSpell && (
-          <div
-            style={{
-              background:
-                theme.name === "hyperscape"
-                  ? "linear-gradient(180deg, rgba(54, 44, 28, 0.96) 0%, rgba(22, 18, 12, 0.96) 100%)"
-                  : `linear-gradient(180deg, ${theme.colors.background.secondary} 0%, ${theme.colors.background.primary} 100%)`,
-              border: `1px solid ${getElementColor(hoveredSpell.element)}50`,
-              borderRadius: theme.borderRadius.md,
-              padding: "12px 14px",
-              boxShadow: `${theme.shadows.lg}, inset 0 1px 0 rgba(255,255,255,0.04)`,
-              minWidth: 200,
-            }}
-          >
+          <>
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
                 gap: 10,
-                marginBottom: 8,
+                marginBottom: 10,
               }}
             >
               <span style={{ fontSize: 28 }}>
@@ -605,14 +607,13 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
               <div>
                 <div
                   style={{
+                    ...getTooltipTitleStyle(theme),
                     fontSize: 15,
-                    fontWeight: 700,
-                    color: getElementColor(hoveredSpell.element),
                   }}
                 >
                   {hoveredSpell.name}
                 </div>
-                <div style={{ fontSize: 11, color: theme.colors.text.muted }}>
+                <div style={getTooltipMetaStyle(theme)}>
                   Level {hoveredSpell.level} Magic
                 </div>
               </div>
@@ -623,19 +624,23 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
                 display: "grid",
                 gridTemplateColumns: "1fr 1fr",
                 gap: 6,
-                fontSize: 11,
-                marginBottom: 10,
+                ...getTooltipBodyStyle(theme),
+                marginBottom: 8,
               }}
             >
-              <div style={{ color: theme.colors.text.muted }}>
+              <div>
                 Max Hit:{" "}
-                <span style={{ color: theme.colors.state.danger }}>
+                <span
+                  style={{ fontWeight: 600, color: theme.colors.text.primary }}
+                >
                   {hoveredSpell.baseMaxHit}
                 </span>
               </div>
-              <div style={{ color: theme.colors.text.muted }}>
+              <div>
                 XP:{" "}
-                <span style={{ color: theme.colors.state.success }}>
+                <span
+                  style={{ fontWeight: 600, color: theme.colors.text.primary }}
+                >
                   {hoveredSpell.baseXp}
                 </span>
               </div>
@@ -643,23 +648,22 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
 
             <div
               style={{
-                fontSize: 10,
-                color: theme.colors.text.muted,
+                ...getTooltipDividerStyle(theme),
                 marginBottom: 8,
               }}
             >
-              <div style={{ marginBottom: 4, fontWeight: 600 }}>Rune Cost:</div>
+              <div
+                style={{
+                  ...getTooltipMetaStyle(theme),
+                  marginBottom: 4,
+                  fontWeight: 600,
+                }}
+              >
+                Rune Cost
+              </div>
               <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                 {hoveredSpell.runes.map((rune, idx) => (
-                  <span
-                    key={idx}
-                    style={{
-                      background: theme.colors.slot.filled,
-                      padding: "2px 6px",
-                      borderRadius: theme.borderRadius.sm,
-                      color: theme.colors.text.secondary,
-                    }}
-                  >
+                  <span key={idx} style={getTooltipTagStyle(theme)}>
                     {rune.quantity}x{" "}
                     {rune.runeId.replace("_rune", "").replace("_", " ")}
                   </span>
@@ -670,12 +674,7 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
             {playerMagicLevel < hoveredSpell.level && (
               <div
                 style={{
-                  padding: "5px 10px",
-                  background: `${theme.colors.state.danger}26`,
-                  borderRadius: theme.borderRadius.sm,
-                  fontSize: 11,
-                  color: theme.colors.state.danger,
-                  textAlign: "center",
+                  ...getTooltipStatusStyle(theme, "danger"),
                 }}
               >
                 Requires level {hoveredSpell.level} Magic
@@ -684,19 +683,13 @@ export function SpellsPanel({ stats, world }: SpellsPanelProps) {
             {hoveredSpell.isSelected && (
               <div
                 style={{
-                  padding: "5px 10px",
-                  background: `${theme.colors.state.success}26`,
-                  borderRadius: theme.borderRadius.sm,
-                  fontSize: 11,
-                  color: theme.colors.state.success,
-                  textAlign: "center",
-                  fontWeight: 600,
+                  ...getTooltipStatusStyle(theme, "success"),
                 }}
               >
                 Currently Selected for Autocast
               </div>
             )}
-          </div>
+          </>
         )}
       </CursorTooltip>
 

--- a/packages/client/src/game/panels/StorePanel.tsx
+++ b/packages/client/src/game/panels/StorePanel.tsx
@@ -20,7 +20,16 @@ import { createPortal } from "react-dom";
 import type { ClientWorld, InventorySlotItem } from "../../types";
 import { COLORS } from "../../constants";
 import { InventoryPanel } from "./InventoryPanel";
-import { useWindowStore, useThemeStore, useMobileLayout } from "@/ui";
+import {
+  CursorTooltip,
+  useWindowStore,
+  useThemeStore,
+  useMobileLayout,
+} from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import {
   getContextMenuItemStyle,
   getContextMenuSurfaceStyle,
@@ -374,6 +383,13 @@ export function StorePanel({
     type: "store",
     itemName: "",
   });
+  const [hoveredStoreItemId, setHoveredStoreItemId] = useState<string | null>(
+    null,
+  );
+  const [hoveredStoreTooltip, setHoveredStoreTooltip] = useState<{
+    item: StoreItem;
+    position: { x: number; y: number };
+  } | null>(null);
 
   // NOTE: Distance validation is handled server-side (InteractionSessionManager)
   // The server sends storeClose packets when the player moves too far away.
@@ -531,26 +547,37 @@ export function StorePanel({
                     width: `${responsiveSlotSize}px`,
                     height: `${responsiveSlotSize}px`,
                     ...getInteractiveTileStyle(theme, {
+                      hovered: hoveredStoreItemId === item.id,
                       radius: theme.borderRadius.md,
                       accentColor: theme.colors.accent.primary,
                     }),
                   }}
-                  title={`${item.name} - ${item.price} gp${item.stockQuantity !== -1 ? ` (${item.stockQuantity} in stock)` : ""}`}
                   onClick={() => handleBuy(item.itemId, 1)}
                   onContextMenu={(e) => openStoreContextMenu(e, item)}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.background =
-                      theme.name === "hyperscape"
-                        ? "linear-gradient(180deg, rgba(255, 255, 255, 0.065) 0%, rgba(190, 165, 123, 0.12) 20%, rgba(25, 29, 35, 0.98) 100%)"
-                        : `${theme.colors.accent.primary}20`;
-                    e.currentTarget.style.borderColor = `${theme.colors.accent.primary}66`;
+                    setHoveredStoreItemId(item.id);
+                    setHoveredStoreTooltip({
+                      item,
+                      position: { x: e.clientX, y: e.clientY },
+                    });
                   }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background =
-                      theme.name === "hyperscape"
-                        ? "linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.012) 18%, rgba(22, 26, 31, 0.99) 100%)"
-                        : `${theme.colors.accent.primary}10`;
-                    e.currentTarget.style.borderColor = `${theme.colors.accent.primary}40`;
+                  onMouseMove={(e) => {
+                    setHoveredStoreTooltip((prev) =>
+                      prev?.item.id === item.id
+                        ? {
+                            item,
+                            position: { x: e.clientX, y: e.clientY },
+                          }
+                        : prev,
+                    );
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredStoreItemId((prev) =>
+                      prev === item.id ? null : prev,
+                    );
+                    setHoveredStoreTooltip((prev) =>
+                      prev?.item.id === item.id ? null : prev,
+                    );
                   }}
                 >
                   <span className="select-none">
@@ -585,6 +612,38 @@ export function StorePanel({
               ))}
             </div>
           </div>
+
+          {hoveredStoreTooltip && !contextMenu.visible && (
+            <CursorTooltip
+              visible={true}
+              position={hoveredStoreTooltip.position}
+              estimatedSize={{ width: 220, height: 70 }}
+              style={{
+                zIndex: theme.zIndex.tooltip,
+                minWidth: "180px",
+                maxWidth: "260px",
+              }}
+            >
+              <div
+                style={{
+                  ...getTooltipTitleStyle(theme),
+                }}
+              >
+                {hoveredStoreTooltip.item.name}
+              </div>
+              <div
+                style={{
+                  ...getTooltipMetaStyle(theme),
+                  marginTop: "4px",
+                }}
+              >
+                {hoveredStoreTooltip.item.price} gp
+                {hoveredStoreTooltip.item.stockQuantity !== -1
+                  ? ` • ${hoveredStoreTooltip.item.stockQuantity} in stock`
+                  : " • Unlimited stock"}
+              </div>
+            </CursorTooltip>
+          )}
 
           {/* Footer */}
           <div

--- a/packages/client/src/game/panels/TradePanel/components/InventoryItem.tsx
+++ b/packages/client/src/game/panels/TradePanel/components/InventoryItem.tsx
@@ -6,7 +6,13 @@
  * Right-click: show context menu
  */
 
+import { useState } from "react";
 import { getItem } from "@hyperscape/shared";
+import { CursorTooltip } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { ItemIcon } from "@/ui/components/ItemIcon";
 import { formatQuantity } from "../utils";
 import type { InventoryItemProps } from "../types";
@@ -19,48 +25,87 @@ export function InventoryItem({
 }: InventoryItemProps) {
   const itemData = getItem(item.itemId);
   const qtyDisplay = item.quantity > 1 ? formatQuantity(item.quantity) : null;
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
 
   return (
-    <div
-      className="relative flex items-center justify-center hover:brightness-110"
-      style={{
-        width: "36px",
-        height: "36px",
-        background: theme.colors.background.panelSecondary,
-        border: `1px solid ${theme.colors.border.default}`,
-        borderRadius: "4px",
-        cursor: "pointer",
-        transition: "filter 0.1s",
-      }}
-      title={`${itemData?.name || item.itemId} (Left-click: Offer 1, Right-click: Options)`}
-      onClick={(e) => {
-        e.preventDefault();
-        onLeftClick();
-      }}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        onRightClick(e);
-      }}
-    >
-      {/* Render item icon */}
-      <ItemIcon
-        itemId={item.itemId}
-        size={32}
-        style={{ filter: "drop-shadow(0 2px 2px rgba(0, 0, 0, 0.6))" }}
-      />
-      {qtyDisplay && (
-        <span
-          className="absolute bottom-0 right-0.5 text-xs font-bold"
+    <>
+      <div
+        className="relative flex items-center justify-center hover:brightness-110"
+        style={{
+          width: "36px",
+          height: "36px",
+          background: theme.colors.background.panelSecondary,
+          border: `1px solid ${theme.colors.border.default}`,
+          borderRadius: "4px",
+          cursor: "pointer",
+          transition: "filter 0.1s",
+        }}
+        onClick={(e) => {
+          e.preventDefault();
+          onLeftClick();
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onRightClick(e);
+        }}
+        onMouseEnter={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseMove={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseLeave={() => setHoverState(null)}
+      >
+        {/* Render item icon */}
+        <ItemIcon
+          itemId={item.itemId}
+          size={32}
+          style={{ filter: "drop-shadow(0 2px 2px rgba(0, 0, 0, 0.6))" }}
+        />
+        {qtyDisplay && (
+          <span
+            className="absolute bottom-0 right-0.5 text-xs font-bold"
+            style={{
+              color: qtyDisplay.color,
+              textShadow:
+                "1px 1px 0 #000, -1px 1px 0 #000, 1px -1px 0 #000, -1px -1px 0 #000",
+              fontSize: "10px",
+            }}
+          >
+            {qtyDisplay.text}
+          </span>
+        )}
+      </div>
+
+      {hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 180, height: 52 }}
           style={{
-            color: qtyDisplay.color,
-            textShadow:
-              "1px 1px 0 #000, -1px 1px 0 #000, 1px -1px 0 #000, -1px -1px 0 #000",
-            fontSize: "10px",
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "150px",
           }}
         >
-          {qtyDisplay.text}
-        </span>
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {itemData?.name || item.itemId}
+          </div>
+          <div
+            style={{
+              ...getTooltipMetaStyle(theme),
+              marginTop: "4px",
+            }}
+          >
+            Left-click: Offer 1. Right-click: Options.
+          </div>
+        </CursorTooltip>
       )}
-    </div>
+    </>
   );
 }

--- a/packages/client/src/game/panels/TradePanel/components/TradeSlot.tsx
+++ b/packages/client/src/game/panels/TradePanel/components/TradeSlot.tsx
@@ -5,7 +5,13 @@
  * Shows red flashing exclamation when item was recently removed (anti-scam).
  */
 
+import { useState } from "react";
 import { getItem } from "@hyperscape/shared";
+import { CursorTooltip } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { ItemIcon } from "@/ui/components/ItemIcon";
 import { getInteractiveTileStyle } from "@/ui/theme/themes";
 import { formatQuantity } from "../utils";
@@ -22,65 +28,104 @@ export function TradeSlot({
   const itemData = item ? getItem(item.itemId) : null;
   const quantity = item?.quantity ?? 0;
   const qtyDisplay = quantity > 1 ? formatQuantity(quantity) : null;
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
 
   return (
-    <div
-      className="relative flex items-center justify-center"
-      style={{
-        width: "36px",
-        height: "36px",
-        ...getInteractiveTileStyle(theme, {
-          radius: 4,
-          accentColor: isRemoved
-            ? theme.colors.state.danger
-            : theme.colors.accent.primary,
-          active: Boolean(item),
-        }),
-        cursor: item && side === "my" ? "pointer" : "default",
-        transition: "background 0.15s, border-color 0.15s",
-        animation: isRemoved ? "pulse 0.5s ease-in-out infinite" : "none",
-      }}
-      onClick={() => {
-        if (item && side === "my" && onRemove) {
-          onRemove();
-        }
-      }}
-      title={itemData?.name || ""}
-    >
-      {/* Red flashing exclamation for removed items */}
-      {isRemoved && !item && (
-        <span
+    <>
+      <div
+        className="relative flex items-center justify-center"
+        style={{
+          width: "36px",
+          height: "36px",
+          ...getInteractiveTileStyle(theme, {
+            radius: 4,
+            accentColor: isRemoved
+              ? theme.colors.state.danger
+              : theme.colors.accent.primary,
+            active: Boolean(item),
+          }),
+          cursor: item && side === "my" ? "pointer" : "default",
+          transition: "background 0.15s, border-color 0.15s",
+          animation: isRemoved ? "pulse 0.5s ease-in-out infinite" : "none",
+        }}
+        onClick={() => {
+          if (item && side === "my" && onRemove) {
+            onRemove();
+          }
+        }}
+        onMouseEnter={(e) => {
+          if (itemData?.name) {
+            setHoverState({ x: e.clientX, y: e.clientY });
+          }
+        }}
+        onMouseMove={(e) => {
+          if (itemData?.name) {
+            setHoverState({ x: e.clientX, y: e.clientY });
+          }
+        }}
+        onMouseLeave={() => setHoverState(null)}
+      >
+        {/* Red flashing exclamation for removed items */}
+        {isRemoved && !item && (
+          <span
+            style={{
+              fontSize: "24px",
+              color: "#ef4444",
+              fontWeight: "bold",
+              textShadow: "0 0 8px rgba(239, 68, 68, 0.8)",
+            }}
+          >
+            !
+          </span>
+        )}
+        {/* Render item icon */}
+        {item && (
+          <ItemIcon
+            itemId={item.itemId}
+            size={32}
+            style={{ filter: "drop-shadow(0 2px 2px rgba(0, 0, 0, 0.6))" }}
+          />
+        )}
+        {qtyDisplay && (
+          <span
+            className="absolute bottom-0 right-0.5 text-xs font-bold"
+            style={{
+              color: qtyDisplay.color,
+              textShadow:
+                "1px 1px 0 #000, -1px 1px 0 #000, 1px -1px 0 #000, -1px -1px 0 #000",
+              fontSize: "10px",
+            }}
+          >
+            {qtyDisplay.text}
+          </span>
+        )}
+      </div>
+
+      {itemData?.name && hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 150, height: 48 }}
           style={{
-            fontSize: "24px",
-            color: "#ef4444",
-            fontWeight: "bold",
-            textShadow: "0 0 8px rgba(239, 68, 68, 0.8)",
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "120px",
           }}
         >
-          !
-        </span>
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {itemData.name}
+            {quantity > 1 ? ` x${quantity}` : ""}
+          </div>
+          <div style={{ ...getTooltipMetaStyle(theme), marginTop: "4px" }}>
+            {side === "my" ? "Click to remove from trade" : "Offered in trade"}
+          </div>
+        </CursorTooltip>
       )}
-      {/* Render item icon */}
-      {item && (
-        <ItemIcon
-          itemId={item.itemId}
-          size={32}
-          style={{ filter: "drop-shadow(0 2px 2px rgba(0, 0, 0, 0.6))" }}
-        />
-      )}
-      {qtyDisplay && (
-        <span
-          className="absolute bottom-0 right-0.5 text-xs font-bold"
-          style={{
-            color: qtyDisplay.color,
-            textShadow:
-              "1px 1px 0 #000, -1px 1px 0 #000, 1px -1px 0 #000, -1px -1px 0 #000",
-            fontSize: "10px",
-          }}
-        >
-          {qtyDisplay.text}
-        </span>
-      )}
-    </div>
+    </>
   );
 }

--- a/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentPaperdollPortrait.tsx
@@ -27,6 +27,8 @@ interface EquipmentPaperdollPortraitProps {
   className?: string;
   equipmentSignature?: string;
   compact?: boolean;
+  layoutVariant?: "default" | "bank";
+  isVisible?: boolean;
 }
 
 interface PreviewAvatarScene {
@@ -142,6 +144,8 @@ function framePortraitAvatar(
   avatarRoot: THREE.Object3D,
   camera: THREE.PerspectiveCamera,
   zoomMultiplier = 1.0,
+  fitDistanceMultiplier = 1.0,
+  centerBiasX = 0,
   baseStateRef?: React.MutableRefObject<{
     camY: number;
     lookY: number;
@@ -151,7 +155,8 @@ function framePortraitAvatar(
 ) {
   if (baseStateRef?.current) {
     const { camY, lookY, distance, center } = baseStateRef.current;
-    const currentDistance = distance / Math.max(0.1, zoomMultiplier);
+    const currentDistance =
+      (distance * fitDistanceMultiplier) / Math.max(0.1, zoomMultiplier);
     camera.position.set(center.x, camY, -currentDistance);
     camera.lookAt(center.x, lookY, center.z);
     return;
@@ -170,9 +175,16 @@ function framePortraitAvatar(
   const center = box.getCenter(new THREE.Vector3());
   const height = Math.max(size.y, 1.6);
   const width = Math.max(size.x, 0.7);
+  center.x += width * centerBiasX;
+  const verticalFov = THREE.MathUtils.degToRad(camera.fov);
+  const effectiveAspect = Math.max(camera.aspect, 0.25);
+  const horizontalFov =
+    2 * Math.atan(Math.tan(verticalFov / 2) * effectiveAspect);
+  const verticalDistance = (height * 0.5) / Math.tan(verticalFov / 2);
+  const horizontalDistance = (width * 0.5) / Math.tan(horizontalFov / 2);
 
-  // Zoom out enough so the full avatar fits within the portrait container
-  const distance = Math.max(3.2, height * 2.1, width * 1.6);
+  // Add a little breathing room so narrow portrait panels do not clip shoulders or weapons.
+  const distance = Math.max(3.2, verticalDistance, horizontalDistance) * 1.22;
 
   // Look slightly higher to push the avatar down in the viewport
   const lookY = center.y + height * 0.02;
@@ -184,7 +196,8 @@ function framePortraitAvatar(
     baseStateRef.current = { camY, lookY, distance, center: center.clone() };
   }
 
-  const currentDistance = distance / Math.max(0.1, zoomMultiplier);
+  const currentDistance =
+    (distance * fitDistanceMultiplier) / Math.max(0.1, zoomMultiplier);
 
   camera.position.set(center.x, camY, -currentDistance);
   camera.lookAt(center.x, lookY, center.z);
@@ -414,6 +427,8 @@ export const EquipmentPaperdollPortrait = React.memo(
     className = "",
     equipmentSignature = "",
     compact = false,
+    layoutVariant = "default",
+    isVisible = true,
   }: EquipmentPaperdollPortraitProps) {
     const theme = useThemeStore((s) => s.theme);
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -448,9 +463,11 @@ export const EquipmentPaperdollPortrait = React.memo(
 
     const signature = useMemo(
       () =>
-        `${avatarUrl ?? "no-avatar"}|${equipmentSignature}|${compact ? "compact" : "full"}`,
-      [avatarUrl, compact, equipmentSignature],
+        `${avatarUrl ?? "no-avatar"}|${equipmentSignature}|${compact ? "compact" : "full"}|${layoutVariant}`,
+      [avatarUrl, compact, equipmentSignature, layoutVariant],
     );
+    const fitDistanceMultiplier = layoutVariant === "bank" ? 1 : 1.03;
+    const centerBiasX = 0;
 
     const clearPreviewAvatar = () => {
       clearPreviewVisuals(previewVisualsRef.current);
@@ -485,6 +502,7 @@ export const EquipmentPaperdollPortrait = React.memo(
 
       let cancelled = false;
       let resizeObserver: ResizeObserver | null = null;
+      let resizeHandler: (() => void) | null = null;
 
       createAvatarPreviewViewport({
         container,
@@ -499,6 +517,23 @@ export const EquipmentPaperdollPortrait = React.memo(
           }
 
           viewportRef.current = viewport;
+          const handleViewportResize = () => {
+            viewport.resize();
+
+            if (avatarSceneRef.current) {
+              baseCameraStateRef.current = null;
+              framePortraitAvatar(
+                avatarSceneRef.current,
+                viewport.camera,
+                currentZoomRef.current,
+                fitDistanceMultiplier,
+                centerBiasX,
+                baseCameraStateRef,
+              );
+            }
+          };
+          resizeHandler = handleViewportResize;
+
           viewport.start((delta) => {
             avatarNodeRef.current?.instance?.update(delta);
 
@@ -520,6 +555,8 @@ export const EquipmentPaperdollPortrait = React.memo(
                   avatarSceneRef.current,
                   viewport.camera,
                   currentZoomRef.current,
+                  fitDistanceMultiplier,
+                  centerBiasX,
                   baseCameraStateRef,
                 );
               }
@@ -528,10 +565,10 @@ export const EquipmentPaperdollPortrait = React.memo(
           setRendererReady(true);
 
           if (typeof ResizeObserver !== "undefined") {
-            resizeObserver = new ResizeObserver(() => viewport.resize());
+            resizeObserver = new ResizeObserver(handleViewportResize);
             resizeObserver.observe(container);
           } else {
-            window.addEventListener("resize", viewport.resize);
+            window.addEventListener("resize", handleViewportResize);
           }
         })
         .catch((error) => {
@@ -548,8 +585,8 @@ export const EquipmentPaperdollPortrait = React.memo(
       return () => {
         cancelled = true;
         resizeObserver?.disconnect();
-        if (viewportRef.current) {
-          window.removeEventListener("resize", viewportRef.current.resize);
+        if (resizeHandler) {
+          window.removeEventListener("resize", resizeHandler);
         }
         clearPreviewAvatar();
         viewportRef.current?.dispose();
@@ -685,6 +722,8 @@ export const EquipmentPaperdollPortrait = React.memo(
             avatarScene,
             viewport.camera,
             currentZoomRef.current,
+            fitDistanceMultiplier,
+            centerBiasX,
             baseCameraStateRef,
           );
           setMode("live");
@@ -707,12 +746,29 @@ export const EquipmentPaperdollPortrait = React.memo(
       };
     }, [avatarUrl, equipment, rendererReady, signature, world]);
 
+    useEffect(() => {
+      if (!isVisible || !viewportRef.current || !avatarSceneRef.current) {
+        return;
+      }
+
+      viewportRef.current.resize();
+      baseCameraStateRef.current = null;
+      framePortraitAvatar(
+        avatarSceneRef.current,
+        viewportRef.current.camera,
+        currentZoomRef.current,
+        fitDistanceMultiplier,
+        centerBiasX,
+        baseCameraStateRef,
+      );
+    }, [centerBiasX, fitDistanceMultiplier, isVisible]);
+
     return (
       <div
         ref={containerRef}
         data-equipment-portrait="true"
         data-portrait-mode={mode}
-        className={`relative overflow-hidden touch-none select-none ${className}`}
+        className={`relative overflow-visible touch-none select-none ${className}`}
         onPointerDown={(e) => {
           isDraggingRef.current = true;
           lastMousePosRef.current = { x: e.clientX, y: e.clientY };

--- a/packages/client/src/game/panels/equipment/EquipmentTooltip.tsx
+++ b/packages/client/src/game/panels/equipment/EquipmentTooltip.tsx
@@ -1,7 +1,12 @@
-import React, { useRef } from "react";
-import { createPortal } from "react-dom";
-import { useTooltipSize } from "@/hooks/useTooltipSize";
+import React from "react";
 import { TOOLTIP_SIZE_ESTIMATES, useThemeStore, CursorTooltip } from "@/ui";
+import {
+  getTooltipBodyStyle,
+  getTooltipDividerStyle,
+  getTooltipMetaStyle,
+  getTooltipStatusStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 import { getItem } from "@hyperscape/shared";
 import type { Item } from "../../../types";
 
@@ -110,8 +115,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {/* Item name with rarity color */}
       <div
         style={{
-          color: rarityColor,
-          fontWeight: theme.typography.fontWeight.bold,
+          ...getTooltipTitleStyle(theme, rarityColor),
           fontSize: theme.typography.fontSize.sm,
           marginBottom: "2px",
         }}
@@ -122,8 +126,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {/* Item type and rarity */}
       <div
         style={{
-          fontSize: "10px",
-          color: theme.colors.text.muted,
+          ...getTooltipMetaStyle(theme),
           marginBottom: hasBonuses ? "8px" : "0",
           textTransform: "capitalize",
         }}
@@ -135,16 +138,15 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {hasDetailedBonuses ? (
         <div
           style={{
+            ...getTooltipDividerStyle(theme, rarityColor),
             fontSize: "11px",
-            borderTop: `1px solid ${theme.colors.border.default}40`,
-            paddingTop: "6px",
             marginBottom: "6px",
           }}
         >
           {hasPerStyleDefence && (
             <div
               style={{
-                color: theme.colors.text.secondary,
+                ...getTooltipBodyStyle(theme),
                 marginBottom: "3px",
               }}
             >
@@ -200,7 +202,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
             </div>
           )}
           {(hasMagicBonuses || hasRangedBonuses || hasPerStyleAttack) && (
-            <div style={{ color: theme.colors.text.secondary }}>
+            <div style={getTooltipBodyStyle(theme)}>
               <span style={{ color: theme.colors.text.muted }}>Attack: </span>
               {[
                 hasPerStyleAttack &&
@@ -257,9 +259,8 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       ) : hasBonuses ? (
         <div
           style={{
+            ...getTooltipDividerStyle(theme, rarityColor),
             fontSize: "11px",
-            borderTop: `1px solid ${theme.colors.border.default}40`,
-            paddingTop: "6px",
             marginBottom: "6px",
           }}
         >
@@ -268,7 +269,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
               style={{
                 display: "flex",
                 justifyContent: "space-between",
-                color: theme.colors.text.secondary,
+                ...getTooltipBodyStyle(theme),
                 marginBottom: "2px",
               }}
             >
@@ -284,7 +285,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
                 style={{
                   display: "flex",
                   justifyContent: "space-between",
-                  color: theme.colors.text.secondary,
+                  ...getTooltipBodyStyle(theme),
                   marginBottom: "2px",
                 }}
               >
@@ -300,7 +301,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
                 style={{
                   display: "flex",
                   justifyContent: "space-between",
-                  color: theme.colors.text.secondary,
+                  ...getTooltipBodyStyle(theme),
                 }}
               >
                 <span>Strength</span>
@@ -316,8 +317,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {itemData?.requirements?.level && (
         <div
           style={{
-            fontSize: "10px",
-            color: theme.colors.text.muted,
+            ...getTooltipMetaStyle(theme),
             marginBottom: "4px",
           }}
         >
@@ -327,8 +327,7 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {itemData?.requirements?.skills && !itemData?.requirements?.level && (
         <div
           style={{
-            fontSize: "10px",
-            color: theme.colors.text.muted,
+            ...getTooltipMetaStyle(theme),
             marginBottom: "4px",
           }}
         >
@@ -348,15 +347,11 @@ export const EquipmentTooltip = React.memo(function EquipmentTooltip({
       {/* Click hint */}
       <div
         style={{
-          fontSize: "9px",
-          color: theme.colors.text.muted,
-          marginTop: "6px",
-          paddingTop: "6px",
-          borderTop: `1px solid ${theme.colors.border.default}30`,
-          opacity: 0.7,
+          ...getTooltipStatusStyle(theme, "default"),
+          opacity: 0.85,
         }}
       >
-        Click to unequip • Right-click for options
+        Right-click for options
       </div>
     </CursorTooltip>
   );

--- a/packages/client/src/game/panels/inventory/CoinPouch.tsx
+++ b/packages/client/src/game/panels/inventory/CoinPouch.tsx
@@ -14,8 +14,12 @@
  * @see CoinAmountModal - Modal for withdrawal amount selection
  */
 
-import { useCallback } from "react";
-import { useThemeStore } from "@/ui";
+import { useCallback, useState } from "react";
+import { CursorTooltip, useThemeStore } from "@/ui";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "@/ui/core/tooltip/tooltipStyles";
 
 // ============================================================================
 // Props Interface
@@ -34,6 +38,9 @@ interface CoinPouchProps {
 
 export function CoinPouch({ coins, onWithdrawClick }: CoinPouchProps) {
   const theme = useThemeStore((s) => s.theme);
+  const [hoverState, setHoverState] = useState<{ x: number; y: number } | null>(
+    null,
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -46,39 +53,75 @@ export function CoinPouch({ coins, onWithdrawClick }: CoinPouchProps) {
   );
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="border rounded flex items-center justify-between py-1 px-2 cursor-pointer hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-yellow-500/50 transition-all"
-      style={{
-        background: `linear-gradient(180deg, ${theme.colors.background.panelSecondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
-        borderColor: theme.colors.border.default,
-        boxShadow:
-          "inset 0 1px 0 rgba(150, 130, 80, 0.2), 0 1px 2px rgba(0, 0, 0, 0.3)",
-      }}
-      onClick={onWithdrawClick}
-      onKeyDown={handleKeyDown}
-      aria-label={`Money pouch: ${coins.toLocaleString()} coins. Press Enter to withdraw.`}
-      title="Click to withdraw coins to inventory"
-    >
-      <div className="flex items-center gap-1.5">
-        <span className="text-base">💰</span>
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        className="border rounded flex items-center justify-between py-1 px-2 cursor-pointer hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-yellow-500/50 transition-all"
+        style={{
+          background: `linear-gradient(180deg, ${theme.colors.background.panelSecondary} 0%, ${theme.colors.background.panelPrimary} 100%)`,
+          borderColor: theme.colors.border.default,
+          boxShadow:
+            "inset 0 1px 0 rgba(150, 130, 80, 0.2), 0 1px 2px rgba(0, 0, 0, 0.3)",
+        }}
+        onClick={onWithdrawClick}
+        onKeyDown={handleKeyDown}
+        onMouseEnter={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseMove={(e) => {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }}
+        onMouseLeave={() => setHoverState(null)}
+        aria-label={`Money pouch: ${coins.toLocaleString()} coins. Press Enter to withdraw.`}
+      >
+        <div className="flex items-center gap-1.5">
+          <span className="text-base">💰</span>
+          <span
+            className="font-medium text-xs"
+            style={{ color: theme.colors.text.secondary }}
+          >
+            Coins
+          </span>
+        </div>
         <span
-          className="font-medium text-xs"
-          style={{ color: theme.colors.text.secondary }}
+          className="font-bold text-xs"
+          style={{
+            color: theme.colors.accent.secondary,
+            textShadow: "0 1px 2px rgba(0, 0, 0, 0.8)",
+          }}
         >
-          Coins
+          {coins.toLocaleString()}
         </span>
       </div>
-      <span
-        className="font-bold text-xs"
-        style={{
-          color: theme.colors.accent.secondary,
-          textShadow: "0 1px 2px rgba(0, 0, 0, 0.8)",
-        }}
-      >
-        {coins.toLocaleString()}
-      </span>
-    </div>
+
+      {hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 190, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "150px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            Money pouch: {coins.toLocaleString()} coins
+          </div>
+          <div
+            style={{
+              ...getTooltipMetaStyle(theme),
+              marginTop: "4px",
+            }}
+          >
+            Click to withdraw coins to inventory
+          </div>
+        </CursorTooltip>
+      )}
+    </>
   );
 }

--- a/packages/client/src/ui/components/ItemSlot.tsx
+++ b/packages/client/src/ui/components/ItemSlot.tsx
@@ -11,6 +11,7 @@ import React, {
   memo,
   useCallback,
   useRef,
+  useState,
   type CSSProperties,
   type ReactNode,
 } from "react";
@@ -18,6 +19,11 @@ import { useTheme } from "../stores/themeStore";
 import { useDraggable, useDroppable, useDndMonitor } from "../core/drag";
 import type { DragEndEvent } from "../core/drag";
 import { getSlotStyle } from "../theme/themes";
+import { CursorTooltip } from "../core/tooltip/CursorTooltip";
+import {
+  getTooltipMetaStyle,
+  getTooltipTitleStyle,
+} from "../core/tooltip/tooltipStyles";
 
 /** Item data interface */
 export interface ItemData {
@@ -96,6 +102,10 @@ export const ItemSlot = memo(function ItemSlot({
 }: ItemSlotProps): React.ReactElement {
   const theme = useTheme();
   const slotSize = size ?? theme.slot.size;
+  const [hoverState, setHoverState] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
 
   // Track the drop target ID for this slot
   const dropTargetId = `drop-${slotId}`;
@@ -255,9 +265,19 @@ export const ItemSlot = memo(function ItemSlot({
       style={containerStyle}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
+      onMouseEnter={(e) => {
+        if (item) {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }
+      }}
+      onMouseMove={(e) => {
+        if (item) {
+          setHoverState({ x: e.clientX, y: e.clientY });
+        }
+      }}
+      onMouseLeave={() => setHoverState(null)}
       {...dragAttributes}
       {...dragListeners}
-      title={item?.tooltip || item?.name}
     >
       {/* Item icon */}
       {item && (
@@ -290,6 +310,31 @@ export const ItemSlot = memo(function ItemSlot({
 
       {/* Noted indicator */}
       {item?.noted && <span style={notedStyle}>N</span>}
+
+      {item && hoverState && (
+        <CursorTooltip
+          visible={true}
+          position={hoverState}
+          estimatedSize={{ width: 150, height: 48 }}
+          style={{
+            zIndex: theme.zIndex.tooltip,
+            minWidth: "120px",
+            maxWidth: "220px",
+          }}
+        >
+          <div
+            style={{
+              ...getTooltipTitleStyle(theme),
+            }}
+          >
+            {item.tooltip || item.name}
+            {item.quantity && item.quantity > 1 ? ` x${item.quantity}` : ""}
+          </div>
+          <div style={{ ...getTooltipMetaStyle(theme), marginTop: "4px" }}>
+            Item slot
+          </div>
+        </CursorTooltip>
+      )}
     </div>
   );
 });

--- a/packages/client/src/ui/core/tooltip/tooltipStyles.ts
+++ b/packages/client/src/ui/core/tooltip/tooltipStyles.ts
@@ -1,0 +1,105 @@
+import type React from "react";
+import type { Theme } from "@/ui";
+
+type TooltipTone = "default" | "success" | "danger" | "warning";
+
+function getToneColors(theme: Theme, tone: TooltipTone) {
+  switch (tone) {
+    case "success":
+      return {
+        text: theme.colors.state.success,
+        background: `${theme.colors.state.success}22`,
+        border: `${theme.colors.state.success}4d`,
+      };
+    case "danger":
+      return {
+        text: theme.colors.state.danger,
+        background: `${theme.colors.state.danger}22`,
+        border: `${theme.colors.state.danger}4d`,
+      };
+    case "warning":
+      return {
+        text: theme.colors.state.warning,
+        background: `${theme.colors.state.warning}22`,
+        border: `${theme.colors.state.warning}4d`,
+      };
+    default:
+      return {
+        text: theme.colors.accent.secondary,
+        background: `${theme.colors.accent.secondary}18`,
+        border: `${theme.colors.accent.secondary}33`,
+      };
+  }
+}
+
+export function getTooltipTitleStyle(
+  theme: Theme,
+  accentColor = theme.colors.accent.secondary,
+): React.CSSProperties {
+  return {
+    color: accentColor,
+    fontWeight: 700,
+    fontSize: "13px",
+    lineHeight: 1.2,
+  };
+}
+
+export function getTooltipMetaStyle(theme: Theme): React.CSSProperties {
+  return {
+    color: theme.colors.text.muted,
+    fontSize: "11px",
+    lineHeight: 1.3,
+  };
+}
+
+export function getTooltipBodyStyle(theme: Theme): React.CSSProperties {
+  return {
+    color: theme.colors.text.secondary,
+    fontSize: "11px",
+    lineHeight: 1.45,
+  };
+}
+
+export function getTooltipDividerStyle(
+  theme: Theme,
+  accentColor = theme.colors.border.default,
+): React.CSSProperties {
+  return {
+    borderTop: `1px solid ${accentColor}33`,
+    marginTop: "8px",
+    paddingTop: "8px",
+  };
+}
+
+export function getTooltipTagStyle(theme: Theme): React.CSSProperties {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "2px 6px",
+    borderRadius: theme.borderRadius.sm,
+    background: `${theme.colors.background.tertiary}cc`,
+    border: `1px solid ${theme.colors.border.default}33`,
+    color: theme.colors.text.secondary,
+    fontSize: "10px",
+    lineHeight: 1.2,
+  };
+}
+
+export function getTooltipStatusStyle(
+  theme: Theme,
+  tone: TooltipTone,
+): React.CSSProperties {
+  const colors = getToneColors(theme, tone);
+  return {
+    marginTop: "8px",
+    padding: "5px 8px",
+    borderRadius: theme.borderRadius.sm,
+    background: colors.background,
+    border: `1px solid ${colors.border}`,
+    color: colors.text,
+    fontSize: "10px",
+    lineHeight: 1.3,
+    textAlign: "center",
+    fontWeight: 600,
+  };
+}


### PR DESCRIPTION
## Summary
- unify hover tooltip styling across inventory, equipment, spells, prayer, and popup panel paths
- clean up bank hover behavior and tab/slot treatment to better match the shared UI language
- rework the bank equipment sidebar to reuse the shared equipment panel path with a bank-specific layout

## Testing
- bunx tsc --noEmit --pretty false