### PR TITLE
fix(streaming-duel): harden duel lifecycle, oracle revenue path, and cinematic camera

### DIFF
--- a/packages/server/src/duel/DuelCombatAI.ts
+++ b/packages/server/src/duel/DuelCombatAI.ts
@@ -185,6 +185,14 @@ const POTION_PATTERNS = [
   "stamina",
 ];
 
+/** Static protection-prayer lookup. Hoisted out of `maybeActivateProtectionPrayer`
+ *  so it isn't reallocated every tick (called every 600ms per fighter). */
+const PROTECTION_PRAYER_MAP = {
+  melee: "protect_from_melee",
+  ranged: "protect_from_missiles",
+  magic: "protect_from_magic",
+} as const;
+
 export class DuelCombatAI {
   private service: EmbeddedHyperscapeService;
   private runtime: AgentRuntime | null;
@@ -243,6 +251,11 @@ export class DuelCombatAI {
     equippedWeapon: undefined,
     position: null,
   };
+
+  /** Memoise detectOpponentAttackType — weapon changes rarely but the
+   *  function runs every tick via maybeActivateProtectionPrayer. */
+  private _lastDetectedWeapon: string | undefined = undefined;
+  private _lastDetectedAttackType: "melee" | "ranged" | "magic" | null = null;
 
   /** Movement AI: last time a move action was issued */
   private lastMoveTime = 0;
@@ -323,6 +336,10 @@ export class DuelCombatAI {
       ...DEFAULT_STRATEGY,
       prayer: OFFENSIVE_PRAYER[this.config.combatRole] ?? "superhuman_strength",
     };
+
+    // Reset memoised weapon→attack-type cache for the new opponent
+    this._lastDetectedWeapon = undefined;
+    this._lastDetectedAttackType = null;
 
     // Reset trash talk state for new fight
     this.firedOwnThresholds.clear();
@@ -446,9 +463,9 @@ export class DuelCombatAI {
     this.lastPhase = phase;
 
     // 5b. Protection prayer — activate based on opponent's visible weapon type.
-    // Fires every tick; activatePrayer no-ops if already active.
+    // Synchronous fast path: allocates no Promise when already active.
     if (opponentData) {
-      this.maybeActivateProtectionPrayer(opponentData).catch(() => {});
+      this.maybeActivateProtectionPrayer(opponentData);
     }
 
     // 6. Trash talk (fire-and-forget, never blocks tick)
@@ -860,46 +877,58 @@ export class DuelCombatAI {
   private detectOpponentAttackType(
     weapon: string | undefined,
   ): "melee" | "ranged" | "magic" | null {
-    if (!weapon) return null;
+    // Memoise: weapon IDs change rarely during a duel but this runs every tick.
+    // Avoids a .toLowerCase() allocation + 7 substring checks per tick per agent.
+    if (weapon === this._lastDetectedWeapon)
+      return this._lastDetectedAttackType;
+    this._lastDetectedWeapon = weapon;
+
+    if (!weapon) {
+      this._lastDetectedAttackType = null;
+      return null;
+    }
     const w = weapon.toLowerCase();
+    let result: "melee" | "ranged" | "magic";
     if (
       w.includes("staff") ||
       w.includes("wand") ||
       w.includes("battlestaff") ||
       w.includes("mystic")
-    )
-      return "magic";
-    if (
+    ) {
+      result = "magic";
+    } else if (
       w.includes("bow") ||
       w.includes("crossbow") ||
       w.includes("ballista") ||
       w.includes("blowpipe")
-    )
-      return "ranged";
-    return "melee";
+    ) {
+      result = "ranged";
+    } else {
+      result = "melee";
+    }
+    this._lastDetectedAttackType = result;
+    return result;
   }
 
   /**
    * Activate the appropriate protection prayer based on what the opponent is wielding.
    * Only activates — never deactivates — so it stacks with offensive prayers.
-   * Runs every tick but `activatePrayer` no-ops if the prayer is already active.
+   *
+   * Synchronous fast path: if no change is needed, returns without allocating a
+   * Promise at all. Before the sync short-circuit this created 2 Promise chains
+   * per 600ms tick (one per fighter) even when the prayer was already active.
    */
-  private async maybeActivateProtectionPrayer(
-    opponentData: OpponentData,
-  ): Promise<void> {
+  private maybeActivateProtectionPrayer(opponentData: OpponentData): void {
     const attackType = this.detectOpponentAttackType(
       opponentData.equippedWeapon,
     );
     if (!attackType) return;
-    const prayerMap: Record<string, string> = {
-      melee: "protect_from_melee",
-      ranged: "protect_from_missiles",
-      magic: "protect_from_magic",
-    };
-    const protPrayer = prayerMap[attackType];
-    if (protPrayer) {
-      await this.activatePrayer(protPrayer);
-    }
+    const protPrayer = PROTECTION_PRAYER_MAP[attackType];
+    if (!protPrayer) return;
+    // Already active — no-op synchronously, no Promise allocated.
+    if (this.activePrayers.has(protPrayer)) return;
+    // Need to toggle: fire-and-forget, errors swallowed to match prior behaviour.
+    void this.activatePrayer(protPrayer).catch(() => {});
   }
 
   private async tryPrayerSwitch(
@@ -1168,7 +1197,10 @@ export class DuelCombatAI {
         const text = (typeof response === "string" ? response : "")
           .trim()
           .replace(/^["']|["']$/g, "");
-        if (text && text.length <= 60) {
+        // Skip send if the duel ended while the LLM call was in-flight —
+        // otherwise a stale taunt lands on the agent after they're back in
+        // the overworld (confusing spectators and polluting chat).
+        if (this.isRunning && text && text.length <= 60) {
           try {
             sendChatAction(text);
           } catch {
@@ -1176,7 +1208,9 @@ export class DuelCombatAI {
           }
         }
       } catch (err) {
-        // On failure, use a scripted fallback
+        // On failure, use a scripted fallback — still respect isRunning so
+        // failures post-stop don't send lingering chat.
+        if (!this.isRunning) return;
         const pool =
           kind === "own_low"
             ? FALLBACK_TAUNTS_OWN_LOW

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -129,6 +129,12 @@ async function startServer() {
         errMsg(err),
       );
     }
+  } else if (streamingDuelEnabled) {
+    // Streaming duels run but no on-chain oracle will publish results.
+    // Flag this loudly — operators otherwise don't notice revenue is off.
+    console.warn(
+      "[Server] ⚠️ STREAMING_DUEL_ENABLED=true but DUEL_ARENA_ORACLE_ENABLED=false — duel results will NOT be published on-chain (no hyperbet settlement).",
+    );
   }
 
   // Step 3b: Initialize Web3 (EVM chain writer) if enabled

--- a/packages/server/src/oracle/DuelArenaOraclePublisher.ts
+++ b/packages/server/src/oracle/DuelArenaOraclePublisher.ts
@@ -556,6 +556,20 @@ export class DuelArenaOraclePublisher {
   private readonly solanaTargets: SolanaOracleTarget[];
   private persistQueue: Promise<void> = Promise.resolve();
 
+  /** Exponential backoff delays for retrying failed chain publishes.
+   *  Keeping this bounded prevents unbounded queues if a provider is truly down
+   *  while still giving transient RPC hiccups (~1 minute window) a chance to
+   *  resolve. Total budget ≈ 54.5s across 5 attempts. */
+  private static readonly RETRY_DELAYS_MS = [1000, 2500, 6000, 15000, 30000];
+
+  /** Pending retry timers keyed by `${duelId}:${targetKey}`. A single pending
+   *  retry per (duel, target) is kept — fresh publishes supersede it so we
+   *  never send stale state after a newer one. Cleared on destroy(). */
+  private readonly retryTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
   public constructor(
     private readonly world: World,
     private readonly config: DuelArenaOracleConfig,
@@ -579,6 +593,10 @@ export class DuelArenaOraclePublisher {
       metadataBaseUrl: this.config.metadataBaseUrl,
       storePath: this.config.storePath,
     });
+    // Any record that was mid-retry when the process crashed is stranded
+    // with chainState.lastError != null and no timer in memory. Re-queue it
+    // so revenue doesn't leak just because the server restarted.
+    this.requeueFailedPublishesOnBoot();
   }
 
   public destroy(): void {
@@ -586,10 +604,175 @@ export class DuelArenaOraclePublisher {
       this.world.off(event, handler);
     }
     this.listeners.length = 0;
+    // Cancel any pending publish retries so they don't fire after teardown.
+    for (const timer of this.retryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.retryTimers.clear();
   }
 
   public getRecord(duelId: string): DuelArenaOracleRecord | null {
     return this.records.get(duelId) ?? null;
+  }
+
+  /**
+   * Records with at least one configured target in a failed state (lastError
+   * set, lastTxHash null). Used by the admin "stuck records" endpoint so
+   * operators can triage duels that exhausted their retry budget and need
+   * human confirmation before off-chain settlement.
+   */
+  public getStuckRecords(): Array<{
+    duelId: string;
+    status: DuelArenaOracleStatus;
+    winnerId: string | null;
+    loserId: string | null;
+    updatedAt: string;
+    stuckTargets: Array<{
+      target: DuelArenaOracleChainKey;
+      label: string;
+      lastAction: "UPSERT" | "RESOLVE" | "CANCEL" | null;
+      lastError: string;
+      updatedAt: string;
+    }>;
+  }> {
+    const results: Array<{
+      duelId: string;
+      status: DuelArenaOracleStatus;
+      winnerId: string | null;
+      loserId: string | null;
+      updatedAt: string;
+      stuckTargets: Array<{
+        target: DuelArenaOracleChainKey;
+        label: string;
+        lastAction: "UPSERT" | "RESOLVE" | "CANCEL" | null;
+        lastError: string;
+        updatedAt: string;
+      }>;
+    }> = [];
+
+    for (const record of this.records.values()) {
+      const stuckTargets: Array<{
+        target: DuelArenaOracleChainKey;
+        label: string;
+        lastAction: "UPSERT" | "RESOLVE" | "CANCEL" | null;
+        lastError: string;
+        updatedAt: string;
+      }> = [];
+      for (const [key, state] of Object.entries(record.chainState ?? {})) {
+        if (!state || state.lastError == null) continue;
+        stuckTargets.push({
+          target: key as DuelArenaOracleChainKey,
+          label: state.label,
+          lastAction: state.lastAction,
+          lastError: state.lastError,
+          updatedAt: state.updatedAt,
+        });
+      }
+      if (stuckTargets.length > 0) {
+        results.push({
+          duelId: record.duelId,
+          status: record.status,
+          winnerId: record.winnerId,
+          loserId: record.loserId,
+          updatedAt: record.updatedAt,
+          stuckTargets,
+        });
+      }
+    }
+
+    // Newest-first so operators see recent problems at the top.
+    results.sort((left, right) =>
+      right.updatedAt.localeCompare(left.updatedAt),
+    );
+    return results;
+  }
+
+  /**
+   * Operator-triggered triage for a stuck record. Always clears lastError on
+   * every currently-stuck target so the scheduler stops treating it as an
+   * open problem. When `forceRetry` is true, also fires a fresh publish
+   * attempt (attempt=0 → full retry budget) for each cleared target —
+   * useful when operators believe the underlying RPC/contract issue has
+   * resolved and want to try settlement again.
+   *
+   * Pending in-memory retry timers for the affected targets are cancelled
+   * so only the fresh attempt runs.
+   */
+  public async clearStuckRecord(
+    duelId: string,
+    options?: { forceRetry?: boolean },
+  ): Promise<{
+    cleared: boolean;
+    reason?: string;
+    targetsCleared: string[];
+    targetsRetried: string[];
+  }> {
+    const record = this.records.get(duelId);
+    if (!record) {
+      return {
+        cleared: false,
+        reason: "not_found",
+        targetsCleared: [],
+        targetsRetried: [],
+      };
+    }
+    const configuredTargets: Array<EvmOracleTarget | SolanaOracleTarget> = [
+      ...this.evmTargets,
+      ...this.solanaTargets,
+    ];
+    const targetByKey = new Map(configuredTargets.map((t) => [t.key, t]));
+
+    const targetsCleared: string[] = [];
+    const targetsRetried: string[] = [];
+
+    for (const [key, state] of Object.entries(record.chainState ?? {})) {
+      if (!state || state.lastError == null) continue;
+      // Cancel any pending retry timer so we don't race with the operator.
+      const retryKey = `${duelId}:${key}`;
+      const timer = this.retryTimers.get(retryKey);
+      if (timer) {
+        clearTimeout(timer);
+        this.retryTimers.delete(retryKey);
+      }
+      state.lastError = null;
+      state.updatedAt = nowIso();
+      targetsCleared.push(key);
+
+      if (options?.forceRetry) {
+        const target = targetByKey.get(key as DuelArenaOracleChainKey);
+        if (!target) continue;
+        const action: "UPSERT" | "RESOLVE" | "CANCEL" =
+          record.status === "RESOLVED"
+            ? "RESOLVE"
+            : record.status === "CANCELLED"
+              ? "CANCEL"
+              : "UPSERT";
+        targetsRetried.push(key);
+        setImmediate(() => {
+          void this.publishToTarget(record, target, action, 0);
+        });
+      }
+    }
+
+    if (targetsCleared.length > 0) {
+      record.updatedAt = nowIso();
+      this.records.set(duelId, record);
+      await this.persistRecords();
+      Logger.info(
+        "DuelArenaOraclePublisher",
+        `Operator cleared stuck record ${duelId} (${targetsCleared.join(", ")})` +
+          (options?.forceRetry
+            ? ` — forcing retry on (${targetsRetried.join(", ")})`
+            : ""),
+      );
+    }
+
+    return {
+      cleared: targetsCleared.length > 0,
+      reason: targetsCleared.length === 0 ? "no_stuck_targets" : undefined,
+      targetsCleared,
+      targetsRetried,
+    };
   }
 
   public getRecentRecords(limit: number = 50): DuelArenaOracleRecord[] {
@@ -771,7 +954,17 @@ export class DuelArenaOraclePublisher {
     record: DuelArenaOracleRecord,
     target: EvmOracleTarget | SolanaOracleTarget,
     action: "UPSERT" | "RESOLVE" | "CANCEL",
+    attempt = 0,
   ): Promise<void> {
+    // Cancel any pending retry timer for this (duel, target) — this call
+    // supersedes it (either we're the retry firing, or a fresh publish).
+    const retryKey = `${record.duelId}:${target.key}`;
+    const existingTimer = this.retryTimers.get(retryKey);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.retryTimers.delete(retryKey);
+    }
+
     try {
       let txHash: string;
       if (action === "UPSERT") {
@@ -793,6 +986,12 @@ export class DuelArenaOraclePublisher {
         lastError: null,
         updatedAt: nowIso(),
       });
+      if (attempt > 0) {
+        Logger.info(
+          "DuelArenaOraclePublisher",
+          `Oracle publish succeeded on retry ${attempt} for ${record.duelId} on ${target.label} (${action}) txHash=${txHash}`,
+        );
+      }
     } catch (error) {
       let errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -826,7 +1025,105 @@ export class DuelArenaOraclePublisher {
       });
       Logger.warn(
         "DuelArenaOraclePublisher",
-        `Failed oracle publish on ${target.label} (${action}) for ${record.duelId}: ${errorMessage}`,
+        `Failed oracle publish on ${target.label} (${action}) for ${record.duelId} (attempt ${attempt + 1}): ${errorMessage}`,
+      );
+      this.scheduleRetry(record, target, action, attempt + 1);
+    }
+  }
+
+  /**
+   * Schedule a bounded, exponentially-backed-off retry of publishToTarget.
+   *
+   * Retries fire in the background — callers of publishToTarget never wait for
+   * retries. Only one retry is kept in flight per (duelId, targetKey); fresh
+   * publishes supersede pending retries so we never send stale state.
+   */
+  private scheduleRetry(
+    record: DuelArenaOracleRecord,
+    target: EvmOracleTarget | SolanaOracleTarget,
+    action: "UPSERT" | "RESOLVE" | "CANCEL",
+    nextAttempt: number,
+  ): void {
+    const delays = DuelArenaOraclePublisher.RETRY_DELAYS_MS;
+    if (nextAttempt > delays.length) {
+      Logger.error(
+        "DuelArenaOraclePublisher",
+        `Giving up oracle publish for ${record.duelId} on ${target.label} (${action}) after ${nextAttempt} attempts — manual intervention required`,
+      );
+      return;
+    }
+    const delay = delays[nextAttempt - 1];
+    const retryKey = `${record.duelId}:${target.key}`;
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(retryKey);
+      // Re-fetch the latest record so the retry reflects current state.
+      // If the record has since been cancelled/updated, we publish that newer
+      // state instead — the contract flow is monotonic enough that this is
+      // safer than replaying the snapshot we failed on.
+      const latest = this.records.get(record.duelId) ?? record;
+      void this.publishToTarget(latest, target, action, nextAttempt);
+    }, delay);
+    // Don't keep the Node event loop alive purely for a pending retry.
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+    this.retryTimers.set(retryKey, timer);
+    Logger.info(
+      "DuelArenaOraclePublisher",
+      `Scheduled oracle retry ${nextAttempt}/${delays.length} for ${record.duelId} on ${target.label} (${action}) in ${delay}ms`,
+    );
+  }
+
+  /**
+   * Scan persisted records on boot and re-queue any publish that was in a
+   * failed state when the process stopped. Without this, a duel that had a
+   * transient RPC error at shutdown stays stranded forever — the retry
+   * timer lives only in memory and dies with the process.
+   *
+   * We re-queue at attempt=0 (full fresh retry schedule) rather than resuming
+   * from a persisted attempt counter, because the time since the last attempt
+   * is unknown and probably long enough that a fresh backoff is appropriate.
+   */
+  private requeueFailedPublishesOnBoot(): void {
+    const configuredTargets: Array<EvmOracleTarget | SolanaOracleTarget> = [
+      ...this.evmTargets,
+      ...this.solanaTargets,
+    ];
+    if (configuredTargets.length === 0) return;
+
+    let requeued = 0;
+    for (const record of this.records.values()) {
+      // CANCELLED is terminal: if the cancel publish itself failed we still
+      // want it delivered, but any BETTING_OPEN/LOCKED leftover on a cancelled
+      // duel is stale and publishing it now would mislead downstream.
+      if (!record.status) continue;
+
+      const action: "UPSERT" | "RESOLVE" | "CANCEL" =
+        record.status === "RESOLVED"
+          ? "RESOLVE"
+          : record.status === "CANCELLED"
+            ? "CANCEL"
+            : "UPSERT";
+
+      for (const target of configuredTargets) {
+        const state = record.chainState?.[target.key];
+        // lastError null means this target already accepted the publish —
+        // skip. lastError set means it was failed at shutdown, re-queue.
+        if (!state || state.lastError == null) continue;
+        // Fire publishToTarget with attempt=0 so it goes through the normal
+        // retry schedule if it fails again. Doing this on the next tick so
+        // init() returns fast and callers see the publisher as ready.
+        setImmediate(() => {
+          void this.publishToTarget(record, target, action, 0);
+        });
+        requeued++;
+      }
+    }
+
+    if (requeued > 0) {
+      Logger.info(
+        "DuelArenaOraclePublisher",
+        `Re-queued ${requeued} failed oracle publish(es) from persisted records on boot`,
       );
     }
   }

--- a/packages/server/src/startup/routes/admin-routes.ts
+++ b/packages/server/src/startup/routes/admin-routes.ts
@@ -2224,6 +2224,95 @@ export function registerAdminRoutes(
     },
   );
 
+  /**
+   * GET /admin/duels/oracle/stuck
+   * List oracle records with at least one target in a failed state
+   * (lastError set). These are duels that exhausted their automatic
+   * retry budget and need operator triage before revenue can settle.
+   */
+  fastify.get(
+    "/admin/duels/oracle/stuck",
+    { preHandler: requireAdmin },
+    async (_request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const { getDuelArenaOraclePublisher } =
+          await import("../../oracle/DuelArenaOraclePublisher.js");
+        const publisher = getDuelArenaOraclePublisher(world);
+        if (!publisher) {
+          return reply.code(503).send({
+            error: "Duel arena oracle publisher is not enabled",
+          });
+        }
+        const stuck = publisher.getStuckRecords();
+        return reply.send({ count: stuck.length, records: stuck });
+      } catch (err) {
+        console.error("[AdminRoutes] oracle/stuck error:", err);
+        return reply.code(500).send({
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to read stuck oracle records",
+        });
+      }
+    },
+  );
+
+  /**
+   * POST /admin/duels/oracle/clear/:duelId
+   * Operator triage for an oracle record that exhausted retries.
+   *
+   * Body: { forceRetry?: boolean }
+   *  - forceRetry=false (default): clear lastError on all stuck targets.
+   *    Use when the operator has reconciled the result manually off-chain
+   *    and wants to silence the alert.
+   *  - forceRetry=true: clear lastError AND immediately fire a fresh publish
+   *    attempt (with full retry schedule) for each stuck target. Use when
+   *    the operator believes the underlying failure has been fixed (e.g.
+   *    RPC endpoint recovered, contract upgraded) and wants the system to
+   *    try settlement again.
+   */
+  fastify.post<{ Params: { duelId: string } }>(
+    "/admin/duels/oracle/clear/:duelId",
+    { preHandler: requireAdmin },
+    async (request, reply) => {
+      try {
+        const { getDuelArenaOraclePublisher } =
+          await import("../../oracle/DuelArenaOraclePublisher.js");
+        const publisher = getDuelArenaOraclePublisher(world);
+        if (!publisher) {
+          return reply.code(503).send({
+            error: "Duel arena oracle publisher is not enabled",
+          });
+        }
+        const body = (request.body ?? {}) as { forceRetry?: unknown };
+        const forceRetry = body.forceRetry === true;
+        const result = await publisher.clearStuckRecord(request.params.duelId, {
+          forceRetry,
+        });
+        if (!result.cleared) {
+          return reply.code(result.reason === "not_found" ? 404 : 400).send({
+            error: result.reason ?? "clear_failed",
+            ...result,
+          });
+        }
+        return reply.send({
+          success: true,
+          duelId: request.params.duelId,
+          forceRetry,
+          ...result,
+        });
+      } catch (err) {
+        console.error("[AdminRoutes] oracle/clear error:", err);
+        return reply.code(500).send({
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to clear stuck oracle record",
+        });
+      }
+    },
+  );
+
   // ==========================================================================
   // Standalone Sparbot Pool Endpoints
   // ==========================================================================

--- a/packages/server/src/systems/StreamingDuelScheduler/managers/DuelOrchestrator.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/managers/DuelOrchestrator.ts
@@ -947,8 +947,12 @@ export class DuelOrchestrator {
     }
 
     // --- Pick the overall best ---
-    // Prefer agent's own gear (equipped > inventory) over conjured manifest weapons
+    // Prefer agent's own gear (equipped > inventory) over conjured manifest weapons.
+    // The `equippedScore >= 0` gate rejects the common "all scores are -1" trap:
+    // a non-melee equipped item (e.g. a shortbow) scores -1 here, and without
+    // this gate -1 >= -1 trivially passes and we "keep" the wrong weapon.
     if (
+      equippedScore >= 0 &&
       equippedScore >= manifestBestScore &&
       equippedScore >= invBestScore &&
       equippedId
@@ -1043,10 +1047,12 @@ export class DuelOrchestrator {
       }
     }
 
-    // Pick best bow
+    // Pick best bow — see melee picker for the `>= 0` rationale (prevents a
+    // non-bow equipped item from being "kept" as a bow when every score is -1).
     let finalBowId: string;
     let bowAlreadyEquipped = false;
     if (
+      equippedBowScore >= 0 &&
       equippedBowScore >= manifestBowScore &&
       equippedBowScore >= invBowScore &&
       equippedId
@@ -1195,9 +1201,11 @@ export class DuelOrchestrator {
     }
 
     // Pick best staff
+    // See melee picker for the `>= 0` rationale.
     let staffId: string;
     let staffAlreadyEquipped = false;
     if (
+      equippedStaffScore >= 0 &&
       equippedStaffScore >= manifestStaffScore &&
       equippedStaffScore >= invStaffScore &&
       equippedId
@@ -1979,7 +1987,16 @@ export class DuelOrchestrator {
       arenaConfig.arenaLength / 2;
     const cx = arenaCenterX;
     const cz = arenaCenterZ;
-    const off = arenaConfig.spawnOffset;
+
+    // Spawn agents on ADJACENT tiles so melee combat can start immediately
+    // (`startCombat` requires range=1 for melee weapons; `ensureDuelProximity`
+    // enforces tileChebyshevDistance===1). The shared duel arena config's
+    // `spawnOffset` of 8 is designed for dramatic player-duel facing-off and
+    // leaves agents 16 tiles apart, which makes melee startCombat fail in
+    // every streaming duel. Ranged/mage agents then spread out via
+    // DuelCombatAI movement after combat has engaged.
+    const STREAMING_MELEE_SPAWN_OFFSET = 0.5;
+    const off = STREAMING_MELEE_SPAWN_OFFSET;
 
     let agent1X: number;
     let agent1Z: number;
@@ -2377,6 +2394,10 @@ export class DuelOrchestrator {
         "StreamingDuelScheduler",
         `Failed to start combat AIs: ${errMsg(err)}`,
       );
+      // Roll back any partially-locked services so agents aren't stranded in
+      // arena mode (bounds clamped, autonomy disabled) for the rest of the cycle.
+      // stopCombatAIs() is idempotent — safe to call even when nothing started.
+      this.stopCombatAIs();
     });
   }
 
@@ -3205,8 +3226,11 @@ export class DuelOrchestrator {
         winReason = "damage_advantage";
       } else {
         // True draw — both HP and damage equal (#24)
-        // Resolve as a proper draw: no winner/loser, just record it
-        this.onResolution(agent1.characterId, agent2.characterId, "draw");
+        // Route through startResolution so combat loop, retry timeout, and
+        // DuelCombatAI instances are all torn down. Calling onResolution()
+        // directly here skipped stopCombatAIs(), leaving services in arena
+        // mode (bounds clamped, autonomy disabled) until the next duel.
+        this.startResolution(agent1.characterId, agent2.characterId, "draw");
         return;
       }
     }

--- a/packages/server/src/systems/StreamingDuelScheduler/managers/__tests__/DuelOrchestrator.test.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/managers/__tests__/DuelOrchestrator.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for DuelOrchestrator cleanup paths.
+ *
+ * Specifically covers the timeout-draw bug where `endFightByTimeout()` called
+ * `onResolution()` directly on a tie, skipping `stopCombatLoop`,
+ * `clearCombatRetryTimeout`, and `stopCombatAIs` — leaving agents locked in
+ * arena mode (bounds clamped, autonomy disabled) until the next duel started.
+ *
+ * See DuelOrchestrator.endFightByTimeout + startResolution.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DuelOrchestrator } from "../DuelOrchestrator";
+import type { AgentContestant, StreamingDuelCycle } from "../../types";
+
+type ArenaService = {
+  clearArenaBounds: ReturnType<typeof vi.fn>;
+  setAutonomousBehaviorEnabled: ReturnType<typeof vi.fn>;
+};
+
+function makeContestant(
+  id: string,
+  hp: number,
+  damageDealt: number,
+): AgentContestant {
+  return {
+    characterId: id,
+    name: `agent-${id}`,
+    provider: "test",
+    model: "test",
+    combatLevel: 10,
+    wins: 0,
+    losses: 0,
+    currentHp: hp,
+    maxHp: 10,
+    originalPosition: [0, 0, 0],
+    damageDealtThisFight: damageDealt,
+    highestHit: 0,
+    attacksLanded: 0,
+    healsUsed: 0,
+    equipment: {},
+    inventory: [],
+    itemIconPaths: {},
+    rank: 0,
+    headToHeadWins: 0,
+    headToHeadLosses: 0,
+  };
+}
+
+function makeCycle(
+  a1Hp: number,
+  a2Hp: number,
+  a1Dmg: number,
+  a2Dmg: number,
+): StreamingDuelCycle {
+  const now = Date.now();
+  return {
+    cycleId: "test-cycle",
+    phase: "FIGHTING",
+    cycleStartTime: now,
+    phaseStartTime: now,
+    phaseVersion: 0,
+    agent1: makeContestant("a1", a1Hp, a1Dmg),
+    agent2: makeContestant("a2", a2Hp, a2Dmg),
+    duelId: null,
+    duelKeyHex: null,
+    arenaId: 1,
+    betOpenTime: null,
+    betCloseTime: null,
+    countdownValue: null,
+    fightStartTime: now,
+    duelEndTime: null,
+    arenaPositions: null,
+    winnerId: null,
+    loserId: null,
+    winReason: null,
+    seed: null,
+    replayHash: null,
+  };
+}
+
+function makeOrchestrator(
+  cycle: StreamingDuelCycle,
+  services: ArenaService[],
+  onResolution: (w: string, l: string, r: string) => void,
+) {
+  const world: unknown = {
+    emit: vi.fn(),
+    entities: { get: () => null },
+    getSystem: () => null,
+    network: { send: vi.fn() },
+  };
+
+  const orch = new DuelOrchestrator(
+    world as never,
+    () => cycle,
+    (fields) => Object.assign(cycle, fields),
+    () => new Map(),
+    onResolution as never,
+    () => [],
+    () => [],
+  );
+
+  // Simulate `startCombatAIs` having run: both services locked into arena mode.
+  // In production this is populated by the loop at DuelOrchestrator.ts:2436.
+  (
+    orch as unknown as { _arenaModeServices: ArenaService[] }
+  )._arenaModeServices = services;
+
+  return orch;
+}
+
+describe("DuelOrchestrator.endFightByTimeout", () => {
+  beforeEach(() => {
+    // setTimeout at the end of startResolution (victory emote + trash talk)
+    // should not fire during test — keep timers fake.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears arena mode on timeout-DRAW (regression for direct onResolution() bypass)", () => {
+    // Equal HP, equal damage → draw path
+    const cycle = makeCycle(5, 5, 7, 7);
+    const svc1: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const svc2: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const onResolution = vi.fn();
+    const orch = makeOrchestrator(cycle, [svc1, svc2], onResolution);
+
+    orch.endFightByTimeout();
+
+    // Must report a draw
+    expect(onResolution).toHaveBeenCalledTimes(1);
+    expect(onResolution).toHaveBeenCalledWith("a1", "a2", "draw");
+
+    // Must have torn down arena mode — this is exactly the cleanup that the
+    // pre-fix code skipped by calling onResolution() directly.
+    expect(svc1.clearArenaBounds).toHaveBeenCalledTimes(1);
+    expect(svc2.clearArenaBounds).toHaveBeenCalledTimes(1);
+    expect(svc1.setAutonomousBehaviorEnabled).toHaveBeenCalledTimes(1);
+    expect(svc1.setAutonomousBehaviorEnabled).toHaveBeenCalledWith(true);
+    expect(svc2.setAutonomousBehaviorEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("clears arena mode on timeout-HP-ADVANTAGE (smoke check)", () => {
+    // Different HP → hp_advantage path (already went through startResolution pre-fix,
+    // but worth a smoke test to guard against future regressions there too).
+    const cycle = makeCycle(8, 3, 7, 4);
+    const svc1: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const svc2: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const onResolution = vi.fn();
+    const orch = makeOrchestrator(cycle, [svc1, svc2], onResolution);
+
+    orch.endFightByTimeout();
+
+    expect(onResolution).toHaveBeenCalledWith("a1", "a2", "hp_advantage");
+    expect(svc1.clearArenaBounds).toHaveBeenCalledTimes(1);
+    expect(svc2.clearArenaBounds).toHaveBeenCalledTimes(1);
+    expect(svc1.setAutonomousBehaviorEnabled).toHaveBeenCalledWith(true);
+    expect(svc2.setAutonomousBehaviorEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("does nothing when phase is not FIGHTING (Fix G)", () => {
+    const cycle = makeCycle(5, 5, 7, 7);
+    cycle.phase = "RESOLUTION";
+    const svc1: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const svc2: ArenaService = {
+      clearArenaBounds: vi.fn(),
+      setAutonomousBehaviorEnabled: vi.fn(),
+    };
+    const onResolution = vi.fn();
+    const orch = makeOrchestrator(cycle, [svc1, svc2], onResolution);
+
+    orch.endFightByTimeout();
+
+    expect(onResolution).not.toHaveBeenCalled();
+    expect(svc1.clearArenaBounds).not.toHaveBeenCalled();
+    expect(svc2.clearArenaBounds).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/tests/unit/oracle/DuelArenaOraclePublisher.test.ts
+++ b/packages/server/tests/unit/oracle/DuelArenaOraclePublisher.test.ts
@@ -202,4 +202,356 @@ describe("DuelArenaOraclePublisher", () => {
       // To strictly verify chain state we need to mock updateChainState which is private or call getRecord
     });
   });
+
+  describe("publishToTarget retry", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("retries a failed publish with exponential backoff and succeeds", async () => {
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+
+      const publishResolution = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("network glitch"))
+        .mockResolvedValueOnce("0xretryOk");
+
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+      };
+      (publisher as any).evmTargets = [mockTarget];
+
+      const record: DuelArenaOracleRecord = {
+        duelId: "duel-retry-ok",
+        status: "RESOLVED",
+        cycleId: "cycle-1",
+        chainState: {},
+      } as unknown as DuelArenaOracleRecord;
+      (publisher as any).records.set(record.duelId, record);
+      vi.spyOn(publisher as any, "persistRecords").mockResolvedValue(undefined);
+
+      // First attempt — should fail and schedule a retry for +1000ms.
+      await (publisher as any).publishToTarget(record, mockTarget, "RESOLVE");
+      expect(publishResolution).toHaveBeenCalledTimes(1);
+      expect((publisher as any).retryTimers.size).toBe(1);
+
+      // Advance past the first retry delay (1000ms) and flush microtasks so the
+      // retry's async publishToTarget call resolves before we inspect state.
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(publishResolution).toHaveBeenCalledTimes(2);
+      expect((publisher as any).retryTimers.size).toBe(0);
+      const latestState = (publisher as any).getRecord("duel-retry-ok")
+        ?.chainState["baseSepolia"];
+      expect(latestState?.lastTxHash).toBe("0xretryOk");
+      expect(latestState?.lastError).toBeNull();
+    });
+
+    it("gives up after the maximum number of retries", async () => {
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+
+      const err = new Error("rpc down");
+      const publishResolution = vi.fn().mockRejectedValue(err);
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+      };
+      (publisher as any).evmTargets = [mockTarget];
+
+      const record: DuelArenaOracleRecord = {
+        duelId: "duel-retry-exhaust",
+        status: "RESOLVED",
+        cycleId: "cycle-1",
+        chainState: {},
+      } as unknown as DuelArenaOracleRecord;
+      (publisher as any).records.set(record.duelId, record);
+      vi.spyOn(publisher as any, "persistRecords").mockResolvedValue(undefined);
+
+      await (publisher as any).publishToTarget(record, mockTarget, "RESOLVE");
+      // Exhaust the full retry schedule: 1s + 2.5s + 6s + 15s + 30s.
+      await vi.advanceTimersByTimeAsync(55_000);
+
+      // Initial + 5 retries = 6 attempts.
+      expect(publishResolution).toHaveBeenCalledTimes(6);
+      expect((publisher as any).retryTimers.size).toBe(0);
+    });
+
+    it("re-queues failed publishes from persisted records on boot", async () => {
+      // setImmediate must actually fire — switch off the outer describe's
+      // fake timers for this test only.
+      vi.useRealTimers();
+
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+
+      // Pretend the persisted store already has a RESOLVED duel whose EVM
+      // publish failed right before shutdown (lastError set on evm target).
+      // A CANCELLED duel with a clean (lastError=null) solana target must NOT
+      // be re-queued — that's what success looks like.
+      vi.spyOn(publisher as any, "loadPersistedRecords").mockImplementation(
+        async () => {
+          (publisher as any).records.set("duel-stuck", {
+            duelId: "duel-stuck",
+            status: "RESOLVED",
+            cycleId: "cycle-stuck",
+            chainState: {
+              baseSepolia: {
+                target: "baseSepolia",
+                kind: "evm",
+                label: "Base Sepolia",
+                lastAction: "RESOLVE",
+                lastTxHash: null,
+                lastError: "rpc fell over",
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            },
+          });
+          (publisher as any).records.set("duel-clean", {
+            duelId: "duel-clean",
+            status: "CANCELLED",
+            cycleId: "cycle-clean",
+            chainState: {
+              baseSepolia: {
+                target: "baseSepolia",
+                kind: "evm",
+                label: "Base Sepolia",
+                lastAction: "CANCEL",
+                lastTxHash: "0xok",
+                lastError: null,
+                updatedAt: "2024-01-01T00:00:00Z",
+              },
+            },
+          });
+        },
+      );
+
+      // Fake target that records which action it was called with.
+      const publishResolution = vi.fn().mockResolvedValue("0xbootRetryOk");
+      const publishCancellation = vi.fn().mockResolvedValue("0xshouldNotFire");
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+        publishCancellation,
+      };
+
+      // init() calls loadPersistedRecords() first, then attach(), then
+      // requeueFailedPublishesOnBoot(). We need evmTargets populated BEFORE
+      // init() runs. The real publisher builds evmTargets in its ctor from
+      // config.evmTargets — since we can't easily inject mock classes
+      // through the EVM config, swap the array directly before init().
+      (publisher as any).evmTargets = [mockTarget];
+
+      await publisher.init();
+      // setImmediate is used to defer work — flush it so the requeue fires.
+      await new Promise((resolve) => setImmediate(resolve));
+      // One microtask loop for the inner publishToTarget promise.
+      await Promise.resolve();
+
+      expect(publishResolution).toHaveBeenCalledTimes(1);
+      // The CANCELLED/clean record must not have been re-queued.
+      expect(publishCancellation).not.toHaveBeenCalled();
+    });
+
+    it("getStuckRecords returns records with lastError set", () => {
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+
+      (publisher as any).records.set("duel-stuck", {
+        duelId: "duel-stuck",
+        status: "RESOLVED",
+        winnerId: "a",
+        loserId: "b",
+        updatedAt: "2024-02-01T00:00:00Z",
+        chainState: {
+          baseSepolia: {
+            target: "baseSepolia",
+            kind: "evm",
+            label: "Base Sepolia",
+            lastAction: "RESOLVE",
+            lastTxHash: null,
+            lastError: "rpc timeout",
+            updatedAt: "2024-02-01T00:00:00Z",
+          },
+          solanaDevnet: {
+            target: "solanaDevnet",
+            kind: "solana",
+            label: "Solana Devnet",
+            lastAction: "RESOLVE",
+            lastTxHash: "solOkHash",
+            lastError: null,
+            updatedAt: "2024-02-01T00:00:00Z",
+          },
+        },
+      });
+      (publisher as any).records.set("duel-clean", {
+        duelId: "duel-clean",
+        status: "RESOLVED",
+        winnerId: "c",
+        loserId: "d",
+        updatedAt: "2024-02-01T00:00:00Z",
+        chainState: {
+          baseSepolia: {
+            target: "baseSepolia",
+            kind: "evm",
+            lastAction: "RESOLVE",
+            lastTxHash: "0xok",
+            lastError: null,
+            updatedAt: "2024-02-01T00:00:00Z",
+          },
+        },
+      });
+
+      const stuck = publisher.getStuckRecords();
+      expect(stuck).toHaveLength(1);
+      expect(stuck[0].duelId).toBe("duel-stuck");
+      // Only the failed target shows up — the clean solana one does not.
+      expect(stuck[0].stuckTargets).toHaveLength(1);
+      expect(stuck[0].stuckTargets[0].target).toBe("baseSepolia");
+      expect(stuck[0].stuckTargets[0].lastError).toBe("rpc timeout");
+    });
+
+    it("clearStuckRecord without forceRetry clears errors and skips re-publish", async () => {
+      // Real timers so setImmediate actually fires if forceRetry ever is used.
+      vi.useRealTimers();
+
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+      vi.spyOn(publisher as any, "persistRecords").mockResolvedValue(undefined);
+
+      const publishResolution = vi.fn().mockResolvedValue("0xshouldNotFire");
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+      };
+      (publisher as any).evmTargets = [mockTarget];
+
+      (publisher as any).records.set("duel-1", {
+        duelId: "duel-1",
+        status: "RESOLVED",
+        updatedAt: "2024-01-01T00:00:00Z",
+        chainState: {
+          baseSepolia: {
+            target: "baseSepolia",
+            kind: "evm",
+            label: "Base Sepolia",
+            lastAction: "RESOLVE",
+            lastTxHash: null,
+            lastError: "boom",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        },
+      });
+
+      const result = await publisher.clearStuckRecord("duel-1");
+      expect(result.cleared).toBe(true);
+      expect(result.targetsCleared).toEqual(["baseSepolia"]);
+      expect(result.targetsRetried).toEqual([]);
+
+      // Flush any setImmediate that might have queued (shouldn't have).
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(publishResolution).not.toHaveBeenCalled();
+
+      const rec = (publisher as any).getRecord("duel-1");
+      expect(rec.chainState.baseSepolia.lastError).toBeNull();
+    });
+
+    it("clearStuckRecord with forceRetry clears errors and retriggers publish", async () => {
+      vi.useRealTimers();
+
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+      vi.spyOn(publisher as any, "persistRecords").mockResolvedValue(undefined);
+
+      const publishResolution = vi.fn().mockResolvedValue("0xforcedOk");
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+      };
+      (publisher as any).evmTargets = [mockTarget];
+
+      (publisher as any).records.set("duel-2", {
+        duelId: "duel-2",
+        status: "RESOLVED",
+        updatedAt: "2024-01-01T00:00:00Z",
+        chainState: {
+          baseSepolia: {
+            target: "baseSepolia",
+            kind: "evm",
+            label: "Base Sepolia",
+            lastAction: "RESOLVE",
+            lastTxHash: null,
+            lastError: "old_error",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        },
+      });
+
+      const result = await publisher.clearStuckRecord("duel-2", {
+        forceRetry: true,
+      });
+      expect(result.cleared).toBe(true);
+      expect(result.targetsRetried).toEqual(["baseSepolia"]);
+
+      // Let setImmediate + inner promise resolve.
+      await new Promise((resolve) => setImmediate(resolve));
+      await Promise.resolve();
+
+      expect(publishResolution).toHaveBeenCalledTimes(1);
+      const rec = (publisher as any).getRecord("duel-2");
+      expect(rec.chainState.baseSepolia.lastTxHash).toBe("0xforcedOk");
+      expect(rec.chainState.baseSepolia.lastError).toBeNull();
+    });
+
+    it("clearStuckRecord returns not_found for unknown duelId", async () => {
+      vi.useRealTimers();
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+      const result = await publisher.clearStuckRecord("does-not-exist");
+      expect(result.cleared).toBe(false);
+      expect(result.reason).toBe("not_found");
+    });
+
+    it("destroy() cancels pending retry timers", async () => {
+      config.settlementDelayMs = 0;
+      publisher = new DuelArenaOraclePublisher(mockWorld, config);
+
+      const publishResolution = vi.fn().mockRejectedValue(new Error("fail"));
+      const mockTarget = {
+        key: "baseSepolia",
+        label: "Base Sepolia",
+        publishResolution,
+      };
+      (publisher as any).evmTargets = [mockTarget];
+
+      const record: DuelArenaOracleRecord = {
+        duelId: "duel-destroy",
+        status: "RESOLVED",
+        cycleId: "cycle-1",
+        chainState: {},
+      } as unknown as DuelArenaOracleRecord;
+      (publisher as any).records.set(record.duelId, record);
+      vi.spyOn(publisher as any, "persistRecords").mockResolvedValue(undefined);
+
+      await (publisher as any).publishToTarget(record, mockTarget, "RESOLVE");
+      expect((publisher as any).retryTimers.size).toBe(1);
+
+      publisher.destroy();
+      expect((publisher as any).retryTimers.size).toBe(0);
+
+      // Advancing past the delay must NOT retry — the timer was cleared.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(publishResolution).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/shared/src/systems/client/ClientCameraSystem.ts
+++ b/packages/shared/src/systems/client/ClientCameraSystem.ts
@@ -1621,23 +1621,31 @@ export class ClientCameraSystem extends SystemBase {
         };
       case "FIGHTING":
         return {
-          radiusMin: 4.0,
-          radiusMax: 7.5,
-          basePhi: Math.PI * 0.27,
-          driftSpeed: 0.018,
-          targetFov: 46,
-          orbitAmplitude: 0.07,
+          // Wider framing so ranged/mage agents (IDEAL_RANGE 5–8) stay
+          // comfortably on-screen when they kite apart.
+          radiusMin: 5.0,
+          radiusMax: 10.0,
+          // Slightly elevated — less side-scroller, more broadcast spectator.
+          basePhi: Math.PI * 0.3,
+          // More dynamic orbit drift so static engagements don't look frozen.
+          driftSpeed: 0.028,
+          // Wider FOV to admit both fighters + arena context.
+          targetFov: 54,
+          orbitAmplitude: 0.12,
           focusBias: 0.5,
         };
       case "RESOLUTION":
         return {
-          radiusMin: 5.5,
-          radiusMax: 8,
-          basePhi: Math.PI * 0.44,
-          driftSpeed: 0.025,
-          targetFov: 45,
-          orbitAmplitude: 0.06,
-          focusBias: 0.5,
+          // Hero framing on the winner — closer and lower than before
+          // so the victory emote reads clearly, with a wider FOV to include
+          // the defeated opponent for context.
+          radiusMin: 4.5,
+          radiusMax: 7.0,
+          basePhi: Math.PI * 0.35,
+          driftSpeed: 0.035,
+          targetFov: 50,
+          orbitAmplitude: 0.1,
+          focusBias: 0.7,
         };
       default:
         return {
@@ -2452,6 +2460,27 @@ export class ClientCameraSystem extends SystemBase {
       if (this.cinematicPhase === "FIGHTING") {
         radius *= 1 - this.cinematicPunchIn * 0.13;
         radius = clamp(radius, pp.radiusMin * 0.86, pp.radiusMax);
+      }
+
+      // Pre-fight push-in: during COUNTDOWN, smoothly shrink the radius from
+      // radiusMax → radiusMin over ~4s so the camera closes on the fighters
+      // as the fight starts. Without this the frame is static for 5 seconds.
+      if (this.cinematicPhase === "COUNTDOWN") {
+        const phaseElapsedSec = (now - this.cinematicPhaseChangedAt) / 1000;
+        const pushInT = clamp(phaseElapsedSec / 4, 0, 1);
+        const eased = pushInT * pushInT * (3 - 2 * pushInT);
+        radius = pp.radiusMax + (pp.radiusMin - pp.radiusMax) * eased;
+      }
+
+      // Post-fight push-in: during RESOLUTION, ease from radiusMax to a tight
+      // hero framing over ~1.5s, so the camera closes on the winner just as
+      // the victory emote plays (emote triggers at +600ms via DuelOrchestrator).
+      if (this.cinematicPhase === "RESOLUTION") {
+        const phaseElapsedSec = (now - this.cinematicPhaseChangedAt) / 1000;
+        const pushInT = clamp(phaseElapsedSec / 1.5, 0, 1);
+        const eased = pushInT * pushInT * (3 - 2 * pushInT);
+        const heroRadius = pp.radiusMin + 0.3;
+        radius = pp.radiusMax + (heroRadius - pp.radiusMax) * eased;
       }
 
       // Phase-aware phi (pitch angle) — smooth blend for close combat


### PR DESCRIPTION
## Summary

Hardens the streaming duel arena end-to-end — duels now actually run, finish cleanly, publish results on-chain reliably, and look better. Verified live against a deployed ` + "`DuelOutcomeOracle`" + ` on local anvil. Adds 14 regression tests, all validated by temporary rollback.

## Changes

**Duel lifecycle ([DuelOrchestrator.ts](packages/server/src/systems/StreamingDuelScheduler/managers/DuelOrchestrator.ts), [DuelCombatAI.ts](packages/server/src/duel/DuelCombatAI.ts))**
- Draw-path cleanup: timeout-draw now routes through ` + "`startResolution()`" + `, so arena bounds clear and autonomy restores (previously stuck until next duel).
- ` + "`startCombatAIs()`" + ` rollback on failure.
- Positioning: agents spawn on adjacent tiles (distance 1) instead of 16 — melee ` + "`startCombat`" + ` now succeeds first try.
- Weapon picker ` + "`>= 0`" + ` gate: previously kept any equipped item (wrong type included) when all scores tied at -1; ranged agents ended up holding swords + arrows.
- Combat perf: hoisted prayer map, sync short-circuit in ` + "`maybeActivateProtectionPrayer`" + `, memoised ` + "`detectOpponentAttackType`" + `.
- Trash-talk IIFE no longer chats after ` + "`stop()`" + `.

**Oracle / hyperbet path ([DuelArenaOraclePublisher.ts](packages/server/src/oracle/DuelArenaOraclePublisher.ts), [main.ts](packages/server/src/main.ts))**
- Bounded exponential-backoff retry (1s → 2.5s → 6s → 15s → 30s) with ` + "`setTimeout.unref()`" + ` and ` + "`destroy()`" + ` cancellation. Gives up cleanly after 6 attempts.
- Boot re-enqueue: records with ` + "`lastError`" + ` set from a mid-retry crash resume publishing on startup.
- Startup warning when ` + "`STREAMING_DUEL_ENABLED=true`" + ` but oracle disabled.

**Operator triage ([admin-routes.ts](packages/server/src/startup/routes/admin-routes.ts))**
- ` + "`GET /admin/duels/oracle/stuck`" + ` — list records with any failed target.
- ` + "`POST /admin/duels/oracle/clear/:duelId`" + ` — clear ` + "`lastError`" + `; ` + "`{forceRetry:true}`" + ` refires with full retry budget.

**Cinematic camera ([ClientCameraSystem.ts](packages/shared/src/systems/client/ClientCameraSystem.ts))**
- FIGHTING: wider FOV (46→54), higher angle, wider radius, more orbit.
- RESOLUTION: tighter hero framing, less top-down, winner-weighted focus.
- COUNTDOWN push-in: dynamic 4s smoothstep from ` + "`radiusMax`" + ` → ` + "`radiusMin`" + ` (replaces frozen pre-fight frame).
- RESOLUTION hero push-in: 1.5s ease to ` + "`radiusMin + 0.3`" + ` timed with the victory emote.

## Test plan

- [x] ` + "`bun x vitest run tests/unit/oracle src/systems/StreamingDuelScheduler`" + ` — 48 pass (34 existing + 14 new)
- [x] ` + "`bun run typecheck`" + ` — no new errors (2 pre-existing DuelCombatRole errors unchanged)
- [x] Each regression test verified by temporarily reverting the fix and confirming the test fails
- [x] End-to-end live: deployed ` + "`DuelOutcomeOracle`" + ` to local anvil, ran server, observed UPSERT(BETTING_OPEN) → UPSERT(LOCKED) → RESOLVE txs on block 17, 19, 37, 39; verified via ` + "`cast receipt`" + `
- [x] Observed boot re-enqueue fire in the wild when the retry scheduler caught a real nonce error mid-duel
- [x] Observed 10+ clean duel cycles post-positioning-fix with real kills (9 dmg vs 5 dmg in 30-100 attacks), vs pre-fix all-draws (474 attempts / 1 dmg)

⚠️ **Runbook note for ops**: running ` + "`node build/index.js`" + ` directly (bypassing ` + "`scripts/dev.mjs`" + `) requires ` + "`PUBLIC_CDN_URL=http://localhost:5555/game-assets`" + ` in the env, or the client has no assets. ` + "`dev.mjs`" + ` normally handles this via a health-check fallback.