### PR TITLE
fix(visuals): restore day/night cycle duration and AO dark floor

### DIFF
--- a/packages/shared/src/systems/shared/world/GPUMaterials.ts
+++ b/packages/shared/src/systems/shared/world/GPUMaterials.ts
@@ -1043,7 +1043,7 @@ export function createTreeDissolveMaterial(
 
   // --- Tuning ---
   const AO_POWER = 1.8;
-  const AO_DARK = 0.2;
+  const AO_DARK = 0.4;
   const SNOW_COLOR: [number, number, number] = [0.92, 0.95, 0.98];
   const SNOW_AO_TINT: [number, number, number] = [0.55, 0.6, 0.72];
   const SNOW_THRESHOLD = 0.15;

--- a/packages/shared/src/systems/shared/world/LightingConfig.ts
+++ b/packages/shared/src/systems/shared/world/LightingConfig.ts
@@ -16,7 +16,7 @@
 
 export const DAY_CYCLE = {
   /** Full day cycle duration in seconds */
-  DURATION_SEC: 80,
+  DURATION_SEC: 240,
 
   /** dayPhase thresholds — 0 = midnight, 0.25 = sunrise, 0.5 = noon, 0.75 = sunset */
   DAWN_START: 0.22,


### PR DESCRIPTION
Revert accidental changes: DAY_CYCLE.DURATION_SEC back to 240s (was 80s, 3x too fast) and AO_DARK floor in tree shader back to 0.4.

