### PR TITLE
fix(vegetation): fix mushroom disappearance and tree texture corruption on fresh GLTF load

### DIFF
--- a/packages/shared/src/systems/shared/world/GPUMaterials.ts
+++ b/packages/shared/src/systems/shared/world/GPUMaterials.ts
@@ -1053,11 +1053,12 @@ export function createTreeDissolveMaterial(
   const HL_BRIGHTEN = 0.08;
   const HL_RIM_POWER = 2.5;
   const HL_RIM_STRENGTH = 0.4;
-  const TOON_BRIGHT_EDGE = 0.7;
-  const TOON_MID_EDGE = 0.35;
-  const TOON_SHADOW_EDGE = 0.0;
-  const TOON_RIM_THRESHOLD = 0.3;
-  const TOON_RIM_BRIGHT = 1.3;
+  const DIFFUSE_RAMP_MIN = -0.15;
+  const DIFFUSE_RAMP_MAX = 0.6;
+  const TERMINATOR_BAND_STRENGTH = 0.3;
+  const RIM_EDGE_INNER = 0.15;
+  const RIM_EDGE_OUTER = 0.4;
+  const RIM_BRIGHT = 1.3;
   const NIGHT_MIN_BRIGHTNESS = NIGHT.BRIGHTNESS;
   /** Leaf back-scatter translucency (disabled = no extra warm glow when backlit). */
   const ENABLE_TREE_SSS = true;
@@ -1105,7 +1106,7 @@ export function createTreeDissolveMaterial(
   );
   material.fog = false;
 
-  // --- Output: toon lighting (bypass PBR, compute Lambert from scratch) ---
+  // --- Output: custom lighting (bypass PBR, compute diffuse ramp from scratch) ---
   const albedoMap = material.map;
   const matColor = vec3(material.color.r, material.color.g, material.color.b);
 
@@ -1125,7 +1126,7 @@ export function createTreeDissolveMaterial(
       : vec3(0, 1, 0);
     const aoRaw = vtxColor.y;
 
-    // ---- AO (used later as a single post-toon multiplier) ----
+    // ---- AO (post-diffuse multiplier) ----
     const aoFactor = pow(aoRaw, float(AO_POWER));
 
     // ---- Snow ----
@@ -1156,24 +1157,34 @@ export function createTreeDissolveMaterial(
     // ---- Sun shade on albedo ----
     baseAlbedo = applySunShade(baseAlbedo, uDayIntensity, vec3(uShadeColor));
 
-    // ---- 4-band Ghibli toon lighting (warm highlights -> cool shadows) ----
+    // ---- Smooth diffuse ramp (warm highlights -> cool shadows) ----
     const leafMask = vtxColor.x;
     const L = normalize(vec3(uSunDir));
     const N = normalize(normalWorldGeometry);
     const NdotL = dot(N, L);
 
-    const band0Color = mul(baseAlbedo, vec3(1.35, 1.08, 0.82));
-    const band1Color = baseAlbedo;
-    const band2Color = mul(baseAlbedo, vec3(0.65, 0.78, 0.82));
-    const band3Color = mul(baseAlbedo, vec3(0.38, 0.52, 0.68));
+    // Smooth 0..1 ramp across the terminator — no hard bands
+    const diffuseRamp = smoothstep(
+      float(DIFFUSE_RAMP_MIN),
+      float(DIFFUSE_RAMP_MAX),
+      NdotL,
+    );
 
-    const s0 = step(float(TOON_BRIGHT_EDGE), NdotL);
-    const s1 = step(float(TOON_MID_EDGE), NdotL);
-    const s2 = step(float(TOON_SHADOW_EDGE), NdotL);
+    // Warm highlight -> cool deep shadow
+    const litColor = mul(baseAlbedo, vec3(1.28, 1.06, 0.88));
+    const shadowColor = mul(baseAlbedo, vec3(0.42, 0.54, 0.72));
+    let rampColor: any = mix(shadowColor, litColor, diffuseRamp);
 
-    const toonStep0 = mix(band3Color, band2Color, s2);
-    const toonStep1 = mix(toonStep0, band1Color, s1);
-    const toonColor = mix(toonStep1, band0Color, s0);
+    // Narrow warm-tinted band at the shadow terminator
+    const terminatorA = smoothstep(float(-0.2), float(0.25), NdotL);
+    const terminatorB = smoothstep(float(0.08), float(0.45), NdotL);
+    const terminatorBand = sub(terminatorA, terminatorB);
+    const terminatorTint = mul(baseAlbedo, vec3(1.12, 0.72, 0.54));
+    rampColor = mix(
+      rampColor,
+      terminatorTint,
+      mul(terminatorBand, float(TERMINATOR_BAND_STRENGTH)),
+    );
 
     const nightDim = mix(
       float(NIGHT_MIN_BRIGHTNESS),
@@ -1181,9 +1192,9 @@ export function createTreeDissolveMaterial(
       uDayIntensity,
     );
     const aoMul = mix(float(AO_DARK), float(1.0), aoFactor);
-    let result: any = mul(mul(toonColor, nightDim), aoMul);
+    let result: any = mul(mul(rampColor, nightDim), aoMul);
 
-    // ---- View vector (toon rim); optional leaf SSS when ENABLE_TREE_SSS ----
+    // ---- View vector (rim); optional leaf SSS when ENABLE_TREE_SSS ----
     const V = normalize(sub(cameraPosition, positionWorld));
 
     if (ENABLE_TREE_SSS) {
@@ -1197,10 +1208,13 @@ export function createTreeDissolveMaterial(
     }
 
     const EDotN = clamp(dot(V, N), float(0.0), float(1.0));
-    const rimMask = sub(float(1.0), step(float(TOON_RIM_THRESHOLD), EDotN));
+    const rimMask = sub(
+      float(1.0),
+      smoothstep(float(RIM_EDGE_INNER), float(RIM_EDGE_OUTER), EDotN),
+    );
     const rimBright = mix(
       float(1.0),
-      float(TOON_RIM_BRIGHT),
+      float(RIM_BRIGHT),
       mul(mul(rimMask, dayFactor), leafMask),
     );
     result = mul(result, rimBright);

--- a/packages/shared/src/systems/shared/world/VegetationSystem.ts
+++ b/packages/shared/src/systems/shared/world/VegetationSystem.ts
@@ -1448,7 +1448,9 @@ export class VegetationSystem extends System {
         const height = getHeight(placement.x, placement.z);
 
         // Check water avoidance (ocean)
-        if (height < waterThreshold) continue;
+        if (height < waterThreshold) {
+          continue;
+        }
 
         // Check elevated water body avoidance (mountain ponds, highland lakes, rivers)
         if (bodyRegistry) {
@@ -1458,33 +1460,48 @@ export class VegetationSystem extends System {
               placement.x,
               placement.z,
             );
-            if (height < waterY + WATER_EDGE_BUFFER) continue;
+            if (height < waterY + WATER_EDGE_BUFFER) {
+              continue;
+            }
           } else {
             const body = bodyRegistry.getBodyAt(placement.x, placement.z);
-            if (body && height < body.surfaceY + WATER_EDGE_BUFFER) continue;
+            if (body && height < body.surfaceY + WATER_EDGE_BUFFER) {
+              continue;
+            }
           }
         }
 
         // Check road avoidance
-        if (this.roadNetworkSystem?.isOnRoad(placement.x, placement.z))
+        if (this.roadNetworkSystem?.isOnRoad(placement.x, placement.z)) {
           continue;
+        }
 
         // Keep duel arena floors clear of decorative vegetation.
-        if (isPositionInsideDuelArenaZone(placement.x, placement.z)) continue;
+        if (isPositionInsideDuelArenaZone(placement.x, placement.z)) {
+          continue;
+        }
 
         // Get asset definition for slope constraints
         const asset = this.assetDefinitions.get(placement.assetId);
-        if (!asset) continue;
+        if (!asset) {
+          continue;
+        }
 
         // Get asset data (guaranteed to be loaded from Phase 1)
         const assetDataRef = this.assetData.get(placement.assetId);
-        if (!assetDataRef) continue;
+        if (!assetDataRef) {
+          continue;
+        }
 
         // Calculate slope only when the selected asset has slope constraints.
         if (asset.minSlope !== undefined || asset.maxSlope !== undefined) {
           const slope = this.estimateSlope(placement.x, placement.z, getHeight);
-          if (asset.minSlope !== undefined && slope < asset.minSlope) continue;
-          if (asset.maxSlope !== undefined && slope > asset.maxSlope) continue;
+          if (asset.minSlope !== undefined && slope < asset.minSlope) {
+            continue;
+          }
+          if (asset.maxSlope !== undefined && slope > asset.maxSlope) {
+            continue;
+          }
         }
 
         // Calculate rotation from terrain normal if needed
@@ -2363,7 +2380,9 @@ export class VegetationSystem extends System {
       instance.position.y + assetDataRef.modelBaseOffset * instance.scale;
 
     // Skip instances with invalid height (terrain data not ready yet)
-    if (!Number.isFinite(worldY)) return false;
+    if (!Number.isFinite(worldY)) {
+      return false;
+    }
 
     // Water check — ocean level
     const waterCutoff = WATER_LEVEL + WATER_EDGE_BUFFER;
@@ -2543,7 +2562,6 @@ export class VegetationSystem extends System {
 
     // Update mesh count
     chunked.mesh.count = chunked.count;
-
     // Mark attributes for upload
     chunked.positionAttr.needsUpdate = true;
     chunked.scaleAttr.needsUpdate = true;
@@ -2610,9 +2628,10 @@ export class VegetationSystem extends System {
         radius,
       );
       if (!indexed) {
-        // console.warn(
-        //   `[VegetationSystem] Chunk ${chunkKey} at (${centerX.toFixed(0)}, ${centerZ.toFixed(0)}) outside quadtree bounds - using fallback linear iteration`,
-        // );
+        // Chunk is outside quadtree bounds — will never be made visible by updateChunkVisibility()
+        console.warn(
+          `[VegetationSystem] Chunk "${chunkKey}" at (${centerX.toFixed(1)}, ${centerZ.toFixed(1)}) outside quadtree bounds — check world size config`,
+        );
       }
     }
   }
@@ -2649,10 +2668,6 @@ export class VegetationSystem extends System {
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
     }
-
-    console.log(
-      `[VegetationSystem] Finalized ${totalChunks} chunks (${totalInstances} instances)`,
-    );
   }
 
   /**
@@ -2717,7 +2732,9 @@ export class VegetationSystem extends System {
       });
 
       if (!geometry) {
-        console.warn(`[VegetationSystem] No geometry found in ${asset.id}`);
+        console.warn(
+          `[VegetationSystem] loadAssetData: no geometry found in model "${asset.id}"`,
+        );
         return null;
       }
 
@@ -2785,7 +2802,10 @@ export class VegetationSystem extends System {
 
       return data;
     } catch (err) {
-      console.error(`[VegetationSystem] Failed to load ${asset.id}:`, err);
+      console.error(
+        `[VegetationSystem] loadAssetData failed for "${asset.id}":`,
+        err,
+      );
       return null;
     } finally {
       this.pendingAssetLoads.delete(asset.id);

--- a/packages/shared/src/utils/rendering/ModelCache.ts
+++ b/packages/shared/src/utils/rendering/ModelCache.ts
@@ -380,6 +380,36 @@ export class ModelCache {
       },
     ) => arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength);
 
+    // Extract a geometry attribute's data into a contiguous Float32 buffer.
+    // InterleavedBufferAttribute.array returns the FULL interleaved buffer
+    // (containing positions + normals + UVs all packed together), so we must
+    // deinterleave by reading each component individually via getComponent().
+    // Without this, deserialized geometries get fractional vertex counts and
+    // NaN bounding boxes because the byte length isn't divisible by itemSize*4.
+    const extractAttr = (
+      attr: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+    ): ArrayBuffer => {
+      if (
+        (attr as THREE.InterleavedBufferAttribute).isInterleavedBufferAttribute
+      ) {
+        const iba = attr as THREE.InterleavedBufferAttribute;
+        const out = new Float32Array(iba.count * iba.itemSize);
+        for (let i = 0; i < iba.count; i++) {
+          for (let j = 0; j < iba.itemSize; j++) {
+            out[i * iba.itemSize + j] = iba.getComponent(i, j);
+          }
+        }
+        return out.buffer;
+      }
+      return sliceView(
+        (attr as THREE.BufferAttribute).array as ArrayLike<number> & {
+          buffer: ArrayBuffer;
+          byteOffset: number;
+          byteLength: number;
+        },
+      );
+    };
+
     // Collect all meshes and build identity map (avoids name-collision bugs)
     scene.traverse((node) => {
       if (node instanceof THREE.Mesh || node instanceof THREE.SkinnedMesh) {
@@ -388,7 +418,11 @@ export class ModelCache {
         const sm: SerializedMesh = {
           name: node.name,
           type: node instanceof THREE.SkinnedMesh ? "SkinnedMesh" : "Mesh",
-          positions: sliceView(geo.getAttribute("position").array),
+          positions: extractAttr(
+            geo.getAttribute("position") as
+              | THREE.BufferAttribute
+              | THREE.InterleavedBufferAttribute,
+          ),
           material: Array.isArray(node.material)
             ? node.material.map((m) => this.serializeMaterialProps(m))
             : this.serializeMaterialProps(node.material),
@@ -396,17 +430,28 @@ export class ModelCache {
 
         // Optional attributes
         const normals = geo.getAttribute("normal");
-        if (normals) sm.normals = sliceView(normals.array);
+        if (normals)
+          sm.normals = extractAttr(
+            normals as THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+          );
 
         const uvs = geo.getAttribute("uv");
-        if (uvs) sm.uvs = sliceView(uvs.array);
+        if (uvs)
+          sm.uvs = extractAttr(
+            uvs as THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+          );
 
         const uv2s = geo.getAttribute("uv2");
-        if (uv2s) sm.uv2s = sliceView(uv2s.array);
+        if (uv2s)
+          sm.uv2s = extractAttr(
+            uv2s as THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+          );
 
         const colors = geo.getAttribute("color");
         if (colors) {
-          sm.colors = sliceView(colors.array);
+          sm.colors = extractAttr(
+            colors as THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+          );
           sm.colorItemSize = colors.itemSize;
         }
 
@@ -420,8 +465,18 @@ export class ModelCache {
         if (node instanceof THREE.SkinnedMesh) {
           const skinWeights = geo.getAttribute("skinWeight");
           const skinIndices = geo.getAttribute("skinIndex");
-          if (skinWeights) sm.skinWeights = sliceView(skinWeights.array);
-          if (skinIndices) sm.skinIndices = sliceView(skinIndices.array);
+          if (skinWeights)
+            sm.skinWeights = extractAttr(
+              skinWeights as
+                | THREE.BufferAttribute
+                | THREE.InterleavedBufferAttribute,
+            );
+          if (skinIndices)
+            sm.skinIndices = extractAttr(
+              skinIndices as
+                | THREE.BufferAttribute
+                | THREE.InterleavedBufferAttribute,
+            );
         }
 
         meshes.push(sm);
@@ -475,6 +530,32 @@ export class ModelCache {
   private textureToPixelData(
     texture: THREE.Texture,
   ): SerializedTextureData | null {
+    // DataTexture already has raw pixel data — read it directly without canvas round-trip
+    if ((texture as THREE.DataTexture).isDataTexture) {
+      const img = texture.image as {
+        data: Uint8ClampedArray | Uint8Array;
+        width: number;
+        height: number;
+      };
+      if (img?.data && img.width > 0 && img.height > 0) {
+        const pixels = new Uint8ClampedArray(
+          img.data.buffer,
+          img.data.byteOffset,
+          img.data.byteLength,
+        );
+        // Slice to get a plain ArrayBuffer (not SharedArrayBuffer) for serialization
+        const plainBuffer =
+          pixels.buffer instanceof ArrayBuffer
+            ? pixels.buffer.slice(
+                pixels.byteOffset,
+                pixels.byteOffset + pixels.byteLength,
+              )
+            : new Uint8ClampedArray(pixels).buffer;
+        return { pixels: plainBuffer, width: img.width, height: img.height };
+      }
+      return null;
+    }
+
     const image = texture.source?.data ?? texture.image;
     if (!image) return null;
 
@@ -1102,6 +1183,34 @@ export class ModelCache {
   }
 
   /**
+   * Converts an ImageBitmapTexture to a DataTexture so it uses WebGPU's
+   * writeTexture upload path instead of copyExternalImageToTexture.
+   * DataTextures upload raw bytes without browser-side colorspace conversion,
+   * giving consistent rendering between fresh GLTF loads and cached loads.
+   */
+  private ensureDataTexture(
+    texture: THREE.Texture,
+    srgb: boolean,
+  ): THREE.Texture {
+    if ((texture as THREE.DataTexture).isDataTexture) return texture;
+    const pixelData = this.textureToPixelData(texture);
+    if (!pixelData) return texture;
+    const dt = new THREE.DataTexture(
+      new Uint8ClampedArray(pixelData.pixels),
+      pixelData.width,
+      pixelData.height,
+      THREE.RGBAFormat,
+    );
+    dt.colorSpace = srgb ? THREE.SRGBColorSpace : THREE.LinearSRGBColorSpace;
+    dt.name = texture.name;
+    dt.wrapS = texture.wrapS;
+    dt.wrapT = texture.wrapT;
+    dt.flipY = texture.flipY;
+    dt.needsUpdate = true;
+    return dt;
+  }
+
+  /**
    * Setup a single material for WebGPU/CSM
    */
   private setupSingleMaterial(material: THREE.Material, world?: World): void {
@@ -1126,14 +1235,26 @@ export class ModelCache {
 
     if (
       material instanceof THREE.MeshStandardMaterial ||
-      material instanceof THREE.MeshPhysicalMaterial
+      material instanceof THREE.MeshPhysicalMaterial ||
+      material instanceof MeshStandardNodeMaterial
     ) {
-      // Set up texture color spaces
+      // Set up texture color spaces and force ImageBitmapTexture → DataTexture.
+      // WebGPU uses two different upload paths:
+      //   DataTexture   → writeTexture (raw bytes, reliable)
+      //   ImageBitmap   → copyExternalImageToTexture (browser-side colorspace decode,
+      //                   can double-apply sRGB and corrupt colors)
+      // Converting here guarantees the raw-bytes path for both fresh and cached loads.
       if (materialWithMaps.map) {
-        materialWithMaps.map.colorSpace = THREE.SRGBColorSpace;
+        materialWithMaps.map = this.ensureDataTexture(
+          materialWithMaps.map,
+          true,
+        );
       }
       if (materialWithMaps.emissiveMap) {
-        materialWithMaps.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+        materialWithMaps.emissiveMap = this.ensureDataTexture(
+          materialWithMaps.emissiveMap,
+          true,
+        );
       }
       // Force metalness to 0 — the game has no environment map, so metallic
       // materials lose their diffuse component and appear black. Zeroing metalness
@@ -1144,12 +1265,17 @@ export class ModelCache {
       material instanceof THREE.MeshBasicMaterial ||
       material instanceof THREE.MeshPhongMaterial
     ) {
-      // Set up texture color spaces for non-PBR materials
       if (materialWithMaps.map) {
-        materialWithMaps.map.colorSpace = THREE.SRGBColorSpace;
+        materialWithMaps.map = this.ensureDataTexture(
+          materialWithMaps.map,
+          true,
+        );
       }
       if (materialWithMaps.emissiveMap) {
-        materialWithMaps.emissiveMap.colorSpace = THREE.SRGBColorSpace;
+        materialWithMaps.emissiveMap = this.ensureDataTexture(
+          materialWithMaps.emissiveMap,
+          true,
+        );
       }
     }
 
@@ -1368,9 +1494,6 @@ export class ModelCache {
             world,
           );
           if (processedResult) {
-            console.log(
-              `[ModelCache] ⚡ Restored ${resolvedPath} from processed cache (skipped GLTF parse)`,
-            );
             // Return a pseudo-GLTF result so downstream code works unchanged
             return {
               scene: processedResult.scene,

--- a/packages/shared/src/utils/rendering/ModelCache.ts
+++ b/packages/shared/src/utils/rendering/ModelCache.ts
@@ -380,7 +380,7 @@ export class ModelCache {
       },
     ) => arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength);
 
-    // Extract a geometry attribute's data into a contiguous Float32 buffer.
+    // Extract a geometry attribute's data into a contiguous typed array buffer.
     // InterleavedBufferAttribute.array returns the FULL interleaved buffer
     // (containing positions + normals + UVs all packed together), so we must
     // deinterleave by reading each component individually via getComponent().
@@ -393,7 +393,10 @@ export class ModelCache {
         (attr as THREE.InterleavedBufferAttribute).isInterleavedBufferAttribute
       ) {
         const iba = attr as THREE.InterleavedBufferAttribute;
-        const out = new Float32Array(iba.count * iba.itemSize);
+        const TypedArrayCtor = iba.data.array.constructor as new (
+          len: number,
+        ) => Float32Array | Uint16Array | Uint8Array | Int16Array;
+        const out = new TypedArrayCtor(iba.count * iba.itemSize);
         for (let i = 0; i < iba.count; i++) {
           for (let j = 0; j < iba.itemSize; j++) {
             out[i * iba.itemSize + j] = iba.getComponent(i, j);
@@ -1194,7 +1197,12 @@ export class ModelCache {
   ): THREE.Texture {
     if ((texture as THREE.DataTexture).isDataTexture) return texture;
     const pixelData = this.textureToPixelData(texture);
-    if (!pixelData) return texture;
+    if (!pixelData) {
+      console.warn(
+        `[ModelCache] ensureDataTexture: could not read pixels from "${texture.name}" — sRGB decode may be incorrect`,
+      );
+      return texture;
+    }
     const dt = new THREE.DataTexture(
       new Uint8ClampedArray(pixelData.pixels),
       pixelData.width,
@@ -1205,6 +1213,11 @@ export class ModelCache {
     dt.name = texture.name;
     dt.wrapS = texture.wrapS;
     dt.wrapT = texture.wrapT;
+    dt.minFilter = texture.minFilter;
+    dt.magFilter = texture.magFilter;
+    dt.generateMipmaps = texture.generateMipmaps;
+    dt.repeat.copy(texture.repeat);
+    dt.offset.copy(texture.offset);
     dt.flipY = texture.flipY;
     dt.needsUpdate = true;
     return dt;


### PR DESCRIPTION
## Problem

Two visual bugs affecting vegetation after clearing IndexedDB caches (`hyperscape-processed-models`, `hyperscape-assets`) and hard refreshing:

1. **Mushrooms disappear** — mushrooms show correctly on first load but vanish after any subsequent browser refresh
2. **Tree textures look wrong** — tree textures appear incorrect on fresh load, only correcting after a second normal refresh

## Root Causes

### Mushroom disappearance
GLTF files often store geometry using `InterleavedBufferAttribute`, where multiple attributes share one interleaved `ArrayBuffer`. `serializeScene` was calling `.array` on these attributes and passing the result to `sliceView`, which copied the **entire interleaved buffer** (all attributes combined) as if it were a single attribute. On deserialization, vertex counts were fractional/NaN, bounding boxes were corrupted, and `modelBaseOffset = NaN` caused every instance to be rejected by `addInstanceToChunk`.

### Tree texture corruption
Three.js WebGPU has two texture upload paths:
- `DataTexture` → `writeTexture` (raw byte copy, no transformation)
- `ImageBitmapTexture` (fresh GLTF) → `copyExternalImageToTexture` (browser applies a color-space decode step)

The `copyExternalImageToTexture` path performs a browser-side sRGB decode during upload, which corrupts the stored values when the destination is an `rgba8unorm-srgb` texture. `DataTexture` (from IndexedDB cache) uses `writeTexture` which copies bytes directly and renders correctly. This is why textures looked wrong on fresh load but correct after the processed cache was populated.


