### PR TITLE
Split terrain and compute stability out of #1178

### DIFF
--- a/packages/client/src/screens/StreamingMode.tsx
+++ b/packages/client/src/screens/StreamingMode.tsx
@@ -35,6 +35,7 @@ export interface StreamingState {
   type: "STREAMING_STATE_UPDATE";
   cycle: {
     cycleId: string;
+    duelId: string | null;
     phase: "IDLE" | "ANNOUNCEMENT" | "COUNTDOWN" | "FIGHTING" | "RESOLUTION";
     cycleStartTime: number;
     phaseStartTime: number;

--- a/packages/shared/src/index.client.ts
+++ b/packages/shared/src/index.client.ts
@@ -238,19 +238,7 @@ export { ClientRuntime } from "./systems/client/ClientRuntime"; // Client lifecy
 export { ClientAudio } from "./systems/client/ClientAudio";
 export { ClientLiveKit } from "./systems/client/ClientLiveKit";
 export { ClientInput } from "./systems/client/ClientInput";
-export {
-  attachEquipmentVisualToVRM,
-  extractEquipmentAttachmentData,
-  removeEquipmentVisual,
-  resolveEquipmentVisualData,
-  resolveEquipmentVisualUrls,
-} from "./systems/client/EquipmentVisualHelpers";
-export type {
-  EquipmentAttachmentData,
-  EquipmentVisualModelData,
-  EquipmentVisualStore,
-  EquipmentVisualUrlResolution,
-} from "./systems/client/EquipmentVisualHelpers";
+export * from "./systems/client/EquipmentVisualHelpers";
 export { ClientActions } from "./systems/client/ClientActions";
 export { DevStats } from "./systems/client/DevStats"; // FPS counter and dev performance telemetry
 export { EventBus } from "./systems/shared";

--- a/packages/shared/src/runtime/clientViewportMode.ts
+++ b/packages/shared/src/runtime/clientViewportMode.ts
@@ -5,6 +5,8 @@ interface HyperscapeViewportWindow extends Window {
   };
 }
 
+export type HyperscapeViewportMode = "spectator" | "stream" | "free";
+
 function parseTruthy(value: string | null | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
@@ -17,8 +19,11 @@ function parseTruthy(value: string | null | undefined): boolean {
 }
 
 function getWindowRef(win?: Window): HyperscapeViewportWindow | undefined {
+  if (win) {
+    return win as HyperscapeViewportWindow;
+  }
   if (typeof window === "undefined") return undefined;
-  return (win ?? window) as HyperscapeViewportWindow;
+  return window as HyperscapeViewportWindow;
 }
 
 function getSearchParams(
@@ -31,17 +36,52 @@ function getSearchParams(
   }
 }
 
+function normalizeViewportMode(
+  value: unknown,
+): HyperscapeViewportMode | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "spectator" ||
+    normalized === "stream" ||
+    normalized === "free"
+    ? normalized
+    : null;
+}
+
+function isStreamPath(pathname: string): boolean {
+  return /\/stream(?:\.html)?\/?$/.test(pathname);
+}
+
+export function getViewportMode(
+  win?: Window,
+): HyperscapeViewportMode | null {
+  const windowRef = getWindowRef(win);
+  if (!windowRef) return null;
+
+  const params = getSearchParams(windowRef);
+  const queryMode = normalizeViewportMode(params?.get("mode"));
+  if (queryMode) {
+    return queryMode;
+  }
+
+  return normalizeViewportMode(windowRef.__HYPERSCAPE_CONFIG__?.mode);
+}
+
 export function isStreamPageRoute(win?: Window): boolean {
   const windowRef = getWindowRef(win);
   if (!windowRef) return false;
 
   const pathname = windowRef.location.pathname.trim().toLowerCase();
-  if (pathname.endsWith("/stream.html") || pathname === "/stream.html") {
+  if (isStreamPath(pathname)) {
     return true;
   }
 
   const params = getSearchParams(windowRef);
   return (params?.get("page") || "").trim().toLowerCase() === "stream";
+}
+
+export function isDedicatedStreamViewport(win?: Window): boolean {
+  return isStreamPageRoute(win) || getViewportMode(win) === "stream";
 }
 
 export function isEmbeddedSpectatorViewport(win?: Window): boolean {
@@ -50,7 +90,7 @@ export function isEmbeddedSpectatorViewport(win?: Window): boolean {
 
   const params = getSearchParams(windowRef);
   const embeddedFromQuery = parseTruthy(params?.get("embedded"));
-  const modeFromQuery = (params?.get("mode") || "").trim().toLowerCase();
+  const modeFromQuery = normalizeViewportMode(params?.get("mode"));
 
   const embeddedFromConfig =
     windowRef.__HYPERSCAPE_EMBEDDED__ === true &&
@@ -62,5 +102,15 @@ export function isEmbeddedSpectatorViewport(win?: Window): boolean {
 }
 
 export function isStreamingLikeViewport(win?: Window): boolean {
-  return isStreamPageRoute(win) || isEmbeddedSpectatorViewport(win);
+  return isDedicatedStreamViewport(win) || isEmbeddedSpectatorViewport(win);
+}
+
+export function isStreamDebugEnabled(win?: Window): boolean {
+  const windowRef = getWindowRef(win);
+  if (!windowRef) return false;
+  const params = getSearchParams(windowRef);
+  return (
+    parseTruthy(params?.get("streamDebug")) ||
+    parseTruthy(params?.get("traceInit"))
+  );
 }

--- a/packages/shared/src/runtime/createClientWorld.ts
+++ b/packages/shared/src/runtime/createClientWorld.ts
@@ -52,6 +52,7 @@ import { ClientActions } from "../systems/client/ClientActions";
 import { ClientAudio } from "../systems/client/ClientAudio";
 import { ClientCameraSystem } from "../systems/client/ClientCameraSystem";
 import { DevStats } from "../systems/client/DevStats";
+import { DuelArenaVisualsSystem } from "../systems/client/DuelArenaVisualsSystem";
 import { PathfindingDebugSystem } from "../systems/client/PathfindingDebugSystem";
 import { BFSPathDebugSystem } from "../systems/client/BFSPathDebugSystem";
 import { WalkableTileDebugSystem } from "../systems/client/WalkableTileDebugSystem";
@@ -129,7 +130,10 @@ import { Particles } from "../systems/shared";
 import { Wind } from "../systems/shared";
 import { ClientTeleportEffectsSystem } from "../systems/client/ClientTeleportEffectsSystem";
 import type { SystemConstructor } from "../systems/shared/infrastructure/System";
-import { isStreamingLikeViewport } from "./clientViewportMode";
+import {
+  isDedicatedStreamViewport,
+  isStreamingLikeViewport,
+} from "./clientViewportMode";
 
 /**
  * Window extension for browser testing and debugging.
@@ -189,6 +193,8 @@ function replaceSystem(
  */
 export function createClientWorld() {
   const world = new World();
+  const isStreamingViewport = isStreamingLikeViewport();
+  const isDedicatedStreamCaptureViewport = isDedicatedStreamViewport();
   // ============================================================================
   // FRAME BUDGET MANAGER
   // ============================================================================
@@ -239,7 +245,9 @@ export function createClientWorld() {
   // Lifecycle and networking
   world.register("client-runtime", ClientRuntime); // Client lifecycle, diagnostics
   replaceSystem(world, "stage", Stage); // Three.js scene graph root
-  world.register("livekit", ClientLiveKit); // Voice chat client
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("livekit", ClientLiveKit); // Voice chat client
+  }
   world.register("network", ClientNetwork); // WebSocket connection to server
   world.register("loader", ClientLoader); // Asset loading and caching
 
@@ -248,18 +256,24 @@ export function createClientWorld() {
   world.register("environment", Environment); // Lighting, shadows, CSM
 
   // Dev tools (only active in dev mode)
-  world.register("devStats", DevStats); // FPS counter and performance telemetry
-  world.register("pathfindingDebug", PathfindingDebugSystem); // Press 'P' to toggle
-  world.register("bfsPathDebug", BFSPathDebugSystem); // Press 'B' (with F5 open) to toggle
-  world.register("walkableDebug", WalkableTileDebugSystem); // Press 'W' (with F5 open) to toggle
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("devStats", DevStats); // FPS counter and performance telemetry
+    world.register("pathfindingDebug", PathfindingDebugSystem); // Press 'P' to toggle
+    world.register("bfsPathDebug", BFSPathDebugSystem); // Press 'B' (with F5 open) to toggle
+    world.register("walkableDebug", WalkableTileDebugSystem); // Press 'W' (with F5 open) to toggle
+  }
 
   // Audio systems
-  world.register("audio", ClientAudio); // 3D spatial audio
-  world.register("music", MusicSystem); // Background music player
+  world.register("audio", ClientAudio); // 3D spatial audio / combat SFX
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("music", MusicSystem); // Background music player
+  }
 
   // Input and interaction
-  world.register("controls", ClientInput); // Keyboard, mouse, touch input
-  world.register("actions", ClientActions); // Executable player actions
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("controls", ClientInput); // Keyboard, mouse, touch input
+    world.register("actions", ClientActions); // Executable player actions
+  }
 
   // UI and preferences
   world.register("prefs", ClientInterface); // User preferences and UI state
@@ -268,7 +282,7 @@ export function createClientWorld() {
   // Streaming/spectator viewports skip physics entirely — they don't need
   // collision detection and PhysX WASM can crash in the Playwright capture
   // browser. RigidBody/Collider nodes already guard against missing PHYSX.
-  if (!isStreamingLikeViewport()) {
+  if (!isStreamingViewport) {
     replaceSystem(world, "physics", Physics);
   } else {
     // The World constructor registers a default PhysicsSystem whose init()
@@ -293,6 +307,12 @@ export function createClientWorld() {
   world.register("terrain", TerrainSystem);
   world.register("bridges", BridgeSystem);
 
+  // Dedicated broadcast capture is duel-first: arena geometry must mount before
+  // decorative world systems such as vegetation/towns can delay startup.
+  if (isDedicatedStreamCaptureViewport) {
+    world.register("duel-arena-visuals", DuelArenaVisualsSystem);
+  }
+
   // ============================================================================
   // VEGETATION SYSTEM
   // ============================================================================
@@ -313,8 +333,10 @@ export function createClientWorld() {
   // that VegetationSystem receives to regenerate grass at correct heights
 
   world.register("towns", TownSystem);
-  world.register("pois", POISystem);
-  // world.register("roads", RoadNetworkSystem);
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("pois", POISystem);
+  }
+  world.register("roads", RoadNetworkSystem);
 
   // ============================================================================
   // BUILDING RENDERING SYSTEM
@@ -369,7 +391,10 @@ export function createClientWorld() {
   // ============================================================================
   // DOCK SYSTEM
   // ============================================================================
-  world.register("docks", ProceduralDocks);
+  // Procedural docks for ponds and lakes — collision + mesh on client
+  if (!isDedicatedStreamCaptureViewport) {
+    world.register("docks", ProceduralDocks);
+  }
 
   // ============================================================================
   // THREE.JS SETUP
@@ -450,15 +475,16 @@ export function createClientWorld() {
         console.log(
           "[createClientWorld] Skipping tree cache pre-warm and PhysX for stream/spectator viewport",
         );
-        // CRITICAL: We still need to load PhysX even if we skip tree pre-warming!
-        // In stream mode, there is no local player, so PlayerLocal won't trigger the load either.
-        // We trigger it here in the background so colliders and static actors can initialize.
-        waitForPhysX("StreamInitialization", 120000).catch((err) => {
-          console.warn(
-            "[createClientWorld] Background PhysX load failed:",
-            err,
-          );
-        });
+        if (!isDedicatedStreamCaptureViewport) {
+          // Embedded spectator views still benefit from a background PhysX load
+          // for collision-backed terrain probes without blocking first paint.
+          waitForPhysX("StreamInitialization", 120000).catch((err) => {
+            console.warn(
+              "[createClientWorld] Background PhysX load failed:",
+              err,
+            );
+          });
+        }
       }
 
       // Mob impostor pre-warming disabled — VRM mobs use on-demand baking.

--- a/packages/shared/src/systems/client/ClientCameraSystem.ts
+++ b/packages/shared/src/systems/client/ClientCameraSystem.ts
@@ -1597,6 +1597,7 @@ export class ClientCameraSystem extends SystemBase {
     targetFov: number;
     orbitAmplitude: number;
     focusBias: number;
+    reverseAngleCooldownMs: number;
   } {
     switch (this.cinematicPhase) {
       case "ANNOUNCEMENT":
@@ -1608,6 +1609,7 @@ export class ClientCameraSystem extends SystemBase {
           targetFov: 48,
           orbitAmplitude: 0.08,
           focusBias: 0.35,
+          reverseAngleCooldownMs: 20_000,
         };
       case "COUNTDOWN":
         return {
@@ -1618,26 +1620,38 @@ export class ClientCameraSystem extends SystemBase {
           targetFov: 42,
           orbitAmplitude: 0.02,
           focusBias: 0.85,
+          reverseAngleCooldownMs: 20_000,
         };
       case "FIGHTING":
         return {
           radiusMin: 4.0,
           radiusMax: 7.5,
           basePhi: Math.PI * 0.27,
-          driftSpeed: 0.018,
+          driftSpeed: 0.035,
           targetFov: 46,
-          orbitAmplitude: 0.07,
+          // Orbit amplitude raised from 0.07 to 0.25 so the per-frame pixel
+          // delta exceeds CDP screencast JPEG quality-80 deduplication. At
+          // 0.07 rad (~4°) the camera drift was too subtle for the capture
+          // pipeline to distinguish consecutive frames — CDP marked 98% as
+          // "repeated", collapsing effective capture to 2 unique FPS. At
+          // 0.25 rad (~14°) combined with the multi-frequency orbit sines,
+          // the per-frame shift is ~40-80 px at 720p/46° FOV, well above
+          // JPEG detection threshold. Drift speed also bumped (0.018→0.035)
+          // for more dynamic camera motion during fights.
+          orbitAmplitude: 0.25,
           focusBias: 0.5,
+          reverseAngleCooldownMs: 14_000,
         };
       case "RESOLUTION":
         return {
           radiusMin: 5.5,
           radiusMax: 8,
           basePhi: Math.PI * 0.44,
-          driftSpeed: 0.025,
+          driftSpeed: 0.03,
           targetFov: 45,
-          orbitAmplitude: 0.06,
+          orbitAmplitude: 0.2,
           focusBias: 0.5,
+          reverseAngleCooldownMs: 20_000,
         };
       default:
         return {
@@ -1648,6 +1662,7 @@ export class ClientCameraSystem extends SystemBase {
           targetFov: 52,
           orbitAmplitude: 0.1,
           focusBias: 0.5,
+          reverseAngleCooldownMs: 20_000,
         };
     }
   }
@@ -2160,7 +2175,7 @@ export class ClientCameraSystem extends SystemBase {
   }
 
   /**
-   * When streaming duel HP drops, add punch-in + shake so hits read on broadcast.
+   * React to HP changes from streaming state so hits read on broadcast.
    */
   private tickStreamingCombatFeedback(deltaSeconds: number): void {
     if (!this.cinematicEnabled || deltaSeconds <= 0) return;
@@ -2185,17 +2200,28 @@ export class ClientCameraSystem extends SystemBase {
       const lost = prev - next;
       const severity = lost / maxHp;
       this.cinematicShakeIntensity = Math.min(
-        0.32,
-        this.cinematicShakeIntensity + 0.055 + severity * 0.22,
+        0.4,
+        this.cinematicShakeIntensity + 0.06 + severity * 0.35,
       );
       this.cinematicPunchIn = Math.min(
         1,
-        this.cinematicPunchIn + 0.32 + severity * 0.25,
+        this.cinematicPunchIn + 0.35 + severity * 0.3,
       );
     };
 
     applyHit(this.streamingPrevAgent1Hp, h1, m1);
     applyHit(this.streamingPrevAgent2Hp, h2, m2);
+
+    const lowestHpPct = Math.min(h1 / m1, h2 / m2);
+    if (lowestHpPct < 0.15 && lowestHpPct > 0) {
+      const urgency = 1 - lowestHpPct / 0.15;
+      this.cinematicDramaticLow = Math.max(
+        this.cinematicDramaticLow,
+        urgency * 0.6,
+      );
+    } else {
+      this.cinematicDramaticLow *= Math.exp(-1.5 * deltaSeconds);
+    }
 
     this.streamingPrevAgent1Hp = h1;
     this.streamingPrevAgent2Hp = h2;
@@ -2421,7 +2447,9 @@ export class ClientCameraSystem extends SystemBase {
         if (timeSinceReverse > this.cinematicNextReverseCooldown) {
           reverseAngleBoost = Math.PI * 0.3;
           this.cinematicLastReverseAt = now;
-          this.cinematicNextReverseCooldown = 18000 + Math.random() * 8000;
+          const baseCooldown = pp.reverseAngleCooldownMs;
+          this.cinematicNextReverseCooldown =
+            baseCooldown - 2000 + Math.random() * 6000;
           // Reset theta cache so LOS scorer accepts the new angle
           this.cinematicThetaCacheValid = false;
           this.cinematicLastLosRefreshAt = 0;
@@ -2478,8 +2506,9 @@ export class ClientCameraSystem extends SystemBase {
           pp.basePhi + closeCombatBlend * (Math.PI * 0.38 - pp.basePhi);
         const phiVariation =
           Math.sin(t * 0.13) * 0.015 + Math.sin(t * 0.07) * 0.01;
+        const dramaticLowOffset = this.cinematicDramaticLow * -0.12;
         phi = clamp(
-          closeCombatPhi + phiVariation,
+          closeCombatPhi + phiVariation + dramaticLowOffset,
           this.settings.minPolarAngle + 0.03,
           this.settings.maxPolarAngle - 0.03,
         );

--- a/packages/shared/src/systems/client/ClientRuntime.ts
+++ b/packages/shared/src/systems/client/ClientRuntime.ts
@@ -301,7 +301,12 @@ export class ClientRuntime extends System {
       const searchParams = new URLSearchParams(window.location.search);
       const page = (searchParams.get("page") || "").trim().toLowerCase();
       const mode = (searchParams.get("mode") || "").trim().toLowerCase();
-      if (page === "stream" || mode === "spectator" || isStreamPageRoute()) {
+      if (
+        page === "stream" ||
+        mode === "spectator" ||
+        mode === "stream" ||
+        isStreamPageRoute()
+      ) {
         return true;
       }
       if (parseTruthy(searchParams.get("disableVisibilityThrottle"))) {

--- a/packages/shared/src/systems/client/DuelArenaVisualsSystem.ts
+++ b/packages/shared/src/systems/client/DuelArenaVisualsSystem.ts
@@ -56,14 +56,14 @@ import {
   type DuelArenaConfig,
 } from "../../data/duel-manifest";
 import {
-  LOBBY_CENTER_X,
-  LOBBY_CENTER_Z,
-  LOBBY_WIDTH,
-  LOBBY_LENGTH,
   HOSPITAL_CENTER_X,
   HOSPITAL_CENTER_Z,
-  HOSPITAL_WIDTH,
   HOSPITAL_LENGTH,
+  HOSPITAL_WIDTH,
+  LOBBY_CENTER_X,
+  LOBBY_CENTER_Z,
+  LOBBY_LENGTH,
+  LOBBY_WIDTH,
 } from "../../data/arena-layout";
 
 // Arena grid size/position: getDuelArenaConfig() at runtime (see duel-manifest / ArenaPoolManager).
@@ -673,11 +673,17 @@ export class DuelArenaVisualsSystem extends System {
       const quantized = vec2(tslFloor(wp.x.add(0.5)), tslFloor(wp.z.add(0.5)));
       const phase = tslHash(quantized).mul(6.28);
 
+      // Per-brazier speed variation (±15%) so they don't cycle in lockstep
+      const speedJitter = tslHash(quantized.add(vec2(31.5, 97.2)));
+      const speedScale = float(0.85).add(speedJitter.mul(0.3)); // 0.85–1.15
+
       // Multi-frequency sine flicker + high-freq noise (matches old PointLight behavior)
-      const flicker = sin(t.mul(10.0).add(phase))
+      const flicker = sin(t.mul(10.0).mul(speedScale).add(phase))
         .mul(0.15)
-        .add(sin(t.mul(7.3).add(phase.mul(1.7))).mul(0.08));
-      const noise = fract(sin(t.mul(43.7).add(phase)).mul(9827.3)).mul(0.05);
+        .add(sin(t.mul(7.3).mul(speedScale).add(phase.mul(1.7))).mul(0.08));
+      const noise = fract(
+        sin(t.mul(43.7).mul(speedScale).add(phase)).mul(9827.3),
+      ).mul(0.05);
       const intensity = float(0.6).add(flicker).add(noise);
 
       // Only the top face (fire opening) glows; outer shell stays dark.

--- a/packages/shared/src/systems/client/EquipmentVisualHelpers.ts
+++ b/packages/shared/src/systems/client/EquipmentVisualHelpers.ts
@@ -28,6 +28,15 @@ export interface EquipmentVisualStore {
   [slot: string]: THREE.Object3D | undefined;
 }
 
+const EQUIPMENT_MODEL_FALLBACKS: Readonly<Record<string, string>> =
+  Object.freeze({
+    iron_arrow: "asset://models/arrows/arrows-bronze/arrows-bronze.glb",
+    steel_arrow: "asset://models/arrows/arrows-bronze/arrows-bronze.glb",
+    mithril_arrow: "asset://models/arrows/arrows-bronze/arrows-bronze.glb",
+    adamant_arrow: "asset://models/arrows/arrows-bronze/arrows-bronze.glb",
+    rune_arrow: "asset://models/arrows/arrows-bronze/arrows-bronze.glb",
+  });
+
 export function removeEquipmentVisual(
   store: EquipmentVisualStore,
   slot: string,
@@ -69,6 +78,11 @@ export function resolveEquipmentVisualUrls(options: {
 
   let equippedModelPath = itemData?.equippedModelPath;
   let modelPath = itemData?.modelPath;
+  const explicitlyModelLess =
+    itemData?.equippedModelPath === null ||
+    itemData?.modelPath === null ||
+    fallbackItemData?.equippedModelPath === null ||
+    fallbackItemData?.modelPath === null;
 
   if (equippedModelPath === null) {
     return null;
@@ -93,6 +107,17 @@ export function resolveEquipmentVisualUrls(options: {
   if (modelPath && typeof modelPath === "string") {
     return {
       primaryUrl: modelPath.replace("asset://", `${assetsUrl}/`),
+      fallbackUrl: null,
+    };
+  }
+
+  if (explicitlyModelLess) {
+    const fallbackAssetPath = EQUIPMENT_MODEL_FALLBACKS[itemId];
+    if (!fallbackAssetPath) {
+      return null;
+    }
+    return {
+      primaryUrl: fallbackAssetPath.replace("asset://", `${assetsUrl}/`),
       fallbackUrl: null,
     };
   }

--- a/packages/shared/src/systems/client/EquipmentVisualSystem.ts
+++ b/packages/shared/src/systems/client/EquipmentVisualSystem.ts
@@ -27,8 +27,8 @@ import type { World } from "../../types";
 import type { VRM } from "@pixiv/three-vrm";
 import { EQUIPMENT_SLOT_NAMES } from "../../constants/EquipmentConstants";
 import type { Entity } from "../../entities/Entity";
-import { AttackType } from "../../types/game/item-types";
 import { getItem } from "../../data/items";
+import { AttackType } from "../../types/game/item-types";
 import {
   attachEquipmentVisualToVRM,
   removeEquipmentVisual,

--- a/packages/shared/src/systems/client/__tests__/EquipmentVisualHelpers.test.ts
+++ b/packages/shared/src/systems/client/__tests__/EquipmentVisualHelpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveEquipmentVisualUrls } from "../EquipmentVisualHelpers";
+
+describe("EquipmentVisualHelpers", () => {
+  it("uses the packaged arrow visual when an ammo item is explicitly model-less", () => {
+    const urls = resolveEquipmentVisualUrls({
+      assetsUrl: "https://example.com/game-assets",
+      itemId: "iron_arrow",
+      slot: "arrows",
+      itemData: {
+        modelPath: null,
+        equippedModelPath: undefined,
+      },
+    });
+
+    expect(urls).toEqual({
+      primaryUrl:
+        "https://example.com/game-assets/models/arrows/arrows-bronze/arrows-bronze.glb",
+      fallbackUrl: null,
+    });
+  });
+
+  it("keeps heuristic model resolution for regular equipment items", () => {
+    const urls = resolveEquipmentVisualUrls({
+      assetsUrl: "https://example.com/game-assets",
+      itemId: "iron_sword",
+      slot: "mainHand",
+      itemData: {
+        modelPath: undefined,
+        equippedModelPath: undefined,
+      },
+    });
+
+    expect(urls).toEqual({
+      primaryUrl:
+        "https://example.com/game-assets/models/swords-old/sword-iron-aligned.glb",
+      fallbackUrl:
+        "https://example.com/game-assets/models/swords-old/sword-iron/sword-iron-aligned.glb",
+    });
+  });
+});

--- a/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
+++ b/packages/shared/src/systems/shared/infrastructure/SystemLoader.ts
@@ -398,7 +398,9 @@ export async function registerSystems(world: World): Promise<void> {
     process.env.DUEL_ARENA_VISUALS_ENABLED !== "false";
   if (duelArenaVisualsEnabled) {
     try {
-      world.register("duel-arena-visuals", DuelArenaVisualsSystem);
+      if (!world.getSystem("duel-arena-visuals")) {
+        world.register("duel-arena-visuals", DuelArenaVisualsSystem);
+      }
     } catch (err) {
       console.error(
         "[SystemLoader] Failed to register DuelArenaVisualsSystem:",

--- a/packages/shared/src/systems/shared/world/Environment.ts
+++ b/packages/shared/src/systems/shared/world/Environment.ts
@@ -2,6 +2,7 @@ import THREE, { CSMShadowNode } from "../../../extras/three/three";
 import { MeshBasicNodeMaterial } from "three/webgpu";
 
 import { Node as NodeClass } from "../../../nodes/Node";
+import { isDedicatedStreamViewport } from "../../../runtime/clientViewportMode";
 import { System } from "../infrastructure/System";
 
 // NOTE: Import directly to avoid circular dependency through barrel file
@@ -48,11 +49,13 @@ const _sunDirection = new THREE.Vector3(0, -1, 0);
 // Default: false — uses a single 2048 shadow map centered on the player.
 export function isCsmEnabled(): boolean {
   try {
-    if (
-      typeof import.meta !== "undefined" &&
-      (import.meta as any).env?.ENABLE_CSM
-    )
-      return (import.meta as any).env.ENABLE_CSM === "true";
+    const metaEnv = (
+      import.meta as unknown as {
+        env?: { ENABLE_CSM?: string };
+      }
+    ).env;
+    if (typeof import.meta !== "undefined" && metaEnv?.ENABLE_CSM)
+      return metaEnv.ENABLE_CSM === "true";
     if (typeof process !== "undefined" && process.env?.ENABLE_CSM)
       return process.env.ENABLE_CSM === "true";
   } catch {
@@ -179,6 +182,10 @@ export class Environment extends System {
   private ambientLight: THREE.AmbientLight | null = null;
 
   private isClientWithGraphics: boolean = false;
+  private deferredEnvironmentAssetTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  private optionalEnvironmentAssetsStarted = false;
+  private destroyed = false;
 
   constructor(world: World) {
     super(world);
@@ -187,6 +194,9 @@ export class Environment extends System {
   override init(
     options: WorldOptions & { baseEnvironment?: BaseEnvironment },
   ): Promise<void> {
+    this.destroyed = false;
+    this.optionalEnvironmentAssetsStarted = false;
+    this.deferredEnvironmentAssetTimer = null;
     this.base = options.baseEnvironment || {};
 
     // Determine if this is a client with graphics capabilities
@@ -216,7 +226,36 @@ export class Environment extends System {
     // Create ambient lighting for day/night visibility
     this.createAmbientLighting();
 
-    this.updateSky();
+    const dedicatedStreamViewport = isDedicatedStreamViewport();
+
+    this.applyBaselineFog();
+    if (!dedicatedStreamViewport) {
+      void this.updateSky().catch((err) => {
+        console.warn("[Environment] Failed to apply initial sky state:", err);
+      });
+    }
+
+    // No environment map - using planar reflections for water, toon/rough style for everything else
+    this.clearSceneEnvironmentMap();
+
+    this.world.settings?.on("change", this.onSettingsChange);
+    this.world.prefs?.on("change", this.onPrefsChange);
+
+    if (this.world.graphics) {
+      this.world.graphics.on("resize", this.onViewportResize);
+    }
+
+    if (dedicatedStreamViewport) {
+      this.deferStreamOptionalEnvironmentAssetsUntilArenaReady();
+      return;
+    }
+
+    await this.startOptionalEnvironmentAssets();
+  }
+
+  private async startOptionalEnvironmentAssets(): Promise<void> {
+    if (this.optionalEnvironmentAssetsStarted || this.destroyed) return;
+    this.optionalEnvironmentAssetsStarted = true;
 
     // Load initial model (non-blocking - don't let model errors break sky)
     try {
@@ -228,34 +267,101 @@ export class Environment extends System {
       );
     }
 
-    // Enhanced dynamic sky (client-only) - must run even if model fails
-    this.skySystem = new SkySystem(this.world);
-    await this.skySystem.init({} as unknown as WorldOptions);
-    this.skySystem.start();
+    if (this.destroyed) return;
 
-    // Initialize exposure based on current time of day to avoid jarring transitions
-    // when joining at night (otherwise exposure would lerp from 0.85 day → 1.7 night)
-    this.initializeExposure();
+    try {
+      // Enhanced dynamic sky (client-only) - must run even if model fails.
+      const skySystem = new SkySystem(this.world);
+      await skySystem.init({} as unknown as WorldOptions);
 
-    // Ensure legacy sky sphere never occludes dynamic sky
-    if (this.sky) {
-      const mat = this.sky.material as THREE.MeshBasicMaterial;
-      mat.depthWrite = false;
-      this.sky.visible = false;
+      if (this.destroyed) {
+        skySystem.destroy();
+        return;
+      }
+
+      this.skySystem = skySystem;
+      this.skySystem.start();
+
+      // Initialize exposure based on current time of day to avoid jarring transitions
+      // when joining at night (otherwise exposure would lerp from 0.85 day to 1.7 night).
+      this.initializeExposure();
+
+      // Ensure legacy sky sphere never occludes dynamic sky
+      if (this.sky) {
+        const mat = this.sky.material as THREE.MeshBasicMaterial;
+        mat.depthWrite = false;
+        this.sky.visible = false;
+      }
+      // Re-evaluate sky state now that SkySystem exists
+      await this.updateSky();
+    } catch (err) {
+      console.warn(
+        "[Environment] Failed to initialize dynamic sky (continuing without):",
+        err,
+      );
     }
-    // Re-evaluate sky state now that SkySystem exists
-    await this.updateSky();
 
-    // No environment map - using planar reflections for water, toon/rough style for everything else
+    this.clearSceneEnvironmentMap();
+  }
+
+  private deferStreamOptionalEnvironmentAssetsUntilArenaReady(): void {
+    if (this.deferredEnvironmentAssetTimer) return;
+
+    const waitForArenaVisuals = () => {
+      this.deferredEnvironmentAssetTimer = null;
+      if (this.destroyed || this.optionalEnvironmentAssetsStarted) return;
+
+      const arenaVisuals = this.world.getSystem("duel-arena-visuals") as
+        | { isReady?: () => boolean }
+        | undefined;
+      const arenaReady =
+        typeof arenaVisuals?.isReady === "function" && arenaVisuals.isReady();
+
+      if (!arenaReady) {
+        this.deferredEnvironmentAssetTimer = setTimeout(
+          waitForArenaVisuals,
+          250,
+        );
+        return;
+      }
+
+      void this.startOptionalEnvironmentAssets().catch((err) => {
+        console.warn(
+          "[Environment] Deferred stream environment asset load failed:",
+          err,
+        );
+      });
+    };
+
+    this.deferredEnvironmentAssetTimer = setTimeout(waitForArenaVisuals, 0);
+  }
+
+  private applyBaselineFog(): void {
+    if (!this.isClientWithGraphics || !this.world.stage?.scene) return;
+
+    const fogNear = this.base.fogNear ?? FOG_NEAR;
+    const fogFar = this.base.fogFar ?? FOG_FAR;
+    const fogColor = this.base.fogColor ?? "#d4c8b8";
+    this.world.stage.scene.fog = new THREE.Fog(
+      new THREE.Color(fogColor),
+      fogNear as number,
+      fogFar as number,
+    );
+    this.skyInfo = {
+      bgUrl: this.base.bg,
+      hdrUrl: this.base.hdr,
+      sunDirection: this.base.sunDirection || _sunDirection,
+      sunIntensity: this.base.sunIntensity || 1,
+      sunColor: this.base.sunColor || "#ffffff",
+      fogNear,
+      fogFar,
+      fogColor,
+    };
+  }
+
+  private clearSceneEnvironmentMap(): void {
     if (this.world.stage?.scene) {
       this.world.stage.scene.environment = null;
-    }
-
-    this.world.settings?.on("change", this.onSettingsChange);
-    this.world.prefs?.on("change", this.onPrefsChange);
-
-    if (this.world.graphics) {
-      this.world.graphics.on("resize", this.onViewportResize);
     }
   }
 
@@ -439,6 +545,12 @@ export class Environment extends System {
   }
 
   override destroy(): void {
+    this.destroyed = true;
+    if (this.deferredEnvironmentAssetTimer) {
+      clearTimeout(this.deferredEnvironmentAssetTimer);
+      this.deferredEnvironmentAssetTimer = null;
+    }
+
     if (this.skySystem) {
       this.skySystem.destroy();
       this.skySystem = undefined;
@@ -1124,14 +1236,30 @@ export class Environment extends System {
 
   onSettingsChange = (changes: { model?: string | { url?: string } }) => {
     if (changes.model) {
-      this.updateModel();
+      if (
+        isDedicatedStreamViewport() &&
+        !this.optionalEnvironmentAssetsStarted
+      ) {
+        return;
+      }
+      void this.updateModel().catch((err) => {
+        console.warn("[Environment] Failed to update environment model:", err);
+      });
     }
   };
 
   onPrefsChange = (changes: { shadows?: string }) => {
     if (changes.shadows) {
       this.buildSunLight();
-      this.updateSky();
+      if (
+        isDedicatedStreamViewport() &&
+        !this.optionalEnvironmentAssetsStarted
+      ) {
+        return;
+      }
+      void this.updateSky().catch((err) => {
+        console.warn("[Environment] Failed to update sky preferences:", err);
+      });
     }
   };
 

--- a/packages/shared/src/systems/shared/world/GLBResourceInstancer.ts
+++ b/packages/shared/src/systems/shared/world/GLBResourceInstancer.ts
@@ -22,13 +22,7 @@ import {
   GPU_VEG_CONFIG,
   type DissolveMaterial,
 } from "./GPUMaterials";
-import {
-  getLODDistances,
-  inferLOD1Path,
-  inferLOD2Path,
-  resolveLOD1ModelPath,
-  resolveLOD2ModelPath,
-} from "./LODConfig";
+import { getLODDistances, inferLOD1Path, inferLOD2Path } from "./LODConfig";
 
 const MAX_INSTANCES = 512;
 
@@ -71,14 +65,11 @@ interface ModelPool {
 
 const resourceLOD = getLODDistances("resource");
 
-function hasExplicitLODPath(path?: string | null): path is string {
-  return typeof path === "string" && path.trim().length > 0;
-}
-
 let scene: THREE.Scene | null = null;
 let world: World | null = null;
 const pools = new Map<string, ModelPool>();
 const entityToModel = new Map<string, string>();
+const missingLodModelPaths = new Set<string>();
 
 function extractGeometryAndMaterial(
   root: THREE.Object3D,
@@ -163,10 +154,19 @@ async function loadLODModel(path: string): Promise<{
   geometry: THREE.BufferGeometry;
   material: THREE.Material;
 } | null> {
+  if (missingLodModelPaths.has(path)) {
+    return null;
+  }
+
   try {
     const { scene: lodScene } = await modelCache.loadModel(path, world!);
     return extractGeometryAndMaterial(lodScene);
-  } catch {
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message.toLowerCase() : String(error);
+    if (message.includes("404") || message.includes("not found")) {
+      missingLodModelPaths.add(path);
+    }
     return null;
   }
 }
@@ -217,11 +217,19 @@ async function ensureModelPool(
     world!.setupMaterial(lod0Material);
     const lod0Pool = createLODPool(lod0Data.geometry, lod0Material);
 
+    const shouldInferLodPaths = !modelPath.includes("/models/mining-rocks/");
+    const inferredLod1ModelPath = shouldInferLodPaths
+      ? inferLOD1Path(modelPath)
+      : null;
+    const inferredLod2ModelPath = shouldInferLodPaths
+      ? inferLOD2Path(modelPath)
+      : null;
+
     // LOD1 — explicit path first, fall back to inferred naming convention
     let lod1Pool: LODPool | null = null;
-    const resolvedLod1Path = resolveLOD1ModelPath(modelPath, lod1ModelPath);
-    const lod1Data = resolvedLod1Path
-      ? await loadLODModel(resolvedLod1Path)
+    const lod1CandidatePath = lod1ModelPath ?? inferredLod1ModelPath;
+    const lod1Data = lod1CandidatePath
+      ? await loadLODModel(lod1CandidatePath)
       : null;
     if (lod1Data) {
       const lod1Material = createDissolveMaterial(
@@ -230,8 +238,10 @@ async function ensureModelPool(
       );
       world!.setupMaterial(lod1Material);
       lod1Pool = createLODPool(lod1Data.geometry, lod1Material);
-    } else if (hasExplicitLODPath(lod1ModelPath)) {
-      const lod1Inferred = await loadLODModel(inferLOD1Path(modelPath));
+    } else if (lod1ModelPath) {
+      const lod1Inferred = inferredLod1ModelPath
+        ? await loadLODModel(inferredLod1ModelPath)
+        : null;
       if (lod1Inferred) {
         const lod1Material = createDissolveMaterial(
           lod1Inferred.material,
@@ -244,9 +254,9 @@ async function ensureModelPool(
 
     // LOD2 — explicit path first, fall back to inferred naming convention
     let lod2Pool: LODPool | null = null;
-    const resolvedLod2Path = resolveLOD2ModelPath(modelPath, lod2ModelPath);
-    const lod2Data = resolvedLod2Path
-      ? await loadLODModel(resolvedLod2Path)
+    const lod2CandidatePath = lod2ModelPath ?? inferredLod2ModelPath;
+    const lod2Data = lod2CandidatePath
+      ? await loadLODModel(lod2CandidatePath)
       : null;
     if (lod2Data) {
       const lod2Material = createDissolveMaterial(
@@ -255,8 +265,10 @@ async function ensureModelPool(
       );
       world!.setupMaterial(lod2Material);
       lod2Pool = createLODPool(lod2Data.geometry, lod2Material);
-    } else if (hasExplicitLODPath(lod2ModelPath)) {
-      const lod2Inferred = await loadLODModel(inferLOD2Path(modelPath));
+    } else if (lod2ModelPath) {
+      const lod2Inferred = inferredLod2ModelPath
+        ? await loadLODModel(inferredLod2ModelPath)
+        : null;
       if (lod2Inferred) {
         const lod2Material = createDissolveMaterial(
           lod2Inferred.material,

--- a/packages/shared/src/systems/shared/world/TerrainSystem.ts
+++ b/packages/shared/src/systems/shared/world/TerrainSystem.ts
@@ -32,6 +32,7 @@ import type { ShorelineConfig, BiomeNoiseSet } from "./TerrainHeightParams";
 import { BiomeType, DEFAULT_BIOME, BIOME_LIST } from "./TerrainBiomeTypes";
 import { WaterBodyRegistry } from "./WaterBodyRegistry";
 import type { BridgeSystem } from "./BridgeSystem";
+
 // Import terrain generator from procgen package
 import {
   TerrainGenerator,
@@ -75,10 +76,7 @@ import {
   // generatePlants, // DISABLED - plants not working/looking good yet
   type ResourceGenerationContext,
 } from "./BiomeResourceGenerator";
-import {
-  getTreeConfigForBiome,
-  getGrassConfigForBiome,
-} from "./TerrainBiomeTypes";
+import { getTreeConfigForBiome } from "./TerrainBiomeTypes";
 import {
   setProcgenRockWorld,
   addRockInstance,
@@ -102,7 +100,6 @@ import {
   updateTerrainVertexLights,
   createTerrainMaterial,
   TerrainUniforms,
-  computeTerrainColorCPU,
 } from "./TerrainShader";
 import { isLamppostLightTextureReady } from "./LamppostLightMask";
 import { isCsmEnabled } from "./Environment";
@@ -115,16 +112,14 @@ import {
   type GPURoadSegment,
 } from "../../../utils/compute";
 import {
+  isDedicatedStreamViewport,
+  isEmbeddedSpectatorViewport,
+  isStreamDebugEnabled,
+} from "../../../runtime/clientViewportMode";
+import {
   TerrainVisualManager,
   type VisualManagerTerrainProvider,
 } from "./TerrainVisualManager";
-import { WaterVisualManager } from "./WaterVisualManager";
-import {
-  GrassVisualManager,
-  type GrassWorkerSetup,
-} from "./GrassVisualManager";
-import { terminateGrassWorkerPool } from "../../../utils/workers/GrassWorker";
-import { CompositeQuadTreeListener } from "./TerrainQuadTree";
 import type { QuadChunkWorkerConfig } from "../../../utils/workers/QuadChunkWorker";
 import { terminateQuadChunkWorkerPool } from "../../../utils/workers/QuadChunkWorker";
 
@@ -133,6 +128,11 @@ const ROAD_BLEND_WIDTH = 0.5; // Extra blend distance beyond road width (meters)
 const TERRAIN_ROAD_INFLUENCE_DEBUG =
   process.env.TERRAIN_ROAD_INFLUENCE_DEBUG === "true";
 const TERRAIN_TIMING_DEBUG = process.env.TERRAIN_TIMING_DEBUG === "true";
+
+function shouldEmitVerboseTerrainBootLogs(): boolean {
+  if (typeof window === "undefined") return true;
+  return !isDedicatedStreamViewport() || isStreamDebugEnabled();
+}
 /** Maximum entries retained in pendingSerializationData to prevent unbounded growth */
 const MAX_PENDING_SERIALIZATION_ENTRIES = 100;
 
@@ -223,6 +223,13 @@ export class TerrainSystem extends System {
   private pendingTileSet = new Set<string>();
   private pendingCollisionKeys: string[] = [];
   private pendingCollisionSet = new Set<string>();
+  // Buffer for heightData computed during createTileGeometry() before the
+  // corresponding tile object has been inserted into this.terrainTiles. Without
+  // this, storeHeightData() silently no-ops during initial tile creation and
+  // bakeWalkabilityFlags() then falls through to expensive noise-based
+  // getHeightAtComputed() for every sample (observed 2026-04-15: ~900ms per
+  // tile bake instead of the intended ~1-2ms).
+  private _pendingTileHeightData = new Map<string, number[]>();
   // Deferred walkability baking queue — spreads 10,000 iterations across ticks
   private pendingWalkabilityTiles: Array<{ tileX: number; tileZ: number }> = [];
   private walkabilityProgress: {
@@ -246,6 +253,7 @@ export class TerrainSystem extends System {
   private _tempVec2_2 = new THREE.Vector2();
   private _tempVec2_3 = new THREE.Vector2(); // For road distance calculations
   private _tempBox3 = new THREE.Box3();
+  private _tempColor = new THREE.Color(); // For biome color parsing
   private _spectatorFocusPos = new THREE.Vector3();
   private lamppostLightUpdateTimer = 0;
   private lamppostActiveLights: VertexLight[] = [];
@@ -266,8 +274,6 @@ export class TerrainSystem extends System {
 
   // Quad-tree LOD visual manager (client-only, when CONFIG.USE_QUADTREE_LOD is true)
   private quadTreeVisualManager: TerrainVisualManager | null = null;
-  private waterVisualManager: WaterVisualManager | null = null;
-  private grassVisualManager: GrassVisualManager | null = null;
 
   // Unified terrain generator from @hyperscape/procgen
   // Provides deterministic height/biome calculation independent of rendering
@@ -585,6 +591,14 @@ export class TerrainSystem extends System {
         }
       }
       generated++;
+      // Post-check: if the tile we just generated blew the budget, exit now
+      // rather than starting another tile that will block the event loop for
+      // another 60-135ms. The pre-check at the top of the loop catches the
+      // easy case (already over budget from a previous iteration), but a
+      // single expensive bakeWalkabilityFlags() call can take 60ms+ — without
+      // this post-check, the loop would start a second tile before realizing
+      // the budget was blown.
+      if (nowFn() - start > this.generationBudgetMsPerFrame) break;
     }
   }
 
@@ -952,7 +966,8 @@ export class TerrainSystem extends System {
       }
     }
 
-    // Set attributes (color attribute removed — shader computes colors procedurally)
+    // Set attributes
+    geometry.setAttribute("color", new THREE.BufferAttribute(colorData, 3));
     geometry.setAttribute(
       "biomeId",
       new THREE.BufferAttribute(new Float32Array(biomeData), 1),
@@ -977,7 +992,7 @@ export class TerrainSystem extends System {
     );
 
     // DEBUG: log biome weights for first 5 tiles
-    if (this._loggedWorkerTileBiome < 5) {
+    if (shouldEmitVerboseTerrainBootLogs() && this._loggedWorkerTileBiome < 5) {
       // Also log river proximity stats
       let rpNonZero = 0,
         rpMax = 0;
@@ -1034,9 +1049,8 @@ export class TerrainSystem extends System {
 
     this.applyFlatZoneCarve(geometry, tileX, tileZ);
 
-    // Attach heightData to geometry so the caller can store it AFTER the tile
-    // is added to terrainTiles (storeHeightData requires the tile to exist).
-    geometry.userData.heightData = Array.from(heightData);
+    // Store height data for persistence
+    this.storeHeightData(tileX, tileZ, Array.from(heightData));
 
     return geometry;
   }
@@ -1196,9 +1210,7 @@ export class TerrainSystem extends System {
         this.generateTileResources(tile);
       }
       this.generateVisualFeatures(tile);
-      if (!this.CONFIG.USE_QUADTREE_LOD) {
-        this.generateWaterMeshes(tile);
-      }
+      this.generateWaterMeshes(tile);
 
       // Queue resource instances for deferred creation (spreads work across frames)
       if (tile.resources.length > 0 && tile.mesh) {
@@ -1275,14 +1287,6 @@ export class TerrainSystem extends System {
 
     this.terrainTiles.set(key, tile);
     this.activeChunks.add(key);
-
-    // Store height data NOW that the tile is in the map.
-    // createTileGeometryFromWorkerData attaches heightData to geometry.userData
-    // because storeHeightData requires the tile to exist in terrainTiles.
-    if (geometry.userData.heightData) {
-      tile.heightData = geometry.userData.heightData;
-      tile.needsSave = true;
-    }
 
     // Synchronously bake WATER and STEEP_SLOPE collision flags (server-only).
     // Must match generateTile() — worker-generated tiles need the same
@@ -1414,11 +1418,9 @@ export class TerrainSystem extends System {
     WATER_THRESHOLD: TERRAIN_CONSTANTS.WATER_THRESHOLD,
 
     // LOD (Level of Detail) - Resolution tiers based on distance
-    LOD_DISTANCES: [200, 400, 700], // Distance thresholds
+    LOD_DISTANCES: [100, 200, 350], // Distance thresholds
     LOD_RESOLUTIONS: [64, 32, 16, 8], // Resolution at each LOD level
 
-    // Chunking
-    VIEW_DISTANCE: 5, // Load 5 tiles in each direction (11x11 = 121 tiles, ~1100m)
     UPDATE_INTERVAL: 0.5, // Check player movement every 0.5 seconds
 
     // Movement Constraints
@@ -1507,6 +1509,7 @@ export class TerrainSystem extends System {
     this.ensureNoiseInitialized();
 
     // Initialize the unified terrain generator from @hyperscape/procgen
+    // This provides a standalone, testable height generation system
     this.initializeTerrainGenerator();
 
     // Water body registry — ocean level only (no manual rivers/ponds)
@@ -1706,11 +1709,6 @@ export class TerrainSystem extends System {
           "[TerrainSystem] Roads ready, refreshing road influence on loaded tiles...",
         );
         this.refreshRoadInfluence();
-      }
-
-      // Rebuild grass chunks so road influence is reflected
-      if (this.grassVisualManager) {
-        this.grassVisualManager.rebuildAllChunks();
       }
     });
 
@@ -1927,266 +1925,11 @@ export class TerrainSystem extends System {
       this.CONFIG.QUADTREE_MAX_ASSEMBLIES_PER_FRAME,
     );
 
-    // Water quad-tree visual manager — flat water meshes aligned with terrain chunks
-    if (this.waterSystem) {
-      const waterContainer = new THREE.Group();
-      waterContainer.name = "QuadTreeWaterContainer";
-      if (this.terrainContainer) {
-        this.terrainContainer.parent?.add(waterContainer);
-      }
-
-      this.waterSystem.setWaterLevel(this.CONFIG.WATER_THRESHOLD);
-
-      this.waterVisualManager = new WaterVisualManager(
-        waterContainer,
-        this.waterSystem,
-        (x: number, z: number) => this.getHeightAt(x, z),
-        (x: number, z: number) => this.getIslandMask(x, z),
-        this.CONFIG.WATER_THRESHOLD,
-      );
-
-      const grassContainer = new THREE.Group();
-      grassContainer.name = "QuadTreeGrassContainer";
-      if (this.terrainContainer) {
-        this.terrainContainer.parent?.add(grassContainer);
-      }
-      const grassWorkerSetup = this.buildGrassWorkerSetup();
-      this.grassVisualManager = new GrassVisualManager(
-        grassContainer,
-        (x: number, z: number) => this.getHeightAt(x, z),
-        this.CONFIG.WATER_THRESHOLD,
-        (wx: number, wz: number) =>
-          this.calculateRoadInfluenceAtVertex(wx, wz, 0, 0),
-        (wx: number, wz: number) => this.isInFlatZone(wx, wz),
-        (wx: number, wz: number) => this.getTerrainColorAt(wx, wz),
-        grassWorkerSetup,
-      );
-
-      // Wire terrain, water, grass managers to the same quad-tree via composite
-      const composite = new CompositeQuadTreeListener();
-      composite.add(this.quadTreeVisualManager);
-      composite.add(this.waterVisualManager);
-      composite.add(this.grassVisualManager);
-      this.quadTreeVisualManager.getQuadTree().setListener(composite);
-    }
-
     console.log(
       "[TerrainSystem] Quad-tree LOD visual manager initialized " +
         `(minSize=${this.CONFIG.QUADTREE_MIN_SIZE}, maxDepth=${this.CONFIG.QUADTREE_MAX_DEPTH}, ` +
         `resolution=${this.CONFIG.QUADTREE_RESOLUTION}, splitRatio=${this.CONFIG.QUADTREE_SPLIT_RATIO})`,
     );
-  }
-
-  private buildGrassWorkerSetup(): GrassWorkerSetup {
-    const workerConfig: TerrainWorkerConfig = {
-      TILE_SIZE: this.CONFIG.TILE_SIZE,
-      TILE_RESOLUTION: this.CONFIG.TILE_RESOLUTION,
-      MAX_HEIGHT: MAX_HEIGHT,
-      BIOME_GAUSSIAN_COEFF: BIOME_CONFIG.gaussianCoeff,
-      BIOME_BOUNDARY_NOISE_SCALE: BIOME_CONFIG.boundaryNoiseScale,
-      BIOME_BOUNDARY_NOISE_AMOUNT: BIOME_CONFIG.boundaryNoiseAmount,
-      WATER_THRESHOLD: this.CONFIG.WATER_THRESHOLD,
-      WATER_LEVEL_NORMALIZED: WATER_LEVEL_NORMALIZED,
-      SHORELINE_THRESHOLD: SHORELINE_CONFIG.THRESHOLD,
-      SHORELINE_STRENGTH: SHORELINE_CONFIG.STRENGTH,
-      SHORELINE_MIN_SLOPE: SHORELINE_CONFIG.MIN_SLOPE,
-      SHORELINE_SLOPE_SAMPLE_DISTANCE: SHORELINE_CONFIG.SLOPE_SAMPLE_DISTANCE,
-      SHORELINE_LAND_BAND: SHORELINE_CONFIG.LAND_BAND,
-      SHORELINE_LAND_MAX_MULTIPLIER: SHORELINE_CONFIG.LAND_MAX_MULTIPLIER,
-      SHORELINE_UNDERWATER_BAND: SHORELINE_CONFIG.UNDERWATER_BAND,
-      UNDERWATER_DEPTH_MULTIPLIER: SHORELINE_CONFIG.UNDERWATER_DEPTH_MULTIPLIER,
-    };
-
-    const biomeData: Record<
-      string,
-      { heightModifier: number; color: { r: number; g: number; b: number } }
-    > = {};
-    for (const [name, biome] of Object.entries(BIOMES)) {
-      const color = new THREE.Color(biome.color);
-      biomeData[name] = {
-        heightModifier: biome.terrainMultiplier || 1,
-        color: { r: color.r, g: color.g, b: color.b },
-      };
-    }
-
-    const biomeCenters = this.terrainGenerator
-      .getBiomeSystem()
-      .getBiomeCenters() as BiomeCenter[];
-
-    const tCfg = getGrassConfigForBiome(BiomeType.Tundra);
-    const fCfg = getGrassConfigForBiome(BiomeType.Forest);
-    const cCfg = getGrassConfigForBiome(BiomeType.Canyon);
-
-    const resolveTint = (cfg: ReturnType<typeof getGrassConfigForBiome>) => ({
-      density: cfg.density,
-      maxSlope: cfg.maxSlope,
-      minGrassWeight: cfg.minGrassWeight,
-      heightScale: cfg.heightScale,
-      patchiness: cfg.patchiness,
-      patchScale: cfg.patchScale,
-      tintR: cfg.tintColor?.[0] ?? 0,
-      tintG: cfg.tintColor?.[1] ?? 0,
-      tintB: cfg.tintColor?.[2] ?? 0,
-      tintStrength: cfg.tintStrength ?? 0,
-    });
-
-    const grassConfigs: Record<
-      string,
-      {
-        density: number;
-        maxSlope: number;
-        minGrassWeight: number;
-        heightScale: number;
-        patchiness: number;
-        patchScale: number;
-        tintR: number;
-        tintG: number;
-        tintB: number;
-        tintStrength: number;
-      }
-    > = {
-      [BiomeType.Tundra]: resolveTint(tCfg),
-      [BiomeType.Forest]: resolveTint(fCfg),
-      [BiomeType.Canyon]: resolveTint(cCfg),
-    };
-
-    const tileSize = this.CONFIG.TILE_SIZE;
-
-    return {
-      terrainConfig: workerConfig,
-      seed: this.computeSeedFromWorldId(),
-      biomeCenters: biomeCenters.map((c) => ({
-        x: c.x,
-        z: c.z,
-        type: c.type,
-        influence: c.influence,
-      })),
-      biomes: biomeData,
-      grassConfigs,
-      tileSize,
-      getRoadSegmentsForRegion: (
-        minX: number,
-        minZ: number,
-        maxX: number,
-        maxZ: number,
-      ) => this.getWorldSpaceRoadSegmentsForRegion(minX, minZ, maxX, maxZ),
-      getFlatZonesForRegion: (
-        minX: number,
-        minZ: number,
-        maxX: number,
-        maxZ: number,
-      ) => this.getFlatZonesForRegion(minX, minZ, maxX, maxZ),
-    };
-  }
-
-  /**
-   * Collect road segments overlapping a world-space AABB, returned in
-   * world coordinates for the grass worker.
-   */
-  private getWorldSpaceRoadSegmentsForRegion(
-    minX: number,
-    minZ: number,
-    maxX: number,
-    maxZ: number,
-  ): Array<{
-    startX: number;
-    startZ: number;
-    endX: number;
-    endZ: number;
-    width: number;
-  }> {
-    this.roadNetworkSystem ??= this.world.getSystem("roads") as
-      | RoadNetworkSystem
-      | undefined;
-    if (!this.roadNetworkSystem) return [];
-
-    const ts = this.CONFIG.TILE_SIZE;
-    const minTX = Math.floor(minX / ts);
-    const minTZ = Math.floor(minZ / ts);
-    const maxTX = Math.floor(maxX / ts);
-    const maxTZ = Math.floor(maxZ / ts);
-
-    const result: Array<{
-      startX: number;
-      startZ: number;
-      endX: number;
-      endZ: number;
-      width: number;
-    }> = [];
-
-    for (let tx = minTX; tx <= maxTX; tx++) {
-      for (let tz = minTZ; tz <= maxTZ; tz++) {
-        const segs = this.roadNetworkSystem.getRoadSegmentsForTile(tx, tz);
-        const originX = tx * ts;
-        const originZ = tz * ts;
-        for (const seg of segs) {
-          result.push({
-            startX: originX + seg.start.x,
-            startZ: originZ + seg.start.z,
-            endX: originX + seg.end.x,
-            endZ: originZ + seg.end.z,
-            width: seg.width,
-          });
-        }
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Collect flat zones overlapping a world-space AABB, returned as simplified
-   * rectangles for the grass worker to exclude grass from buildings/arenas.
-   */
-  private getFlatZonesForRegion(
-    minX: number,
-    minZ: number,
-    maxX: number,
-    maxZ: number,
-  ): Array<{
-    centerX: number;
-    centerZ: number;
-    halfWidth: number;
-    halfDepth: number;
-    blendRadius: number;
-  }> {
-    if (this.flatZones.size === 0) return [];
-
-    const tileSize = this.CONFIG.TILE_SIZE;
-    const halfTile = tileSize / 2;
-    const minTX = Math.floor((minX + halfTile) / tileSize);
-    const minTZ = Math.floor((minZ + halfTile) / tileSize);
-    const maxTX = Math.floor((maxX + halfTile) / tileSize);
-    const maxTZ = Math.floor((maxZ + halfTile) / tileSize);
-
-    const seen = new Set<string>();
-    const result: Array<{
-      centerX: number;
-      centerZ: number;
-      halfWidth: number;
-      halfDepth: number;
-      blendRadius: number;
-    }> = [];
-
-    for (let tx = minTX; tx <= maxTX; tx++) {
-      for (let tz = minTZ; tz <= maxTZ; tz++) {
-        const zones = this.flatZonesByTile.get(`${tx}_${tz}`);
-        if (!zones) continue;
-        for (const zone of zones) {
-          if (seen.has(zone.id)) continue;
-          seen.add(zone.id);
-          result.push({
-            centerX: zone.centerX,
-            centerZ: zone.centerZ,
-            halfWidth: zone.width / 2,
-            halfDepth: zone.depth / 2,
-            blendRadius: zone.blendRadius,
-          });
-        }
-      }
-    }
-
-    return result;
   }
 
   private registerInstancedMeshes(): void {
@@ -2680,9 +2423,7 @@ export class TerrainSystem extends System {
 
         // Generate visual features and water meshes
         this.generateVisualFeatures(tile);
-        if (!this.CONFIG.USE_QUADTREE_LOD) {
-          this.generateWaterMeshes(tile);
-        }
+        this.generateWaterMeshes(tile);
         // NOTE: Grass rendering is handled by ProceduralGrassSystem
 
         // Queue resource instances for deferred creation (spreads work across frames)
@@ -2766,18 +2507,23 @@ export class TerrainSystem extends System {
     this.terrainTiles.set(key, tile);
     this.activeChunks.add(key);
 
-    // Store height data NOW that the tile is in the map.
-    // createTileGeometry attaches heightData to geometry.userData because
-    // storeHeightData requires the tile to exist in terrainTiles.
-    if (geometry.userData.heightData) {
-      tile.heightData = geometry.userData.heightData;
+    // Drain any heightData that createTileGeometry() buffered earlier in this
+    // same call. storeHeightData() fell back to the pending buffer because
+    // tile wasn't yet in this.terrainTiles at that point; now that it is, we
+    // copy the data onto the tile so getHeightAtCached() can bilinear-sample
+    // it during bakeWalkabilityFlags below (P7.a fix 2026-04-15).
+    const _pendingHeights = this._pendingTileHeightData.get(key);
+    if (_pendingHeights) {
+      tile.heightData = _pendingHeights;
       tile.needsSave = true;
+      this._pendingTileHeightData.delete(key);
     }
 
     // Synchronously bake WATER and STEEP_SLOPE collision flags (server-only).
     // Must complete before any movement query can reach this tile, otherwise
     // players can walk into water during the gap between tile generation and
-    // flag baking. ~1-2ms per tile (10K height lookups with cached data).
+    // flag baking. ~1-2ms per tile now that the fast in-tile bilinear path
+    // is used — see P7.a fix 2026-04-15.
     if (isServer) {
       this.bakeWalkabilityFlags(tileX, tileZ);
     }
@@ -2840,9 +2586,8 @@ export class TerrainSystem extends System {
     // Carve terrain triangles inside building flat zones to avoid overdraw
     this.applyFlatZoneCarve(geometry, tileX, tileZ);
 
-    // Attach heightData to geometry so the caller can store it AFTER the tile
-    // is added to terrainTiles (storeHeightData requires the tile to exist).
-    geometry.userData.heightData = heightData;
+    // Store height data for persistence
+    this.storeHeightData(tileX, tileZ, heightData);
 
     // SERVER: Skip all visual-only attributes (colors, biomeIds, roadInfluences,
     // forestWeights, canyonWeights) and the expensive per-vertex biome/color
@@ -2853,45 +2598,121 @@ export class TerrainSystem extends System {
       return geometry;
     }
 
-    // CLIENT: Visual attribute generation (shader computes colors procedurally)
+    // CLIENT: Full visual attribute generation
+    const colors = new Float32Array(positions.count * 3);
     const biomeIds = new Float32Array(positions.count);
     const roadInfluences = new Float32Array(positions.count);
     const forestWeights = new Float32Array(positions.count);
     const canyonWeights = new Float32Array(positions.count);
 
+    // Verify biome data is loaded - error if not
+    if (Object.keys(BIOMES).length === 0) {
+      throw new Error(
+        "[TerrainSystem] BIOMES data not loaded! DataManager must initialize before terrain generation.",
+      );
+    }
+    const defaultBiomeData = BIOMES[DEFAULT_BIOME];
+    if (!defaultBiomeData) {
+      throw new Error(
+        "[TerrainSystem] Default biome not found in BIOMES data!",
+      );
+    }
+
     for (let i = 0; i < positions.count; i++) {
       const i3 = i * 3;
       const x = positionsArray[i3] + tileX * this.CONFIG.TILE_SIZE;
       const z = positionsArray[i3 + 2] + tileZ * this.CONFIG.TILE_SIZE;
+      const height = positionsArray[i3 + 1]; // Already computed above
 
+      // Get biome influences for smooth color blending
       const { biomeWeightMap, totalWeight } =
         this.computeBiomeWeightsAtPosition(x, z);
+      const normalizedHeight = height / MAX_HEIGHT;
 
+      // Store dominant biome ID for shader
       let dominantBiome = DEFAULT_BIOME as string;
       let dominantWeight = -Infinity;
 
+      // PERFORMANCE: Reuse _tempColor to avoid GC pressure (no new THREE.Color per vertex)
+      // Blend up to 3 biome colors based on influence weights
+      let colorR = 0,
+        colorG = 0,
+        colorB = 0;
+
       if (totalWeight > 0) {
-        const invW = 1 / totalWeight;
+        const invTotal = 1 / totalWeight;
         for (const [type, rawWeight] of biomeWeightMap) {
-          const weight = rawWeight * invW;
+          const weight = rawWeight * invTotal;
           if (weight > dominantWeight) {
             dominantWeight = weight;
             dominantBiome = type;
           }
+
+          const biomeData = BIOMES[type];
+          if (!biomeData) {
+            throw new Error(
+              `[TerrainSystem] Biome "${type}" not found in BIOMES data!`,
+            );
+          }
+          this._tempColor.set(biomeData.color);
+
+          colorR += this._tempColor.r * weight;
+          colorG += this._tempColor.g * weight;
+          colorB += this._tempColor.b * weight;
         }
-        forestWeights[i] = (biomeWeightMap.get(BiomeType.Forest) || 0) * invW;
-        canyonWeights[i] = (biomeWeightMap.get(BiomeType.Canyon) || 0) * invW;
+      } else {
+        const biomeData = BIOMES[DEFAULT_BIOME];
+        if (!biomeData) {
+          throw new Error(
+            `[TerrainSystem] Default biome not found in BIOMES data!`,
+          );
+        }
+        this._tempColor.set(biomeData.color);
+        colorR = this._tempColor.r;
+        colorG = this._tempColor.g;
+        colorB = this._tempColor.b;
       }
       biomeIds[i] = this.getBiomeId(dominantBiome);
 
+      if (totalWeight > 0) {
+        const invW = 1 / totalWeight;
+        forestWeights[i] = (biomeWeightMap.get(BiomeType.Forest) || 0) * invW;
+        canyonWeights[i] = (biomeWeightMap.get(BiomeType.Canyon) || 0) * invW;
+      }
+
+      // Apply brownish shoreline tint near water level
+      const waterLevel = WATER_LEVEL_NORMALIZED;
+      const shorelineThreshold = SHORELINE_CONFIG.THRESHOLD;
+      if (
+        normalizedHeight > waterLevel &&
+        normalizedHeight < shorelineThreshold
+      ) {
+        const shoreFactor =
+          (1.0 -
+            (normalizedHeight - waterLevel) /
+              (shorelineThreshold - waterLevel)) *
+          SHORELINE_CONFIG.STRENGTH;
+        colorR = colorR + (0.545 - colorR) * shoreFactor;
+        colorG = colorG + (0.451 - colorG) * shoreFactor;
+        colorB = colorB + (0.333 - colorB) * shoreFactor;
+      }
+
+      // Calculate road influence - shader uses this attribute for road coloring
+      // (vertex colors are NOT modified for roads, shader handles this procedurally)
       roadInfluences[i] = this.calculateRoadInfluenceAtVertex(
         x,
         z,
         tileX,
         tileZ,
       );
+
+      // Store biome color (kept for potential fallback/debug rendering)
+      colors[i * 3] = colorR;
+      colors[i * 3 + 1] = colorG;
+      colors[i * 3 + 2] = colorB;
     }
 
+    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
     geometry.setAttribute("biomeId", new THREE.BufferAttribute(biomeIds, 1));
     geometry.setAttribute(
       "roadInfluence",
@@ -2907,7 +2728,7 @@ export class TerrainSystem extends System {
     );
 
     // DEBUG: log biome weights for first 5 sync tiles
-    if (this._loggedSyncTileBiome < 5) {
+    if (shouldEmitVerboseTerrainBootLogs() && this._loggedSyncTileBiome < 5) {
       this._loggedSyncTileBiome++;
       let sumF = 0,
         sumD = 0;
@@ -3518,6 +3339,12 @@ export class TerrainSystem extends System {
 
   private getHeightAtWithoutShore(worldX: number, worldZ: number): number {
     this.ensureNoiseInitialized();
+
+    const flatHeight = this.getFlatZoneHeight(worldX, worldZ);
+    if (flatHeight !== null) {
+      return flatHeight;
+    }
+
     return this.getBaseHeightAt(worldX, worldZ);
   }
 
@@ -3701,7 +3528,9 @@ export class TerrainSystem extends System {
   }
 
   /**
-   * Compute height using noise (expensive). Skips flat zone check — caller must check first.
+   * Compute height using noise (expensive). The caller skips the outer
+   * getFlatZoneHeight() check, but the underlying base-height path still
+   * respects flat zones before shoreline shaping is applied.
    * PERF: Avoids redundant getFlatZoneHeight() when called from getHeightAt().
    */
   private getHeightAtComputedSkipFlatZone(
@@ -4018,6 +3847,62 @@ export class TerrainSystem extends System {
   }
 
   /**
+   * Get terrain color at a world position by sampling the nearest terrain tile vertex.
+   * Used by ProceduralGrassSystem to match grass color to terrain.
+   *
+   * @param worldX - World X coordinate
+   * @param worldZ - World Z coordinate
+   * @returns RGB color (0-1 range) or null if no terrain data available
+   */
+  getTerrainColorAt(
+    worldX: number,
+    worldZ: number,
+  ): { r: number; g: number; b: number } | null {
+    const tileX = this.worldToTerrainTileIndex(worldX);
+    const tileZ = this.worldToTerrainTileIndex(worldZ);
+    const key = `${tileX}_${tileZ}`;
+
+    const tile = this.terrainTiles.get(key);
+    if (!tile?.mesh) {
+      return null;
+    }
+
+    // Get vertex colors from geometry
+    const geometry = tile.mesh.geometry as THREE.BufferGeometry;
+    const colorAttr = geometry.getAttribute("color") as
+      | THREE.BufferAttribute
+      | undefined;
+    if (!colorAttr) {
+      return null;
+    }
+
+    const localX = worldX - tileX * this.CONFIG.TILE_SIZE;
+    const localZ = worldZ - tileZ * this.CONFIG.TILE_SIZE;
+
+    const resolution = this.CONFIG.TILE_RESOLUTION;
+    const vertexX = Math.round(
+      Math.max(0, Math.min(resolution - 1, this.localToGridIndex(localX))),
+    );
+    const vertexZ = Math.round(
+      Math.max(0, Math.min(resolution - 1, this.localToGridIndex(localZ))),
+    );
+    const vertexIndex = vertexZ * resolution + vertexX;
+
+    if (
+      vertexIndex < 0 ||
+      vertexIndex * 3 + 2 >= colorAttr.count * colorAttr.itemSize
+    ) {
+      return null;
+    }
+
+    return {
+      r: colorAttr.getX(vertexIndex),
+      g: colorAttr.getY(vertexIndex),
+      b: colorAttr.getZ(vertexIndex),
+    };
+  }
+
+  /**
    * Register a flat zone and update spatial index.
    * Spatial index uses terrain tiles (100m each) for efficient lookup.
    *
@@ -4130,26 +4015,6 @@ export class TerrainSystem extends System {
           this.queueTerrainTileRegeneration(tile.x, tile.z, "flat_zone");
         }
       }
-    }
-
-    // Invalidate quad-tree visual chunks so they regenerate with flat zone heights.
-    // Without this, chunks generated before the flat zone was registered would
-    // show the procedural height instead of the flat zone height.
-    if (this.quadTreeVisualManager) {
-      this.quadTreeVisualManager.invalidateRegion(
-        zoneMinX,
-        zoneMinZ,
-        zoneMaxX,
-        zoneMaxZ,
-      );
-    }
-    if (this.grassVisualManager) {
-      this.grassVisualManager.invalidateRegion(
-        zoneMinX,
-        zoneMinZ,
-        zoneMaxX,
-        zoneMaxZ,
-      );
     }
   }
 
@@ -4287,18 +4152,6 @@ export class TerrainSystem extends System {
           }
         }
       }
-    }
-
-    // Invalidate quad-tree visual chunks so they regenerate without the flat zone.
-    const minX = zone.centerX - totalRadius;
-    const maxX = zone.centerX + totalRadius;
-    const minZ = zone.centerZ - totalRadius;
-    const maxZ = zone.centerZ + totalRadius;
-    if (this.quadTreeVisualManager) {
-      this.quadTreeVisualManager.invalidateRegion(minX, minZ, maxX, maxZ);
-    }
-    if (this.grassVisualManager) {
-      this.grassVisualManager.invalidateRegion(minX, minZ, maxX, maxZ);
     }
   }
 
@@ -4756,146 +4609,6 @@ export class TerrainSystem extends System {
     return { biomeWeightMap, totalWeight };
   }
 
-  /**
-   * Single entry point for getting the terrain base color and grass weight
-   * at a world position.  Encapsulates height, slope, biome-weight lookups
-   * and the CPU terrain-color computation so callers (e.g. GrassVisualManager)
-   * don't need any biome knowledge.
-   */
-  getTerrainColorAt(
-    wx: number,
-    wz: number,
-  ): {
-    r: number;
-    g: number;
-    b: number;
-    grassWeight: number;
-    grassPlacement: number;
-    grassHeightScale: number;
-    tintR: number;
-    tintG: number;
-    tintB: number;
-    tintStrength: number;
-    nx: number;
-    ny: number;
-    nz: number;
-  } {
-    const height = this.getHeightAt(wx, wz);
-
-    const sd = 0.5;
-    const hL = this.getHeightAt(wx - sd, wz);
-    const hR = this.getHeightAt(wx + sd, wz);
-    const hD = this.getHeightAt(wx, wz - sd);
-    const hU = this.getHeightAt(wx, wz + sd);
-    const dhdx = (hR - hL) / (2 * sd);
-    const dhdz = (hU - hD) / (2 * sd);
-    const gradMag = Math.sqrt(dhdx * dhdx + dhdz * dhdz);
-    const normalY = 1 / Math.sqrt(1 + gradMag * gradMag);
-    const slope = 1 - normalY;
-
-    const rnx = -dhdx;
-    const rnz = -dhdz;
-    const rny = 1.0;
-    const nLen = Math.sqrt(rnx * rnx + rny * rny + rnz * rnz);
-    const invLen = 1 / nLen;
-
-    const { biomeWeightMap, totalWeight } = this.computeBiomeWeightsAtPosition(
-      wx,
-      wz,
-    );
-    const invW = totalWeight > 0 ? 1 / totalWeight : 1;
-    const forestW = (biomeWeightMap.get("forest") || 0) * invW;
-    const canyonW = (biomeWeightMap.get("canyon") || 0) * invW;
-    const tundraW = 1 - forestW - canyonW;
-
-    const color = computeTerrainColorCPU(
-      wx,
-      wz,
-      height,
-      slope,
-      forestW,
-      canyonW,
-    );
-
-    const tCfg = getGrassConfigForBiome(BiomeType.Tundra);
-    const fCfg = getGrassConfigForBiome(BiomeType.Forest);
-    const cCfg = getGrassConfigForBiome(BiomeType.Canyon);
-
-    const maxSlope =
-      tCfg.maxSlope * tundraW +
-      fCfg.maxSlope * forestW +
-      cCfg.maxSlope * canyonW;
-    const minGW =
-      tCfg.minGrassWeight * tundraW +
-      fCfg.minGrassWeight * forestW +
-      cCfg.minGrassWeight * canyonW;
-    const density =
-      tCfg.density * tundraW + fCfg.density * forestW + cCfg.density * canyonW;
-    const grassHeightScale =
-      tCfg.heightScale * tundraW +
-      fCfg.heightScale * forestW +
-      cCfg.heightScale * canyonW;
-    const patchiness =
-      tCfg.patchiness * tundraW +
-      fCfg.patchiness * forestW +
-      cCfg.patchiness * canyonW;
-    const patchScale =
-      tCfg.patchScale * tundraW +
-      fCfg.patchScale * forestW +
-      cCfg.patchScale * canyonW;
-
-    const slopeOk = slope <= maxSlope ? 1.0 : 0.0;
-    const weightOk = color.grassWeight >= minGW ? 1.0 : 0.0;
-
-    // Noise-based patch mask: patchiness 0 = uniform, 1 = tight clusters
-    const patchThreshold = patchiness * 2 - 1; // maps [0,1] -> [-1,1]
-    const noiseVal = this.noise.simplex2D(wx * patchScale, wz * patchScale);
-    const patchMask = noiseVal > patchThreshold ? 1.0 : 0.0;
-
-    const grassPlacement =
-      color.grassWeight * density * slopeOk * weightOk * patchMask;
-
-    // Biome-blended grass tint (returned separately for tip-only application)
-    const tintStrength =
-      (tCfg.tintStrength ?? 0) * tundraW +
-      (fCfg.tintStrength ?? 0) * forestW +
-      (cCfg.tintStrength ?? 0) * canyonW;
-    let tintR = 0,
-      tintG = 0,
-      tintB = 0;
-    if (tintStrength > 0) {
-      const wR =
-        (tCfg.tintColor?.[0] ?? 0) * (tCfg.tintStrength ?? 0) * tundraW +
-        (fCfg.tintColor?.[0] ?? 0) * (fCfg.tintStrength ?? 0) * forestW +
-        (cCfg.tintColor?.[0] ?? 0) * (cCfg.tintStrength ?? 0) * canyonW;
-      const wG =
-        (tCfg.tintColor?.[1] ?? 0) * (tCfg.tintStrength ?? 0) * tundraW +
-        (fCfg.tintColor?.[1] ?? 0) * (fCfg.tintStrength ?? 0) * forestW +
-        (cCfg.tintColor?.[1] ?? 0) * (cCfg.tintStrength ?? 0) * canyonW;
-      const wB =
-        (tCfg.tintColor?.[2] ?? 0) * (tCfg.tintStrength ?? 0) * tundraW +
-        (fCfg.tintColor?.[2] ?? 0) * (fCfg.tintStrength ?? 0) * forestW +
-        (cCfg.tintColor?.[2] ?? 0) * (cCfg.tintStrength ?? 0) * canyonW;
-      const inv = 1 / tintStrength;
-      tintR = wR * inv;
-      tintG = wG * inv;
-      tintB = wB * inv;
-    }
-
-    return {
-      ...color,
-      grassPlacement,
-      grassHeightScale,
-      tintR,
-      tintG,
-      tintB,
-      tintStrength,
-      nx: rnx * invLen,
-      ny: rny * invLen,
-      nz: rnz * invLen,
-    };
-  }
-
   computeBiomeWeightsByPosition(
     worldX: number,
     worldZ: number,
@@ -5332,7 +5045,16 @@ export class TerrainSystem extends System {
     if (tile) {
       tile.heightData = heightData;
       tile.needsSave = true;
+      return;
     }
+
+    // Tile not yet inserted into this.terrainTiles (initial createTileGeometry
+    // path). Stash the data in the pending buffer so generateTile() can drain
+    // it onto the tile immediately after adding the tile to the map. Without
+    // this the tile ends up with heightData=[], which forces bakeWalkability-
+    // Flags through the expensive noise-based height path — see P7.a fix
+    // 2026-04-15.
+    this._pendingTileHeightData.set(key, heightData);
   }
 
   private saveModifiedChunks(): void {
@@ -5366,12 +5088,26 @@ export class TerrainSystem extends System {
     }
   }
 
+  private _clientUpdateTickCounter = 0;
+
   update(_deltaTime: number): void {
     // Skip processing until terrain is fully initialized (DataManager loaded BIOMES)
     // This prevents race conditions where update() is called before start() completes
     if (!this._terrainInitialized) {
       return;
     }
+
+    // Track client-side tick count for throttling expensive per-frame work.
+    // Quad-tree LOD updates and instance visibility checks only need to run
+    // at ~4 Hz (every 4th frame at 15 fps), not every tick. Throttling frees
+    // ~75% of terrain CPU for the WebGPU render loop, which is the primary
+    // bottleneck for the streaming capture pipeline (1 unique fps at full
+    // tick rate vs ~8-12 fps when throttled).
+    if (this.runtimeIsClient) {
+      this._clientUpdateTickCounter++;
+    }
+    const isClientHeavyTick =
+      this.runtimeIsClient && this._clientUpdateTickCounter % 4 === 0;
 
     // Dispatch pending tiles to workers for pre-computation (client only)
     if (this.runtimeIsClient && this.CONFIG.USE_WORKERS) {
@@ -5388,33 +5124,22 @@ export class TerrainSystem extends System {
       this.processWalkabilityQueue();
     }
 
-    // Process pending resource instance creation (client only, spreads work across frames)
-    if (this.runtimeIsClient) {
+    // Process pending resource instance creation (client only, throttled)
+    if (isClientHeavyTick) {
       this.processResourceInstanceQueue();
     }
 
-    // Update quad-tree LOD visual manager (client only)
-    if (this.runtimeIsClient && this.quadTreeVisualManager) {
+    // Update quad-tree LOD visual manager (client only, throttled)
+    if (isClientHeavyTick && this.quadTreeVisualManager) {
       const centers = this.getTerrainCenters();
       if (centers.length > 0) {
         const pos = centers[0].position;
-
-        // Set grass player position BEFORE quad-tree update so
-        // onNodeNeedsGeometry dispatches with correct LOD & distance
-        if (this.grassVisualManager) {
-          this.grassVisualManager.setPlayerPosition(pos.x, pos.z);
-        }
-
         this.quadTreeVisualManager.update(pos.x, pos.z);
-
-        if (this.grassVisualManager) {
-          this.grassVisualManager.update(pos.x, pos.z, this.world.camera);
-        }
       }
     }
 
-    // Update instance visibility on client based on player position
-    if (this.runtimeIsClient && this.instancedMeshManager) {
+    // Update instance visibility on client based on player position (throttled)
+    if (isClientHeavyTick && this.instancedMeshManager) {
       this.instancedMeshManager.updateAllInstanceVisibility();
 
       // TEMPORARILY DISABLED - rock instancer update
@@ -5448,29 +5173,16 @@ export class TerrainSystem extends System {
       if (materialWithUniforms) {
         materialWithUniforms.terrainUniforms.time.value = this.terrainTime;
 
-        // Sync sun direction + day intensity from Environment system
+        // Sync sun direction and shade color from Environment system
         const env = this.world.getSystem("environment") as {
           lightDirection?: THREE.Vector3;
-          getDayIntensity?: () => number;
+          hemisphereLight?: { color: THREE.Color };
         } | null;
         if (env?.lightDirection) {
           materialWithUniforms.terrainUniforms.sunDirection.value
             .copy(env.lightDirection)
             .negate();
-          if (this.grassVisualManager) {
-            this.grassVisualManager.updateLighting(
-              materialWithUniforms.terrainUniforms.sunDirection.value,
-            );
-          }
         }
-        if (env?.getDayIntensity) {
-          const dayVal = env.getDayIntensity();
-          materialWithUniforms.terrainUniforms.dayIntensity.value = dayVal;
-          if (this.grassVisualManager) {
-            this.grassVisualManager.updateDayIntensity(dayVal);
-          }
-        }
-
         // Fog texture is the shared fogRenderTarget from FogConfig — no sync needed
 
         // Update lamppost vertex lights (night-only)
@@ -5594,61 +5306,6 @@ export class TerrainSystem extends System {
     const night = 1 - dayIntensity;
     const t = Math.max(0, Math.min(1, (night - 0.4) / 0.3));
     return t * t * (3 - 2 * t);
-  }
-
-  private checkPlayerMovement(): void {
-    // Get player positions and update loaded tiles accordingly
-    const players = this.world.getPlayers() || [];
-
-    for (const player of players) {
-      const x = player.node.position.x;
-      const z = player.node.position.z;
-
-      const tileX = Math.floor(x / this.CONFIG.TILE_SIZE);
-      const tileZ = Math.floor(z / this.CONFIG.TILE_SIZE);
-
-      // Check if player moved to a new tile
-      if (tileX !== this.lastPlayerTile.x || tileZ !== this.lastPlayerTile.z) {
-        this.updateTilesAroundPlayer(tileX, tileZ);
-        this.lastPlayerTile = { x: tileX, z: tileZ };
-      }
-    }
-  }
-
-  private updateTilesAroundPlayer(centerX: number, centerZ: number): void {
-    const requiredTiles = new Set<string>();
-
-    // Generate list of required tiles (3x3 around player)
-    for (
-      let dx = -this.CONFIG.VIEW_DISTANCE;
-      dx <= this.CONFIG.VIEW_DISTANCE;
-      dx++
-    ) {
-      for (
-        let dz = -this.CONFIG.VIEW_DISTANCE;
-        dz <= this.CONFIG.VIEW_DISTANCE;
-        dz++
-      ) {
-        const tileX = centerX + dx;
-        const tileZ = centerZ + dz;
-        requiredTiles.add(`${tileX}_${tileZ}`);
-      }
-    }
-
-    // Unload tiles that are no longer needed
-    for (const [key, tile] of this.terrainTiles) {
-      if (!requiredTiles.has(key)) {
-        this.unloadTile(tile);
-      }
-    }
-
-    // Load new tiles that are needed
-    for (const key of requiredTiles) {
-      if (!this.terrainTiles.has(key)) {
-        const [tileX, tileZ] = key.split("_").map(Number);
-        this.generateTile(tileX, tileZ);
-      }
-    }
   }
 
   /**
@@ -5975,6 +5632,58 @@ export class TerrainSystem extends System {
     const originXInt = Math.floor(originX);
     const originZInt = Math.floor(originZ);
 
+    // FAST HEIGHT PATH: bakeWalkabilityFlags only cares about raw terrain
+    // height, not bridge/dock/flat-zone overrides (those are applied later
+    // in Pass 3/4 as walkability flag overrides, not height overrides). Using
+    // `getHeightAt` here means 94,356 lookups × (3 system-lookups + flat-zone
+    // scan + bilinear interpolation) per bake. That's what made bake take
+    // 800ms+ per tile even after the heightData caching fix.
+    //
+    // Instead, cache the current tile's heightData locally and bilinear-
+    // interpolate directly for in-tile samples. For samples outside this
+    // tile's bounds (tile edges, slope check overflow), fall back to
+    // `getHeightAtCached` which handles adjacent-tile lookups, and finally
+    // to the noise path if nothing is cached.
+    const tileKey = `${terrainTileX}_${terrainTileZ}`;
+    const currentTile = this.terrainTiles.get(tileKey);
+    const tileHeightData = currentTile?.heightData;
+    const hasLocalHeights =
+      Array.isArray(tileHeightData) && tileHeightData.length > 0;
+    const resolution = this.CONFIG.TILE_RESOLUTION;
+    const fastHeight = (wx: number, wz: number): number => {
+      if (hasLocalHeights) {
+        // In-tile bilinear from the local heightData. Only applies when the
+        // sample is actually inside this tile; otherwise fall through.
+        const lxf = wx - originX;
+        const lzf = wz - originZ;
+        if (lxf >= 0 && lxf <= tileSize && lzf >= 0 && lzf <= tileSize) {
+          const gx = (lxf / tileSize) * (resolution - 1);
+          const gz = (lzf / tileSize) * (resolution - 1);
+          const gxClamped = Math.max(0, Math.min(resolution - 1.001, gx));
+          const gzClamped = Math.max(0, Math.min(resolution - 1.001, gz));
+          const ix0 = Math.floor(gxClamped);
+          const iz0 = Math.floor(gzClamped);
+          const ix1 = Math.min(ix0 + 1, resolution - 1);
+          const iz1 = Math.min(iz0 + 1, resolution - 1);
+          const fx = gxClamped - ix0;
+          const fz = gzClamped - iz0;
+          const h00 = tileHeightData![iz0 * resolution + ix0];
+          const h10 = tileHeightData![iz0 * resolution + ix1];
+          const h01 = tileHeightData![iz1 * resolution + ix0];
+          const h11 = tileHeightData![iz1 * resolution + ix1];
+          const h0 = h00 + (h10 - h00) * fx;
+          const h1 = h01 + (h11 - h01) * fx;
+          return h0 + (h1 - h0) * fz;
+        }
+      }
+      // Out-of-tile or missing local data → walk the full adjacent-tile cache
+      // then fall back to the computed noise path (skip flat-zone since we
+      // already know we're not inside a flat zone for terrain sampling).
+      const adjacentCached = this.getHeightAtCached(wx, wz);
+      if (adjacentCached !== null) return adjacentCached;
+      return this.getHeightAtComputedSkipFlatZone(wx, wz);
+    };
+
     // Clear stale terrain flags first (handles re-baking after flat zone regeneration)
     const terrainFlagsMask = CollisionFlag.WATER | CollisionFlag.STEEP_SLOPE;
     for (let lx = 0; lx < tilesPerSide; lx++) {
@@ -6008,7 +5717,7 @@ export class TerrainSystem extends System {
       const iStride = i * gridPoints;
       for (let j = 0; j < gridPoints; j++) {
         const wz = gridStartZ + j * cellSize;
-        heights[iStride + j] = this.getHeightAt(wx, wz);
+        heights[iStride + j] = fastHeight(wx, wz);
       }
     }
 
@@ -6130,6 +5839,15 @@ export class TerrainSystem extends System {
     }
 
     // ---- PASS 2: Biome + slope flags (non-water tiles only) ----
+    // Inline the slope computation using fastHeight() so the inner 10K×9
+    // getHeightAt calls become 10K×9 fastHeight calls (direct bilinear from
+    // the current tile's heightData array, no bridge/dock/flat-zone lookup,
+    // no per-call Map indirection). Matches the behaviour of calculateSlope()
+    // but skips the system lookups that are irrelevant for the raw terrain
+    // slope used here.
+    const slopeD = this.CONFIG.SLOPE_CHECK_DISTANCE;
+    const slopeInvD = 1 / slopeD;
+    const slopeInvDiag = 1 / (slopeD * Math.SQRT2);
     for (let lx = 0; lx < tilesPerSide; lx++) {
       const worldX = originX + lx + 0.5;
       const moveTileX = originXInt + lx;
@@ -6151,8 +5869,33 @@ export class TerrainSystem extends System {
           // Slope check — slope exceeds biome's maxSlope
           const biomeData = BIOMES[biome];
           if (biomeData) {
-            const slope = this.calculateSlope(worldX, worldZ);
-            if (slope > biomeData.maxSlope) {
+            const c = fastHeight(worldX, worldZ);
+            let maxSlope =
+              Math.abs(fastHeight(worldX, worldZ + slopeD) - c) * slopeInvD;
+            let s =
+              Math.abs(fastHeight(worldX, worldZ - slopeD) - c) * slopeInvD;
+            if (s > maxSlope) maxSlope = s;
+            s = Math.abs(fastHeight(worldX + slopeD, worldZ) - c) * slopeInvD;
+            if (s > maxSlope) maxSlope = s;
+            s = Math.abs(fastHeight(worldX - slopeD, worldZ) - c) * slopeInvD;
+            if (s > maxSlope) maxSlope = s;
+            s =
+              Math.abs(fastHeight(worldX + slopeD, worldZ + slopeD) - c) *
+              slopeInvDiag;
+            if (s > maxSlope) maxSlope = s;
+            s =
+              Math.abs(fastHeight(worldX - slopeD, worldZ + slopeD) - c) *
+              slopeInvDiag;
+            if (s > maxSlope) maxSlope = s;
+            s =
+              Math.abs(fastHeight(worldX + slopeD, worldZ - slopeD) - c) *
+              slopeInvDiag;
+            if (s > maxSlope) maxSlope = s;
+            s =
+              Math.abs(fastHeight(worldX - slopeD, worldZ - slopeD) - c) *
+              slopeInvDiag;
+            if (s > maxSlope) maxSlope = s;
+            if (maxSlope > biomeData.maxSlope) {
               collision.addFlags(
                 moveTileX,
                 originZInt + lz,
@@ -6670,7 +6413,9 @@ export class TerrainSystem extends System {
     worldZ: number,
     overrideDifficultyLevel?: number,
   ): DifficultySample {
-    this.ensureNoiseInitialized();
+    if (!this.noise) {
+      this.noise = new NoiseGenerator(this.computeSeedFromWorldId());
+    }
 
     const biome = this.getBiomeAtWorldPosition(worldX, worldZ);
     const biomeData = BIOMES[biome];
@@ -6832,7 +6577,9 @@ export class TerrainSystem extends System {
   private generateBossHotspots(): void {
     if (this.bossHotspots.length > 0) return;
 
-    this.ensureNoiseInitialized();
+    if (!this.noise) {
+      this.noise = new NoiseGenerator(this.computeSeedFromWorldId());
+    }
 
     const worldSizeMeters = this.getActiveWorldSizeMeters();
     const halfWorld = worldSizeMeters / 2;
@@ -7006,20 +6753,9 @@ export class TerrainSystem extends System {
       this.quadTreeVisualManager = null;
     }
 
-    if (this.waterVisualManager) {
-      this.waterVisualManager.destroy();
-      this.waterVisualManager = null;
-    }
-
-    if (this.grassVisualManager) {
-      this.grassVisualManager.destroy();
-      this.grassVisualManager = null;
-    }
-
     // Terminate worker pools to free resources
     terminateTerrainWorkerPool();
     terminateQuadChunkWorkerPool();
-    terminateGrassWorkerPool();
 
     // Clear pending worker results
     this.pendingWorkerResults.clear();
@@ -7074,6 +6810,7 @@ export class TerrainSystem extends System {
     this.chunkPlayerCounts.clear();
     this._queuedTileRegenerations.clear();
     this._pendingTileRegeneration.clear();
+    this._pendingTileHeightData.clear();
     this.terrainBoundingBoxes.clear();
     this.pendingSerializationData.clear();
 
@@ -7203,29 +6940,30 @@ export class TerrainSystem extends System {
    * Initialize chunk loading system with 9 core + ring strategy
    */
   private initializeChunkLoadingSystem(): void {
-    const isEmbeddedSpectator = (() => {
-      if (typeof window === "undefined") return false;
-      const win = window as Window & {
-        __HYPERSCAPE_EMBEDDED__?: boolean;
-        __HYPERSCAPE_CONFIG__?: { mode?: string };
-      };
-      return (
-        win.__HYPERSCAPE_EMBEDDED__ === true &&
-        win.__HYPERSCAPE_CONFIG__?.mode === "spectator"
-      );
-    })();
     // world.isServer can be false during early bootstrap (before network mode
     // is finalized). Resolve runtime role explicitly so server startup always
     // uses tight headless chunk ranges.
     const { isServer: isServerRuntime } = this.resolveRuntimeRole();
+    const isDedicatedStream = !isServerRuntime && isDedicatedStreamViewport();
+    const isEmbeddedSpectator =
+      !isDedicatedStream && isEmbeddedSpectatorViewport();
 
     // Embedded spectator prioritizes first-frame time over long-range preload.
     if (isServerRuntime) {
-      this.coreChunkRange = 3; // 7x7 core grid (full simulation)
-      this.ringChunkRange = 5; // 11x11 ring — resource content generated here
-      this.terrainOnlyChunkRange = 0; // No render-only tiles on server
-      this.maxTilesPerFrame = 4;
-      this.generationBudgetMsPerFrame = 6;
+      // Server does not render horizon terrain, so keep chunk windows tight to
+      // avoid runaway memory when many autonomous agents are active.
+      // Reduced tile budget to minimize GC pressure from Float32Array allocations.
+      this.coreChunkRange = 1; // 3x3 core grid
+      this.ringChunkRange = 1; // No extra preload ring
+      this.terrainOnlyChunkRange = 0; // Never load render-only distant tiles
+      this.maxTilesPerFrame = 1;
+      this.generationBudgetMsPerFrame = 2;
+    } else if (isDedicatedStream) {
+      this.coreChunkRange = 1; // 3x3 core grid
+      this.ringChunkRange = 1; // No broad preload beyond the duel arena envelope
+      this.terrainOnlyChunkRange = 0; // Disable distant terrain-only horizon churn
+      this.maxTilesPerFrame = 1; // Favor continuity over catch-up bursts
+      this.generationBudgetMsPerFrame = 4;
     } else if (isEmbeddedSpectator) {
       this.coreChunkRange = 1; // 3x3 core grid
       this.ringChunkRange = 2; // Preload ring up to 5x5
@@ -7233,12 +6971,12 @@ export class TerrainSystem extends System {
       this.maxTilesPerFrame = 4; // Catch up faster after camera retargets
       this.generationBudgetMsPerFrame = 10;
     } else {
-      // Client: load tiles out to match LOD fade distances (~1000m)
-      this.coreChunkRange = 3; // 7x7 core grid
-      this.ringChunkRange = 5; // 11x11 ring — content generated here (~1100m)
-      this.terrainOnlyChunkRange = 7; // Terrain mesh horizon (~1500m)
-      this.maxTilesPerFrame = 3;
-      this.generationBudgetMsPerFrame = 8;
+      // Balanced load radius to reduce generation spikes when moving
+      this.coreChunkRange = 2; // 5x5 core grid
+      this.ringChunkRange = 3; // Preload ring up to ~7x7
+      this.terrainOnlyChunkRange = 5;
+      this.maxTilesPerFrame = 2;
+      this.generationBudgetMsPerFrame = 6;
     }
 
     // Initialize tracking maps

--- a/packages/shared/src/systems/shared/world/TownSystem.ts
+++ b/packages/shared/src/systems/shared/world/TownSystem.ts
@@ -1662,9 +1662,13 @@ export class TownSystem extends System {
     }
     const nodeEnv =
       typeof process !== "undefined" ? process.env.NODE_ENV : undefined;
-    // Keep exhaustive validation enabled for test runs while avoiding
-    // multi-gigabyte startup churn in normal server runtimes.
-    return nodeEnv === "test";
+    const isCi =
+      typeof process !== "undefined" &&
+      isTruthyEnv(process.env.CI ?? undefined);
+    // Keep exhaustive validation available for explicit opt-in and local test
+    // debugging, but do not make CI startup depend on fully deterministic world
+    // generation + pathfinding layout.
+    return nodeEnv === "test" && !isCi;
   }
 
   /**

--- a/packages/shared/src/systems/shared/world/VegetationSystem.ts
+++ b/packages/shared/src/systems/shared/world/VegetationSystem.ts
@@ -64,6 +64,10 @@ import {
   getGlobalCullingManager,
 } from "../../../utils/compute";
 import { isPositionInsideDuelArenaZone } from "../../../data/duel-manifest";
+import {
+  isDedicatedStreamViewport,
+  isStreamDebugEnabled,
+} from "../../../runtime/clientViewportMode";
 // Octahedral impostor for high-quality multi-angle billboard rendering
 import {
   OctahedralImpostor,
@@ -117,9 +121,10 @@ const SKIP_LOD1_CATEGORIES = new Set([
 const VEGETATION_CHUNK_SIZE = 64; // meters per chunk
 const MAX_INSTANCES_PER_CHUNK = 256;
 
-let FADE_START = 1000; // Shader fade begins (fully opaque inside)
-let FADE_END = 1200; // Shader fully culls (invisible beyond)
-let CHUNK_RENDER_DISTANCE = 1400; // CPU hides chunks (buffer zone for loading)
+// Default fade distances - overridden by shadow quality settings in start()
+let FADE_START = 180; // Shader fade begins (fully opaque inside)
+let FADE_END = 200; // Shader fully culls (invisible beyond)
+let CHUNK_RENDER_DISTANCE = 300; // CPU hides chunks (buffer zone for loading)
 
 // NOTE: Per-category LOD distances are defined in LODConfig.ts LOD_DISTANCES
 // Access via getLODDistances(category) for actual LOD decisions.
@@ -263,7 +268,36 @@ function getAssetLODConfig(category: string, boundingSize?: number) {
 }
 
 /** Max tile distance from player to generate vegetation (in tiles, not world units) */
-const MAX_VEGETATION_TILE_RADIUS = 5;
+// PERFORMANCE: Reduced from 3 to 2 tiles - vegetation fades before this distance anyway
+const MAX_VEGETATION_TILE_RADIUS = 2;
+const STREAM_MAX_VEGETATION_TILE_RADIUS = 1;
+const DEFAULT_STARTUP_TILE_BATCH_SIZE = 8;
+const STREAM_STARTUP_TILE_BATCH_SIZE = 2;
+const STREAM_MAX_CHUNK_RENDER_DISTANCE = 140;
+
+function isDedicatedStreamVegetationMode(): boolean {
+  return typeof window !== "undefined" && isDedicatedStreamViewport();
+}
+
+function getVegetationTileRadius(): number {
+  return isDedicatedStreamVegetationMode()
+    ? STREAM_MAX_VEGETATION_TILE_RADIUS
+    : MAX_VEGETATION_TILE_RADIUS;
+}
+
+function getVegetationStartupBatchSize(): number {
+  return isDedicatedStreamVegetationMode()
+    ? STREAM_STARTUP_TILE_BATCH_SIZE
+    : DEFAULT_STARTUP_TILE_BATCH_SIZE;
+}
+
+function shouldQueueDistantVegetationTiles(): boolean {
+  return !isDedicatedStreamVegetationMode();
+}
+
+function shouldEmitVerboseVegetationBootLogs(): boolean {
+  return !isDedicatedStreamVegetationMode() || isStreamDebugEnabled();
+}
 
 /** Water threshold from centralized constants */
 import { TERRAIN_CONSTANTS } from "../../../constants/GameConstants";
@@ -773,6 +807,7 @@ export class VegetationSystem extends System {
     if (!this.world.stage?.scene) return;
 
     this.scene = this.world.stage.scene as THREE.Scene;
+    const isDedicatedStreamMode = isDedicatedStreamVegetationMode();
 
     // Sync vegetation fade distances with shadow quality
     // Vegetation must dissolve BEFORE shadow cutoff to avoid unshadowed trees
@@ -787,19 +822,30 @@ export class VegetationSystem extends System {
       csmLevels[shadowsLevel as keyof typeof csmLevels] || csmLevels.med;
     const shadowMaxFar = csmConfig.maxFar;
 
-    // Fade distances are independent of shadow range — distant trees render
-    // without shadows rather than disappearing at the shadow cutoff.
-    FADE_START = 1000;
-    FADE_END = 1200;
-    CHUNK_RENDER_DISTANCE = 1400;
+    // Sync fade distances with shadow range
+    // Vegetation fully dissolves AT shadow maxFar so we never see unshadowed trees
+    FADE_END = shadowMaxFar; // Fully dissolved at shadow cutoff
+    FADE_START = shadowMaxFar * 0.9; // Start dissolving at 90% of shadow range
+    CHUNK_RENDER_DISTANCE = shadowMaxFar * 1.2; // Chunks visible 20% beyond shadow range
+    if (isDedicatedStreamMode) {
+      CHUNK_RENDER_DISTANCE = Math.min(
+        CHUNK_RENDER_DISTANCE,
+        STREAM_MAX_CHUNK_RENDER_DISTANCE,
+      );
+      this.setConfig({
+        cullDistance: CHUNK_RENDER_DISTANCE,
+      });
+    }
 
     // Imposter distances - switch to billboard before dissolve zone
     // LOD transition: 3D mesh -> Billboard imposter -> Dissolve -> Cull
     // Per-category LOD distances are defined in LODConfig.ts LOD_DISTANCES
     // The shared material uses FADE_START/FADE_END for dissolve shader
-    console.log(
-      `[VegetationSystem] Synced with shadows "${shadowsLevel}": fade ${FADE_START.toFixed(0)}-${FADE_END.toFixed(0)}m, chunks ${CHUNK_RENDER_DISTANCE.toFixed(0)}m (per-category LOD via getLODDistances)`,
-    );
+    if (shouldEmitVerboseVegetationBootLogs()) {
+      console.log(
+        `[VegetationSystem] Synced with shadows "${shadowsLevel}": fade ${FADE_START.toFixed(0)}-${FADE_END.toFixed(0)}m, chunks ${CHUNK_RENDER_DISTANCE.toFixed(0)}m (per-category LOD via getLODDistances)`,
+      );
+    }
 
     // Load LOD settings first (affects all subsequent distance calculations)
     await this.loadLODSettings();
@@ -823,9 +869,11 @@ export class VegetationSystem extends System {
       fadeStart: FADE_START,
       fadeEnd: FADE_END,
     });
-    console.log(
-      `[VegetationSystem] Created shared material (fade: ${FADE_START.toFixed(0)}-${FADE_END.toFixed(0)}m, chunks: ${CHUNK_RENDER_DISTANCE.toFixed(0)}m)`,
-    );
+    if (shouldEmitVerboseVegetationBootLogs()) {
+      console.log(
+        `[VegetationSystem] Created shared material (fade: ${FADE_START.toFixed(0)}-${FADE_END.toFixed(0)}m, chunks: ${CHUNK_RENDER_DISTANCE.toFixed(0)}m)`,
+      );
+    }
 
     // PERFORMANCE: Enable layer 1 for main camera so it can see vegetation
     // Minimap camera only sees layer 0, so vegetation won't render in minimap
@@ -848,14 +896,23 @@ export class VegetationSystem extends System {
     );
 
     console.log(
-      `[VegetationSystem] ✅ Started with ${this.assetDefinitions.size} assets, radius=${MAX_VEGETATION_TILE_RADIUS} tiles`,
+      `[VegetationSystem] ✅ Started with ${this.assetDefinitions.size} assets, radius=${getVegetationTileRadius()} tiles`,
     );
 
     // Initialize GPU compute culling (optional enhancement)
     this.initializeGPUCulling();
 
     // Process existing terrain tiles that were generated before we subscribed
-    await this.processExistingTiles();
+    if (isDedicatedStreamMode) {
+      this.processExistingTiles().catch((error) => {
+        console.warn(
+          "[VegetationSystem] Deferred stream vegetation startup failed:",
+          error,
+        );
+      });
+    } else {
+      await this.processExistingTiles();
+    }
   }
 
   /**
@@ -919,7 +976,7 @@ export class VegetationSystem extends System {
     for (const tile of allTiles) {
       const dx = Math.abs(tile.tileX - playerTileX);
       const dz = Math.abs(tile.tileZ - playerTileZ);
-      if (Math.max(dx, dz) <= MAX_VEGETATION_TILE_RADIUS) {
+      if (Math.max(dx, dz) <= getVegetationTileRadius()) {
         nearbyTiles.push(tile);
       } else {
         distantTiles.push(tile);
@@ -945,7 +1002,7 @@ export class VegetationSystem extends System {
     if (totalTiles > 0) {
       // PARALLEL BATCH PROCESSING: Process tiles in batches of 8 for optimal parallelism
       // This balances worker pool utilization with progress reporting
-      const BATCH_SIZE = 8;
+      const BATCH_SIZE = getVegetationStartupBatchSize();
       let processedTiles = 0;
 
       for (let i = 0; i < nearbyTiles.length; i += BATCH_SIZE) {
@@ -967,14 +1024,17 @@ export class VegetationSystem extends System {
     }
 
     // Queue distant tiles for lazy loading
-    for (const tile of distantTiles) {
-      this.pendingTiles.set(`${tile.tileX}_${tile.tileZ}`, tile);
+    if (shouldQueueDistantVegetationTiles()) {
+      for (const tile of distantTiles) {
+        this.pendingTiles.set(`${tile.tileX}_${tile.tileZ}`, tile);
+      }
     }
 
-    // Keep startup logs concise; per-tile detail is noisy in embedded spectator mode.
-    console.log(
-      `[VegetationSystem] Processed ${nearbyTiles.length} nearby tiles, queued ${distantTiles.length} for lazy loading`,
-    );
+    if (shouldEmitVerboseVegetationBootLogs()) {
+      console.log(
+        `[VegetationSystem] Processed ${nearbyTiles.length} nearby tiles, queued ${shouldQueueDistantVegetationTiles() ? distantTiles.length : 0} for lazy loading`,
+      );
+    }
   }
 
   /**
@@ -1004,7 +1064,7 @@ export class VegetationSystem extends System {
 
     const dx = Math.abs(tileX - playerTile.x);
     const dz = Math.abs(tileZ - playerTile.z);
-    return Math.max(dx, dz) <= MAX_VEGETATION_TILE_RADIUS;
+    return Math.max(dx, dz) <= getVegetationTileRadius();
   }
 
   /**
@@ -1024,7 +1084,9 @@ export class VegetationSystem extends System {
 
     if (!this.isTileInRange(data.tileX, data.tileZ)) {
       // Store as pending for later generation when player gets closer
-      this.pendingTiles.set(key, data);
+      if (shouldQueueDistantVegetationTiles()) {
+        this.pendingTiles.set(key, data);
+      }
       return;
     }
 
@@ -4151,7 +4213,8 @@ export class VegetationSystem extends System {
    * Process pending tiles that are now within range of the player
    */
   private async processPendingTiles(): Promise<void> {
-    if (this.pendingTiles.size === 0) return;
+    if (!shouldQueueDistantVegetationTiles() || this.pendingTiles.size === 0)
+      return;
 
     const playerTile = this.getPlayerTile();
     if (!playerTile) return;

--- a/packages/shared/src/systems/shared/world/WaterSystem.ts
+++ b/packages/shared/src/systems/shared/world/WaterSystem.ts
@@ -123,6 +123,8 @@ const WATER_LOD = {
   MEDIUM_DISTANCE: 200, // Distance threshold for medium->low LOD
 };
 
+const WATER_TEXTURE_LOAD_TIMEOUT_MS = 5000;
+
 type WaveParams = {
   w: number;
   phi: number;
@@ -336,19 +338,21 @@ export class WaterSystem {
         );
       });
 
-    const [normalResult, flowResult] = await Promise.allSettled([
-      loadTex("/textures/waterNormal.png"),
-      loadTex("/textures/noise28.png"),
+    const [normalTex, flowTex] = await Promise.all([
+      this.withTextureLoadFallback(
+        "water normal",
+        loadTex("/textures/waterNormal.png"),
+        () => this.createNormalMap(512, 1.0, 42),
+      ),
+      this.withTextureLoadFallback(
+        "water flow",
+        loadTex("/textures/noise28.png"),
+        () => this.createFlowFallback(256),
+      ),
     ]);
 
-    this.normalTex =
-      normalResult.status === "fulfilled"
-        ? normalResult.value
-        : await this.createNormalMap(512, 1.0, 42);
-    this.flowTex =
-      flowResult.status === "fulfilled"
-        ? flowResult.value
-        : this.createFlowFallback(256);
+    this.normalTex = normalTex;
+    this.flowTex = flowTex;
     this.foamTex = await this.createFoamTexture(128);
 
     // TSL reflector: handles render target, camera mirroring, oblique clipping
@@ -358,6 +362,52 @@ export class WaterSystem {
 
     this.lakeMaterial = this.createLakeMaterial();
     this.oceanMaterial = this.createOceanMaterial();
+  }
+
+  private async withTextureLoadFallback(
+    label: string,
+    texturePromise: Promise<THREE.Texture>,
+    fallback: () => THREE.Texture | Promise<THREE.Texture>,
+  ): Promise<THREE.Texture> {
+    type TextureLoadResult =
+      | { ok: true; texture: THREE.Texture }
+      | { ok: false; error: unknown };
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<TextureLoadResult>((resolve) => {
+      timeoutId = setTimeout(() => {
+        resolve({
+          ok: false,
+          error: new Error(
+            `${label} texture load timed out after ${WATER_TEXTURE_LOAD_TIMEOUT_MS}ms`,
+          ),
+        });
+      }, WATER_TEXTURE_LOAD_TIMEOUT_MS);
+    });
+
+    try {
+      const result = await Promise.race([
+        texturePromise.then(
+          (texture): TextureLoadResult => ({ ok: true, texture }),
+          (error): TextureLoadResult => ({ ok: false, error }),
+        ),
+        timeout,
+      ]);
+
+      if (result.ok) {
+        return result.texture;
+      }
+
+      console.warn(
+        `[WaterSystem] ${label} texture unavailable; using generated fallback`,
+        result.error,
+      );
+      return await fallback();
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   /**

--- a/packages/shared/src/utils/compute/NetworkingComputeContext.ts
+++ b/packages/shared/src/utils/compute/NetworkingComputeContext.ts
@@ -15,10 +15,13 @@ import {
   BATCH_AGGRO_CHECK_SHADER,
   NEAREST_ENTITY_SHADER,
   PHYSICS_BROADPHASE_SHADER,
+  BROADPHASE_WORKGROUP_SIZE_X,
   SOUND_OCCLUSION_SHADER,
   SPAWN_VALIDATION_SHADER,
   LOOT_DISTRIBUTION_SHADER,
 } from "./shaders/networking.wgsl";
+
+export const MAX_INTEREST_MANAGEMENT_ENTITIES = 65_535;
 
 // ============================================================================
 // TYPES
@@ -339,6 +342,11 @@ export class NetworkingComputeContext {
     const entityCount = entities.length;
     const playerCount = players.length;
     const u32PerEntity = Math.ceil(playerCount / 32);
+    if (entityCount > MAX_INTEREST_MANAGEMENT_ENTITIES) {
+      throw new Error(
+        `Interest management supports at most ${MAX_INTEREST_MANAGEMENT_ENTITIES} entities per dispatch; received ${entityCount}`,
+      );
+    }
 
     // Pack entity data (4 floats per entity)
     const entityData = new Float32Array(entityCount * 4);
@@ -737,9 +745,32 @@ export class NetworkingComputeContext {
       "bp_count",
       new Uint32Array([0]),
     );
+    // Dispatch shape: one GPU thread per pair, workgroup size 64.
+    // The pair count is O(N²), so for aabbCount ≳ 5793 the 1D dispatch
+    // exceeds WebGPU's per-dimension ceiling of 65535 workgroups. We
+    // reshape to a 2D dispatch (x × y × 1) in that case and pass
+    // numWorkgroupsX in the uniform buffer so the shader can
+    // reconstruct the linear thread index via
+    //   threadIdx = global_id.y * (numWorkgroupsX * WORKGROUP_SIZE_1D)
+    //             + global_id.x
+    // For the 1D case we still pass numWorkgroupsX = totalWorkgroups,
+    // y=1, and the shader arithmetic degenerates correctly. Workgroup
+    // size is imported from the shader module so the host-side divisor
+    // can't drift from @workgroup_size.
+    const totalPairs = (aabbCount * (aabbCount - 1)) / 2;
+    const totalWorkgroups = Math.ceil(totalPairs / BROADPHASE_WORKGROUP_SIZE_X);
+    const WEBGPU_MAX_WORKGROUPS_PER_DIM = 65535;
+    const dispatchX = Math.min(totalWorkgroups, WEBGPU_MAX_WORKGROUPS_PER_DIM);
+    const dispatchY = Math.ceil(totalWorkgroups / dispatchX);
+    if (dispatchY > WEBGPU_MAX_WORKGROUPS_PER_DIM) {
+      throw new Error(
+        `Broadphase dispatch exceeds WebGPU 2D workgroup limits: totalWorkgroups=${totalWorkgroups}, dispatch=${dispatchX}x${dispatchY}`,
+      );
+    }
+
     const uniformBuffer = this.ctx.createUniformBuffer(
       "bp_uniforms",
-      new Uint32Array([aabbCount, layerMask, maxOverlaps, 0]),
+      new Uint32Array([aabbCount, layerMask, maxOverlaps, dispatchX]),
     );
 
     if (!aabbBuffer || !overlapBuffer || !countBuffer || !uniformBuffer) {
@@ -758,12 +789,10 @@ export class NetworkingComputeContext {
       throw new Error("Failed to create broadphase bind group");
     }
 
-    // Dispatch - one thread per pair
-    const totalPairs = (aabbCount * (aabbCount - 1)) / 2;
     await this.ctx.dispatchAndWait({
       pipeline: this.broadphasePipeline,
       bindGroup,
-      workgroupCount: this.ctx.calculateWorkgroupCount(totalPairs, 64),
+      workgroupCount: [dispatchX, dispatchY, 1],
     });
 
     // Read back results

--- a/packages/shared/src/utils/compute/RuntimeComputeContext.ts
+++ b/packages/shared/src/utils/compute/RuntimeComputeContext.ts
@@ -677,7 +677,28 @@ export class RuntimeComputeContext {
     elementCount: number,
     workgroupSize: number = 64,
   ): number {
-    return Math.ceil(elementCount / workgroupSize);
+    const count = Math.ceil(elementCount / workgroupSize);
+    // TEMPORARY CANARY INSTRUMENTATION: the 2D-reshape migration is in
+    // progress (only broadphase and road-influence done). Any call still
+    // producing > 65535 would previously return the invalid count and let
+    // WebGPU reject the dispatch with "Dispatch workgroup count X exceeds
+    // max compute workgroups per dimension", crashing the client. Log a
+    // stack-trace-tagged warning to reveal the offender, then clamp so the
+    // dispatch proceeds with degraded output instead of a hard renderer
+    // crash while the migration completes. Safe to strip and replace with
+    // a throw once all sites are reshaped to 2D dispatch.
+    if (count > 65535) {
+      const stack =
+        new Error("[compute-dispatch-over-limit]").stack ??
+        "(no stack available)";
+      // Log at error level — truncated output is incorrect, not just slow —
+      // so this shows up in any aggregator configured to alert on errors.
+      console.error(
+        `[compute] calculateWorkgroupCount=${count} (elementCount=${elementCount}, workgroupSize=${workgroupSize}) exceeds WebGPU 65535 per-dimension ceiling. Clamping to 65535; results past element ${65535 * workgroupSize} will be truncated.\n${stack}`,
+      );
+      return 65535;
+    }
+    return count;
   }
 
   /**

--- a/packages/shared/src/utils/compute/TerrainComputeContext.ts
+++ b/packages/shared/src/utils/compute/TerrainComputeContext.ts
@@ -13,6 +13,7 @@ import {
 import {
   ROAD_INFLUENCE_SHADER,
   ROAD_INFLUENCE_TEXTURE_SHADER,
+  ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X,
   TERRAIN_VERTEX_COLOR_SHADER,
   INSTANCE_MATRIX_SHADER,
   BATCH_DISTANCE_SHADER,
@@ -289,6 +290,10 @@ export class TerrainComputeContext {
       throw new Error("TerrainComputeContext not initialized");
     }
 
+    if (!Number.isFinite(textureSize) || textureSize <= 0) {
+      return new Float32Array(0);
+    }
+
     const pixelCount = textureSize * textureSize;
     const roadCount = roads.length;
 
@@ -317,18 +322,44 @@ export class TerrainComputeContext {
       "rtex_output",
       pixelCount * 4,
     );
+    // Dispatch shape: one GPU thread per pixel at workgroup size 64.
+    // At textureSize ≥ 2048 (pixelCount ≥ 4,194,304) the 1D workgroup
+    // count exceeds WebGPU's 65535 per-dimension ceiling. Reshape to
+    // 2D (dispatchX, dispatchY, 1) in that case and pass numWorkgroupsX
+    // so the shader can reconstruct the linear pixel index via
+    //   idx = global_id.y * (numWorkgroupsX * WORKGROUP_SIZE_1D)
+    //       + global_id.x
+    // Under the 1D case (pixelCount < 4.19M) dispatchY degenerates
+    // to 1 and the math yields idx = global_id.x — identical to the
+    // previous behavior. Workgroup size is imported from the shader
+    // module so the host-side divisor can't drift from @workgroup_size.
+    const totalWorkgroups = Math.ceil(
+      pixelCount / ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X,
+    );
+    const WEBGPU_MAX_WORKGROUPS_PER_DIM = 65535;
+    const dispatchX = Math.min(totalWorkgroups, WEBGPU_MAX_WORKGROUPS_PER_DIM);
+    const dispatchY = Math.ceil(totalWorkgroups / dispatchX);
+    if (dispatchY > WEBGPU_MAX_WORKGROUPS_PER_DIM) {
+      throw new Error(
+        `Road influence texture dispatch exceeds WebGPU 2D workgroup limits: totalWorkgroups=${totalWorkgroups}, dispatch=${dispatchX}x${dispatchY}`,
+      );
+    }
+
+    const roadInfluenceUniformData = new ArrayBuffer(8 * 4);
+    const roadInfluenceUniformF32 = new Float32Array(roadInfluenceUniformData);
+    const roadInfluenceUniformU32 = new Uint32Array(roadInfluenceUniformData);
+    roadInfluenceUniformU32[0] = pixelCount;
+    roadInfluenceUniformF32[1] = roadCount;
+    roadInfluenceUniformF32[2] = textureSize;
+    roadInfluenceUniformF32[3] = worldSize;
+    roadInfluenceUniformF32[4] = centerX;
+    roadInfluenceUniformF32[5] = centerZ;
+    roadInfluenceUniformF32[6] = blendWidth;
+    roadInfluenceUniformU32[7] = dispatchX;
+
     const uniformBuffer = this.ctx.createUniformBuffer(
       "rtex_uniforms",
-      new Float32Array([
-        pixelCount,
-        roadCount,
-        textureSize,
-        worldSize,
-        centerX,
-        centerZ,
-        blendWidth,
-        0, // padding
-      ]),
+      new Uint8Array(roadInfluenceUniformData),
     );
 
     if (!roadBuffer || !outputBuffer || !uniformBuffer) {
@@ -349,11 +380,10 @@ export class TerrainComputeContext {
       throw new Error("Failed to create bind group");
     }
 
-    // Dispatch
     await this.ctx.dispatchAndWait({
       pipeline: this.roadInfluenceTexturePipeline,
       bindGroup,
-      workgroupCount: this.ctx.calculateWorkgroupCount(pixelCount, 64),
+      workgroupCount: [dispatchX, dispatchY, 1],
     });
 
     // Read back results

--- a/packages/shared/src/utils/compute/__tests__/NetworkingComputeContext.test.ts
+++ b/packages/shared/src/utils/compute/__tests__/NetworkingComputeContext.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   NetworkingComputeContext,
+  MAX_INTEREST_MANAGEMENT_ENTITIES,
   isNetworkingComputeAvailable,
   type GPUEntityInterest,
   type GPUPlayerPosition,
@@ -52,6 +53,10 @@ describe("NetworkingComputeContext", () => {
       );
     });
 
+    it("documents the one-workgroup-per-entity interest limit", () => {
+      expect(MAX_INTEREST_MANAGEMENT_ENTITIES).toBe(65_535);
+    });
+
     it("should export spatial range query shader", () => {
       expect(SPATIAL_RANGE_QUERY_SHADER).toBeDefined();
       expect(SPATIAL_RANGE_QUERY_SHADER).toContain("@compute");
@@ -85,6 +90,87 @@ describe("NetworkingComputeContext", () => {
       expect(PHYSICS_BROADPHASE_SHADER).toBeDefined();
       expect(PHYSICS_BROADPHASE_SHADER).toContain("@compute");
       expect(PHYSICS_BROADPHASE_SHADER).toContain("aabbOverlap");
+    });
+
+    it("broadphase shader carries the 2D-dispatch linear-index reconstruction and uniform field", () => {
+      // Regression guard for the 2D dispatch reshape: at aabbCount ≳ 5793
+      // the O(N²) pair dispatch exceeds WebGPU's 65535 per-dimension
+      // workgroup ceiling, so the host issues a 2D dispatch and the
+      // shader must reconstruct the linear thread index from
+      // (global_id.x, global_id.y) using `numWorkgroupsX` passed via
+      // uniforms. If this assertion fails the shader is back to the
+      // 1D form and the canary will stall at 1080p.
+      expect(PHYSICS_BROADPHASE_SHADER).toContain("numWorkgroupsX: u32");
+      // Shader multiplies by a named WGSL const bound to the host-side
+      // workgroup constant (not a raw "64u"), so host and shader cannot
+      // drift. The const value itself is still 64u, emitted from the TS
+      // template literal, so the assertion accepts either form for
+      // safety against future template tweaks.
+      expect(PHYSICS_BROADPHASE_SHADER).toMatch(
+        /uniforms\.numWorkgroupsX \* (WORKGROUP_SIZE_1D|64u)/,
+      );
+      expect(PHYSICS_BROADPHASE_SHADER).toContain(
+        "const WORKGROUP_SIZE_1D: u32 = 64u",
+      );
+      expect(PHYSICS_BROADPHASE_SHADER).toContain(
+        "global_id.y * threadsPerRow + global_id.x",
+      );
+      // `padding` was repurposed to numWorkgroupsX; make sure the old
+      // name isn't accidentally reintroduced.
+      expect(PHYSICS_BROADPHASE_SHADER).not.toContain("padding: u32");
+    });
+
+    it("broadphase 2D dispatch shape covers the pair space", () => {
+      // Host-side reshape math: totalPairs = n*(n-1)/2, workgroups =
+      // ceil(totalPairs / 64), dispatchX = min(workgroups, 65535),
+      // dispatchY = ceil(workgroups / dispatchX). Verify the resulting
+      // (x, y, 64 threads-per-workgroup) 3-tuple ALWAYS covers every
+      // pair for a range of aabbCounts spanning under, at, and well
+      // above the dispatch-dimension ceiling.
+      const WEBGPU_MAX = 65535;
+      const reshape = (aabbCount: number) => {
+        const totalPairs = (aabbCount * (aabbCount - 1)) / 2;
+        const workgroups = Math.ceil(totalPairs / 64);
+        const dispatchX = Math.min(workgroups, WEBGPU_MAX);
+        const dispatchY = Math.ceil(workgroups / dispatchX);
+        if (dispatchY > WEBGPU_MAX) {
+          throw new Error("dispatchY exceeds WebGPU limit");
+        }
+        return { totalPairs, workgroups, dispatchX, dispatchY };
+      };
+
+      for (const aabbCount of [2, 1000, 5793, 5800, 8000, 12000, 20000]) {
+        const r = reshape(aabbCount);
+        // Dimensions within WebGPU limits.
+        expect(r.dispatchX).toBeLessThanOrEqual(WEBGPU_MAX);
+        expect(r.dispatchY).toBeLessThanOrEqual(WEBGPU_MAX);
+        // Total threads cover every pair.
+        expect(r.dispatchX * r.dispatchY * 64).toBeGreaterThanOrEqual(
+          r.totalPairs,
+        );
+      }
+    });
+
+    it("rejects impossible broadphase dispatch shapes instead of overflowing Y", () => {
+      // totalPairs = WEBGPU_MAX² * 64 + 1 forces dispatchY one over the
+      // per-dimension ceiling after the 2D reshape.
+      const WEBGPU_MAX = 65535;
+      const reshape = (aabbCount: number) => {
+        const totalPairs = (aabbCount * (aabbCount - 1)) / 2;
+        const workgroups = Math.ceil(totalPairs / 64);
+        const dispatchX = Math.min(workgroups, WEBGPU_MAX);
+        const dispatchY = Math.ceil(workgroups / dispatchX);
+        if (dispatchY > WEBGPU_MAX) {
+          throw new Error("dispatchY exceeds WebGPU limit");
+        }
+        return { dispatchX, dispatchY };
+      };
+      const impossiblePairs = WEBGPU_MAX * WEBGPU_MAX * 64 + 1;
+      const aabbCount = Math.ceil((1 + Math.sqrt(1 + 8 * impossiblePairs)) / 2);
+
+      expect(() => reshape(aabbCount)).toThrow(
+        "dispatchY exceeds WebGPU limit",
+      );
     });
 
     it("should export sound occlusion shader", () => {

--- a/packages/shared/src/utils/compute/__tests__/TerrainComputeContext.test.ts
+++ b/packages/shared/src/utils/compute/__tests__/TerrainComputeContext.test.ts
@@ -16,6 +16,8 @@ import {
 } from "../TerrainComputeContext";
 import {
   ROAD_INFLUENCE_SHADER,
+  ROAD_INFLUENCE_TEXTURE_SHADER,
+  ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X,
   TERRAIN_VERTEX_COLOR_SHADER,
   INSTANCE_MATRIX_SHADER,
   BATCH_DISTANCE_SHADER,
@@ -28,6 +30,17 @@ describe("TerrainComputeContext", () => {
       expect(ROAD_INFLUENCE_SHADER).toBeDefined();
       expect(ROAD_INFLUENCE_SHADER).toContain("@compute");
       expect(ROAD_INFLUENCE_SHADER).toContain("distanceToLineSegment");
+      expect(ROAD_INFLUENCE_TEXTURE_SHADER).toContain("pixelCount: u32");
+      expect(ROAD_INFLUENCE_TEXTURE_SHADER).toContain("numWorkgroupsX: u32");
+      // Shader multiplies by a named WGSL const bound to the host-side
+      // workgroup constant. Accept either the named form or the literal
+      // 64u in case the template substitution path changes.
+      expect(ROAD_INFLUENCE_TEXTURE_SHADER).toMatch(
+        /uniforms\.numWorkgroupsX \* (WORKGROUP_SIZE_1D|64u)/,
+      );
+      expect(ROAD_INFLUENCE_TEXTURE_SHADER).toContain(
+        "const WORKGROUP_SIZE_1D: u32 = 64u",
+      );
     });
 
     it("should export terrain vertex color shader", () => {
@@ -54,6 +67,80 @@ describe("TerrainComputeContext", () => {
       expect(TERRAIN_SHADERS.VERTEX_COLOR).toBe(TERRAIN_VERTEX_COLOR_SHADER);
       expect(TERRAIN_SHADERS.INSTANCE_MATRIX).toBe(INSTANCE_MATRIX_SHADER);
       expect(TERRAIN_SHADERS.BATCH_DISTANCE).toBe(BATCH_DISTANCE_SHADER);
+    });
+  });
+
+  describe("road-influence 2D dispatch reshape", () => {
+    // The host-side reshape math in TerrainComputeContext.computeRoadInfluence
+    // Texture divides pixelCount by ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X
+    // and reshapes to 2D when it exceeds the WebGPU 65535 per-dimension
+    // ceiling. This is what keeps fresh 1080p+ clients from crashing with
+    // "Dispatch workgroup count exceeds max compute workgroups per
+    // dimension". Test the math here directly without requiring a GPU —
+    // the production code uses these exact formulas at line ~333 of
+    // TerrainComputeContext.ts.
+    const WORKGROUP = ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X;
+    const WEBGPU_MAX = 65535;
+    const dispatch = (pixelCount: number) => {
+      const totalWorkgroups = Math.ceil(pixelCount / WORKGROUP);
+      const dispatchX = Math.min(totalWorkgroups, WEBGPU_MAX);
+      const dispatchY = Math.ceil(totalWorkgroups / dispatchX);
+      if (dispatchY > WEBGPU_MAX) {
+        throw new Error("dispatchY exceeds WebGPU limit");
+      }
+      return { totalWorkgroups, dispatchX, dispatchY };
+    };
+
+    it("stays 1D for texture sizes that fit under the ceiling", () => {
+      // 1024×1024 = 1,048,576 pixels → 16384 workgroups → well under 65535.
+      const { totalWorkgroups, dispatchX, dispatchY } = dispatch(1024 * 1024);
+      expect(totalWorkgroups).toBe(16384);
+      expect(dispatchX).toBe(16384);
+      expect(dispatchY).toBe(1);
+    });
+
+    it("reshapes to 2D exactly at the 2048×2048 boundary", () => {
+      // 2048×2048 = 4,194,304 pixels → 65536 workgroups → one over 65535.
+      // Must reshape: dispatchX=65535, dispatchY=ceil(65536/65535)=2.
+      const pixelCount = 2048 * 2048;
+      const { totalWorkgroups, dispatchX, dispatchY } = dispatch(pixelCount);
+      expect(totalWorkgroups).toBe(65536);
+      expect(dispatchX).toBe(WEBGPU_MAX);
+      expect(dispatchY).toBe(2);
+      // Verify the 2D dispatch covers every pixel: dispatchX * dispatchY *
+      // WORKGROUP threads must span all pixelCount indices.
+      expect(dispatchX * dispatchY * WORKGROUP).toBeGreaterThanOrEqual(
+        pixelCount,
+      );
+    });
+
+    it("reshapes cleanly for 4096×4096 and 8192×8192 textures", () => {
+      // 4096² = 16,777,216 → 262144 workgroups → dispatchY=5 (65535*5=327,675 ≥ 262144).
+      const pc4096 = 4096 * 4096;
+      const d4096 = dispatch(pc4096);
+      expect(d4096.totalWorkgroups).toBe(262144);
+      expect(d4096.dispatchX).toBe(WEBGPU_MAX);
+      expect(d4096.dispatchY).toBe(Math.ceil(262144 / WEBGPU_MAX));
+      expect(
+        d4096.dispatchX * d4096.dispatchY * WORKGROUP,
+      ).toBeGreaterThanOrEqual(pc4096);
+
+      // 8192² = 67,108,864 → 1,048,576 workgroups → dispatchY=16.
+      const pc8192 = 8192 * 8192;
+      const d8192 = dispatch(pc8192);
+      expect(d8192.totalWorkgroups).toBe(1_048_576);
+      expect(d8192.dispatchX).toBe(WEBGPU_MAX);
+      expect(d8192.dispatchY).toBe(Math.ceil(1_048_576 / WEBGPU_MAX));
+      expect(
+        d8192.dispatchX * d8192.dispatchY * WORKGROUP,
+      ).toBeGreaterThanOrEqual(pc8192);
+    });
+
+    it("rejects impossible 2D dispatch shapes instead of overflowing Y", () => {
+      const maxCoveredPixels = WEBGPU_MAX * WEBGPU_MAX * WORKGROUP;
+      expect(() => dispatch(maxCoveredPixels + 1)).toThrow(
+        "dispatchY exceeds WebGPU limit",
+      );
     });
   });
 

--- a/packages/shared/src/utils/compute/shaders/networking.wgsl.ts
+++ b/packages/shared/src/utils/compute/shaders/networking.wgsl.ts
@@ -424,7 +424,16 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
  * - overlaps: pairs of overlapping AABB indices
  * - overlapCount: number of overlapping pairs
  */
+// Workgroup size used by the broadphase compute shader (1D along X).
+// Exported so host-side dispatch math stays in sync with the shader — any
+// drift here would silently miscompute thread indices in the 2D dispatch
+// path (threadsPerRow = numWorkgroupsX * BROADPHASE_WORKGROUP_SIZE_X).
+export const BROADPHASE_WORKGROUP_SIZE_X = 64;
+
 export const PHYSICS_BROADPHASE_SHADER = /* wgsl */ `
+// WORKGROUP_SIZE_1D must match BROADPHASE_WORKGROUP_SIZE_X above.
+const WORKGROUP_SIZE_1D: u32 = ${BROADPHASE_WORKGROUP_SIZE_X}u;
+
 struct AABB {
   minX: f32,
   minY: f32,
@@ -445,7 +454,14 @@ struct Uniforms {
   aabbCount: u32,
   layerMask: u32,  // Bitmask for layer filtering
   maxOverlaps: u32,
-  padding: u32,
+  // X-dimension workgroup count passed from the host. Needed because this
+  // shader can be dispatched 2D (dispatchWorkgroups(x, y, 1)) whenever
+  // ceil(totalPairs/64) exceeds WebGPU's per-dimension ceiling of 65535.
+  // In that case the linear thread index must be reconstructed from
+  // (global_invocation_id.x, global_invocation_id.y) instead of
+  // global_invocation_id.x alone. The 1D dispatch case just passes y=1
+  // and this field is still correct (numWorkgroupsX equals the total).
+  numWorkgroupsX: u32,
 }
 
 @group(0) @binding(0) var<storage, read> aabbs: array<AABB>;
@@ -459,15 +475,22 @@ fn aabbOverlap(a: AABB, b: AABB) -> bool {
          a.minZ <= b.maxZ && a.maxZ >= b.minZ;
 }
 
-@compute @workgroup_size(64)
+@compute @workgroup_size(${BROADPHASE_WORKGROUP_SIZE_X})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-  let threadIdx = global_id.x;
-  
+  // Reconstruct the linear thread index across 2D dispatch.
+  // threadsPerRow = numWorkgroupsX * workgroup_size_x.
+  // Under a 1D dispatch dispatchWorkgroups(N, 1, 1), global_id.y is 0 and
+  // this reduces to threadIdx = global_id.x. Under a 2D dispatch
+  // dispatchWorkgroups(65535, K, 1), global_id.y ranges 0..K-1 and we
+  // offset by a full row of threads per y.
+  let threadsPerRow = uniforms.numWorkgroupsX * WORKGROUP_SIZE_1D;
+  let threadIdx = global_id.y * threadsPerRow + global_id.x;
+
   // Each thread checks one pair (upper triangle of N×N matrix)
   // Thread i maps to pair (a, b) where a < b
   let n = uniforms.aabbCount;
   let totalPairs = n * (n - 1u) / 2u;
-  
+
   if (threadIdx >= totalPairs) {
     return;
   }

--- a/packages/shared/src/utils/compute/shaders/terrain.wgsl.ts
+++ b/packages/shared/src/utils/compute/shaders/terrain.wgsl.ts
@@ -150,8 +150,16 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
  * Output:
  * - influences: float per pixel (0-1)
  */
+// Workgroup size used by the road-influence-texture compute shader (1D
+// along X). Exported so host-side TerrainComputeContext dispatch math stays
+// in sync with the shader — any drift here would silently miscompute pixel
+// indices in the 2D dispatch reshape path.
+export const ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X = 64;
+
 export const ROAD_INFLUENCE_TEXTURE_SHADER = /* wgsl */ `
 const EPS: f32 = 0.001;
+// WORKGROUP_SIZE_1D must match ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X above.
+const WORKGROUP_SIZE_1D: u32 = ${ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X}u;
 
 struct Road {
   startX: f32,
@@ -165,14 +173,23 @@ struct Road {
 }
 
 struct Uniforms {
-  pixelCount: f32,
+  pixelCount: u32,
   roadCount: f32,
   textureSize: f32,
   worldSize: f32,
   centerX: f32,
   centerZ: f32,
   blendWidth: f32,
-  padding: f32,
+  // X-dimension workgroup count passed from the host. At textureSize ≥
+  // 2048 (pixelCount ≥ 4,194,304) the 1D dispatch count exceeds
+  // WebGPU's 65535 per-dimension ceiling, so the host issues a 2D
+  // dispatch (dispatchWorkgroups(x, y, 1)) and the shader must
+  // reconstruct the linear pixel index from
+  // (global_invocation_id.x, global_invocation_id.y) using
+  // numWorkgroupsX. Under the 1D case the host passes y=1 and
+  // numWorkgroupsX = totalWorkgroups, and the arithmetic degenerates
+  // back to idx = global_id.x.
+  numWorkgroupsX: u32,
 }
 
 @group(0) @binding(0) var<storage, read> roads: array<Road>;
@@ -206,14 +223,20 @@ fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
   return t * t * (3.0 - 2.0 * t);
 }
 
-@compute @workgroup_size(64)
+@compute @workgroup_size(${ROAD_INFLUENCE_TEXTURE_WORKGROUP_SIZE_X})
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
-  let idx = global_id.x;
-  let pixelCount = u32(uniforms.pixelCount);
-  if (idx >= pixelCount) {
+  // Reconstruct the linear pixel index across 2D dispatch.
+  // threadsPerRow = numWorkgroupsX * workgroup_size_x.
+  // Under a 1D dispatch dispatchWorkgroups(N, 1, 1), global_id.y is 0
+  // and this reduces to idx = global_id.x. Under a 2D dispatch
+  // dispatchWorkgroups(65535, K, 1) we offset by a full row of threads
+  // per y index.
+  let threadsPerRow = uniforms.numWorkgroupsX * WORKGROUP_SIZE_1D;
+  let idx = global_id.y * threadsPerRow + global_id.x;
+  if (idx >= uniforms.pixelCount) {
     return;
   }
-  
+
   let roadCount = u32(uniforms.roadCount);
   let texSize = u32(uniforms.textureSize);
   let halfWorld = uniforms.worldSize * 0.5;


### PR DESCRIPTION
## Summary
This draft isolates the terrain, viewport-loading, and WebGPU compute stability work from the broader umbrella branch.

## Includes
- terrain/world loading and stream viewport tuning
- WebGPU 2D dispatch reshaping and related shader/host fixes
- client/render runtime changes directly needed for that path

## Excludes
- streaming authority and payout/auth hardening
- agent-route and Eliza/dashboard work

## Validation
- split from `enoomian/streaming-authority-compute`
- draft pending focused revalidation in an environment with the full local dependency graph available