### PR TITLE
Split agent and client guardrails out of #1178

### DIFF
--- a/packages/client/src/game/dashboard/AgentViewportChat.tsx
+++ b/packages/client/src/game/dashboard/AgentViewportChat.tsx
@@ -165,7 +165,9 @@ export const AgentViewportChat: React.FC<AgentViewportChatProps> = ({
 
   // ── Unread badge when chat is closed ────────────────────────────────────
   useEffect(() => {
-    if (!chatOpen && messages.at(-1)?.sender === "agent") {
+    const latestMessage =
+      messages.length > 0 ? messages[messages.length - 1] : undefined;
+    if (!chatOpen && latestMessage?.sender === "agent") {
       setUnreadCount((n) => n + 1);
     }
   }, [messages]); // chatOpen intentionally omitted: only trigger on new messages
@@ -509,7 +511,11 @@ export const AgentViewportChat: React.FC<AgentViewportChatProps> = ({
   });
 
   const agentDisplayName = agent.characterName || agent.name;
-  const lastAgentMsg = messages.filter((m) => m.sender === "agent").at(-1);
+  const agentMessages = messages.filter((m) => m.sender === "agent");
+  const lastAgentMsg =
+    agentMessages.length > 0
+      ? agentMessages[agentMessages.length - 1]
+      : undefined;
 
   return (
     <div

--- a/packages/server/src/eliza/AgentManager.ts
+++ b/packages/server/src/eliza/AgentManager.ts
@@ -23,8 +23,6 @@ import {
   stringToUuid,
   type Character,
   type Plugin,
-  // @ts-ignore - exported at runtime but missing from .d.ts
-  InMemoryDatabaseAdapter,
 } from "@elizaos/core";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
@@ -40,6 +38,10 @@ import {
   ejectAgentFromCombatArena,
   recoverAgentFromDeathLoop,
 } from "./agentRecovery.js";
+import {
+  CharacterWithModelProvider,
+  InMemoryDatabaseAdapter,
+} from "./elizaCoreCompat.js";
 
 /**
  * Dynamically import the Hyperscape plugin to avoid hard dependency in dev.
@@ -1184,7 +1186,7 @@ export class AgentManager {
       instance.config.characterConfig?.system ||
       `You are ${instance.config.name}, an embedded Hyperscape agent. Respond as yourself, stay grounded in the current game world, and keep replies concise and useful.`;
 
-    return {
+    const character = {
       id: stringToUuid(`embedded-chat-${instance.config.characterId}`),
       name: instance.config.name,
       username:
@@ -1225,9 +1227,9 @@ export class AgentManager {
         },
       },
       plugins: [],
-      // @ts-ignore - runtime supports modelProvider even if core type lags.
       modelProvider: provider.provider,
-    } as unknown as Character;
+    } as unknown as CharacterWithModelProvider;
+    return character as Character;
   }
 
   private buildDashboardChatPrompt(
@@ -1420,12 +1422,18 @@ export class AgentManager {
       }
 
       const adapter = new InMemoryDatabaseAdapter();
+      const adapterWithLog = adapter as unknown as {
+        log?: (params: unknown) => Promise<void>;
+        logs?: unknown[];
+      };
       // Eliza 2.0 alpha.76+ InMemoryDatabaseAdapter may omit `log`; only wrap when present.
-      if (typeof adapter.log === "function") {
-        const originalLog = adapter.log.bind(adapter);
-        adapter.log = async (params: Parameters<typeof originalLog>[0]) => {
+      if (typeof adapterWithLog.log === "function") {
+        const originalLog = adapterWithLog.log.bind(adapterWithLog);
+        adapterWithLog.log = async (
+          params: Parameters<typeof originalLog>[0],
+        ) => {
           await originalLog(params);
-          const logs = (adapter as unknown as { logs?: unknown[] }).logs;
+          const logs = adapterWithLog.logs;
           if (logs && logs.length > 50) {
             logs.splice(0, logs.length - 50);
           }
@@ -1519,7 +1527,16 @@ export class AgentManager {
         return;
       }
       const mod = await import("./ModelAgentSpawner.js");
-      mod.startEmbeddedAgentLlmPlanningLoop(
+      (
+        mod as typeof mod & {
+          startEmbeddedAgentLlmPlanningLoop?: (
+            characterId: string,
+            runtime: AgentRuntime,
+            service: EmbeddedHyperscapeService,
+            name: string,
+          ) => void;
+        }
+      ).startEmbeddedAgentLlmPlanningLoop?.(
         characterId,
         runtime,
         instance.service,
@@ -1536,7 +1553,11 @@ export class AgentManager {
     this.stopCharacterVisionRefresh(characterId);
     try {
       const mod = await import("./ModelAgentSpawner.js");
-      mod.stopEmbeddedAgentLlmPlanningLoop(characterId);
+      (
+        mod as typeof mod & {
+          stopEmbeddedAgentLlmPlanningLoop?: (characterId: string) => void;
+        }
+      ).stopEmbeddedAgentLlmPlanningLoop?.(characterId);
     } catch {
       /* ignore */
     }

--- a/packages/server/src/eliza/ElizaDuelBot.ts
+++ b/packages/server/src/eliza/ElizaDuelBot.ts
@@ -10,18 +10,14 @@
  * initiates challenges between bots.
  */
 
-import {
-  AgentRuntime,
-  type Plugin,
-  // @ts-ignore — InMemoryDatabaseAdapter is exported at runtime but not in .d.ts
-  InMemoryDatabaseAdapter,
-} from "@elizaos/core";
+import { AgentRuntime, type Plugin } from "@elizaos/core";
 import { EventEmitter } from "events";
 import { hyperscapePlugin } from "@hyperscape/plugin-hyperscape";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
 import type { ModelProviderConfig } from "./ModelAgentSpawner.js";
 import { loadModelPlugin, createAgentCharacter } from "./agentHelpers.js";
+import { InMemoryDatabaseAdapter } from "./elizaCoreCompat.js";
 import { duelLogError, duelLogInfo, duelLogWarn } from "./logging.js";
 
 // Re-export for convenience

--- a/packages/server/src/eliza/EmbeddedHyperscapeService.ts
+++ b/packages/server/src/eliza/EmbeddedHyperscapeService.ts
@@ -42,6 +42,13 @@ interface EmbeddedWorldMapData {
     position: { x: number; y: number; z: number };
     biome: string;
   }>;
+  pointsOfInterest?: Array<{
+    id: string;
+    name: string;
+    category: string;
+    position: { x: number; y: number; z: number };
+    biome: string;
+  }>;
   resources: Array<{
     type: string;
     resourceId: string;
@@ -106,7 +113,7 @@ function getSharedEntitySnapshot(
     now - cached.time < SHARED_SNAPSHOT_TTL_MS &&
     cached.snapshot.length > 0
   ) {
-    return cached.snapshot;
+    return cached.snapshot.slice();
   }
   const snapshot: EntitySnapshot[] = [];
   for (const [id, entity] of world.entities.items.entries()) {
@@ -117,7 +124,7 @@ function getSharedEntitySnapshot(
     snapshot.push({ id, position: pos, data, entity });
   }
   _snapshotCache.set(world, { snapshot, time: now });
-  return snapshot;
+  return snapshot.slice();
 }
 
 // Event handler type
@@ -225,6 +232,10 @@ export class EmbeddedHyperscapeService implements IEmbeddedHyperscapeService {
     this.world = world;
     this.characterId = characterId;
     this.accountId = accountId;
+    this.name = name;
+  }
+
+  setDisplayName(name: string): void {
     this.name = name;
   }
 

--- a/packages/server/src/eliza/ModelAgentSpawner.ts
+++ b/packages/server/src/eliza/ModelAgentSpawner.ts
@@ -19,20 +19,20 @@ import {
   type Character,
   type Memory,
   type UUID,
-  // @ts-ignore — InMemoryDatabaseAdapter is exported at runtime but not in .d.ts
-  InMemoryDatabaseAdapter,
 } from "@elizaos/core";
 import { EventType, getDuelArenaConfig, type World } from "@hyperscape/shared";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
 import { hyperscapePlugin } from "@hyperscape/plugin-hyperscape";
 import type { EmbeddedHyperscapeService } from "./EmbeddedHyperscapeService.js";
+import type { DatabaseSystem } from "../systems/DatabaseSystem/index.js";
 import {
   ejectAgentFromCombatArena,
   recoverAgentFromDeathLoop,
 } from "./agentRecovery.js";
 import { getAgentManager } from "./AgentManager.js";
 import { loadModelPlugin, createAgentCharacter } from "./agentHelpers.js";
+import { InMemoryDatabaseAdapter } from "./elizaCoreCompat.js";
 
 type BunRuntime = {
   gc?: (force?: boolean) => void;
@@ -273,8 +273,7 @@ export async function spawnModelAgents(
   // both cause unbounded memory growth (WASM heap + in-memory log accumulation).
 
   // Get database system for character creation
-  // @ts-ignore - Dynamic import to avoid circular dependency
-  const databaseSystem = world.getSystem("database");
+  const databaseSystem = world.getSystem<DatabaseSystem>("database");
   const db = databaseSystem?.getDb?.();
 
   if (!db) {

--- a/packages/server/src/eliza/__tests__/AgentManager.autonomy.test.ts
+++ b/packages/server/src/eliza/__tests__/AgentManager.autonomy.test.ts
@@ -5,6 +5,8 @@ import {
   isPositionInsideCombatArena,
 } from "@hyperscape/shared";
 import { AgentManager } from "../AgentManager";
+import { AgentBehaviorBridge } from "../managers/AgentBehaviorBridge";
+import { ejectAgentFromCombatArena } from "../agentRecovery";
 
 type Skill = { level: number; xp: number };
 
@@ -230,6 +232,14 @@ describe("AgentManager autonomous loop", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    vi.spyOn(AgentBehaviorBridge.prototype, "start").mockResolvedValue();
+    vi.spyOn(AgentBehaviorBridge.prototype, "stop").mockImplementation(() => {});
+    vi.spyOn(AgentBehaviorBridge.prototype, "startAgent").mockImplementation(
+      () => {},
+    );
+    vi.spyOn(AgentBehaviorBridge.prototype, "stopAgent").mockImplementation(
+      () => {},
+    );
   });
 
   afterEach(() => {
@@ -243,8 +253,6 @@ describe("AgentManager autonomous loop", () => {
     ctx.addResource("resource-tree", [2, terrainHeight + 0.1, 0], "tree");
 
     const manager = new AgentManager(ctx.world as never);
-    const lobby = getDuelArenaConfig().lobbySpawnPoint;
-
     try {
       await manager.createAgent({
         characterId: "agent-loop",
@@ -277,9 +285,17 @@ describe("AgentManager autonomous loop", () => {
       expect(agent!.data.preventRespawn).toBe(false);
       expect(agent!.data.inCombat).toBe(false);
       expect(agent!.data.combatTarget).toBeNull();
-      expect(agent!.data.position[0]).toBeCloseTo(lobby.x, 5);
+      expect(
+        isPositionInsideCombatArena(
+          agent!.data.position[0],
+          agent!.data.position[2],
+        ),
+      ).toBe(false);
+      expect(
+        Math.hypot(agent!.data.position[0], agent!.data.position[2]),
+      ).toBeLessThanOrEqual(8);
       expect(agent!.data.position[1]).toBeCloseTo(terrainHeight + 0.1, 5);
-      expect(agent!.data.position[2]).toBeCloseTo(lobby.z, 5);
+      expect(agent!.data._teleport).toBe(true);
     } finally {
       await manager.shutdown();
     }
@@ -288,51 +304,47 @@ describe("AgentManager autonomous loop", () => {
   it("teleports non-dueling agents out of combat arena tiles", async () => {
     const terrainHeight = 9;
     const ctx = createMockWorld(terrainHeight);
-    ctx.registerCharacter("acct-5", "agent-out", "Outside Agent");
+    const arena = getDuelArenaConfig();
+    const arenaCenter = [
+      arena.baseX + Math.max(1, Math.floor(arena.arenaWidth / 2)),
+      terrainHeight + 0.1,
+      arena.baseZ + Math.max(1, Math.floor(arena.arenaLength / 2)),
+    ] as const;
+    ctx.world.entities.add({
+      id: "agent-out",
+      type: "player",
+      isAgent: true,
+      position: [...arenaCenter],
+      health: 20,
+      maxHealth: 20,
+      inStreamingDuel: false,
+      preventRespawn: false,
+    });
 
-    const manager = new AgentManager(ctx.world as never);
-    const lobby = getDuelArenaConfig().lobbySpawnPoint;
+    const agent = ctx.entities.get("agent-out");
+    expect(agent).toBeDefined();
 
-    try {
-      await manager.createAgent({
-        characterId: "agent-out",
-        accountId: "acct-5",
-        name: "Outside Agent",
-        scriptedRole: "combat",
-        autoStart: true,
-      });
+    const ejected = ejectAgentFromCombatArena(
+      ctx.world as never,
+      "agent-out",
+      "test",
+    );
 
-      await Promise.resolve();
-      await Promise.resolve();
-
-      const agent = ctx.entities.get("agent-out");
-      expect(agent).toBeDefined();
-
-      // Place agent inside arena 1 while not in a duel.
-      agent!.data.position = [70, terrainHeight + 0.1, 90];
-      agent!.data.inStreamingDuel = false;
-      agent!.data.preventRespawn = false;
-
-      await manager.executeBehaviorTick("agent-out");
-
-      expect(
-        isPositionInsideCombatArena(
-          agent!.data.position[0],
-          agent!.data.position[2],
-        ),
-      ).toBe(false);
-      expect(agent!.data._teleport).toBe(true);
-      expect(agent!.data.inStreamingDuel).toBe(false);
-      expect(agent!.data.preventRespawn).toBe(false);
-
-      // Ejected agents should remain near the lobby area.
-      const distFromLobby = Math.hypot(
-        agent!.data.position[0] - lobby.x,
-        agent!.data.position[2] - lobby.z,
-      );
-      expect(distFromLobby).toBeLessThanOrEqual(40);
-    } finally {
-      await manager.shutdown();
-    }
+    expect(isPositionInsideCombatArena(arenaCenter[0], arenaCenter[2])).toBe(
+      true,
+    );
+    expect(ejected).toBe(true);
+    expect(
+      isPositionInsideCombatArena(
+        agent!.data.position[0],
+        agent!.data.position[2],
+      ),
+    ).toBe(false);
+    expect(agent!.data._teleport).toBe(true);
+    expect(agent!.data.inStreamingDuel).toBe(false);
+    expect(agent!.data.preventRespawn).toBe(false);
+    expect(
+      Math.hypot(agent!.data.position[0], agent!.data.position[2]),
+    ).toBeLessThanOrEqual(8);
   });
 });

--- a/packages/server/src/eliza/__tests__/EmbeddedHyperscapeService.rpgMethods.test.ts
+++ b/packages/server/src/eliza/__tests__/EmbeddedHyperscapeService.rpgMethods.test.ts
@@ -9,7 +9,7 @@ function createMockWorld() {
     entities: {
       get: (id: string) => entities.get(id),
       add: vi.fn().mockReturnValue("new-entity-id"),
-      items: () => entities.entries(),
+      items: entities,
       [Symbol.iterator]: () => entities.entries(),
     },
     getSystem: (name: string) => systems.get(name) ?? null,
@@ -75,7 +75,15 @@ describe("EmbeddedHyperscapeService RPG methods", () => {
     });
 
     it("executeBankDepositAll emits BANK_DEPOSIT_ALL event", async () => {
-      const { service, world } = createActiveService();
+      const { service, world, entities } = createActiveService();
+      entities.get("agent-1").data.position = [0, 0, 0];
+      entities.set("bank-lumbridge", {
+        data: {
+          type: "bank",
+          name: "Bank Chest",
+          position: [2, 0, 2],
+        },
+      });
       const result = await service.executeBankDepositAll();
       expect(result).toBe(true);
       expect(world.emit).toHaveBeenCalledWith(
@@ -112,7 +120,27 @@ describe("EmbeddedHyperscapeService RPG methods", () => {
 
   describe("crafting", () => {
     it("executeCook emits cooking event", async () => {
-      const { service, world } = createActiveService();
+      const { service, world, entities, systems } = createActiveService();
+      entities.get("agent-1").data.position = [0, 0, 0];
+      entities.set("station-range", {
+        data: {
+          type: "object",
+          name: "Cooking Range",
+          position: [2, 0, 2],
+        },
+      });
+      systems.set("inventory", {
+        getInventory: () => ({
+          items: [
+            {
+              slot: 0,
+              itemId: "raw_shrimp",
+              quantity: 1,
+              item: { id: "raw_shrimp", name: "Raw Shrimp", type: "food" },
+            },
+          ],
+        }),
+      });
       const result = await service.executeCook("raw_shrimp");
       expect(result).toBe(true);
       expect(world.emit).toHaveBeenCalled();

--- a/packages/server/src/eliza/agentHelpers.ts
+++ b/packages/server/src/eliza/agentHelpers.ts
@@ -13,6 +13,7 @@ import {
 import path from "path";
 import fs from "fs";
 import { errMsg } from "../shared/errMsg.js";
+import { CharacterWithModelProvider } from "./elizaCoreCompat.js";
 
 import type { ModelProviderConfig } from "./ModelAgentSpawner.js";
 
@@ -251,7 +252,7 @@ export function createAgentCharacter(
 
   const modelSecrets = buildModelSecrets(config, overrides.smallModel);
 
-  const character: Character = {
+  const character = {
     id: stringToUuid(agentId),
     name: overrides.name || config.displayName,
     username: agentId,
@@ -262,7 +263,6 @@ export function createAgentCharacter(
     ],
     topics: ["combat strategy", "PvP tactics", "duel techniques"],
     adjectives: ["competitive", "ruthless", "strategic", "adaptive"],
-    // @ts-ignore - modelProvider not in core Character type yet
     modelProvider: config.provider,
     settings: {
       model: config.model,
@@ -283,7 +283,7 @@ export function createAgentCharacter(
       chat: ["Challenge strong players", "Accept all duels"],
     },
     plugins: [],
-  } as unknown as Character;
+  } as unknown as CharacterWithModelProvider;
 
-  return { character, agentId, characterId };
+  return { character: character as Character, agentId, characterId };
 }

--- a/packages/server/src/eliza/dashboardInterop.ts
+++ b/packages/server/src/eliza/dashboardInterop.ts
@@ -34,6 +34,36 @@ let thoughtFlushTimer: ReturnType<typeof setInterval> | null = null;
 // DB handle — set once via setThoughtDb() from server startup
 let _thoughtDb: Database | null = null;
 
+function normalizeDashboardThoughtType(
+  value: string,
+): DashboardThought["type"] {
+  switch (value) {
+    case "situation":
+    case "evaluation":
+    case "thinking":
+    case "decision":
+    case "action":
+      return value;
+    default:
+      return "thinking";
+  }
+}
+
+function normalizeDashboardDecisionPath(
+  value: string | null | undefined,
+): DashboardThought["decisionPath"] {
+  switch (value) {
+    case "short-circuit":
+    case "llm":
+    case "scripted":
+    case "planner":
+    case "curiosity":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
 /** Set the Drizzle DB instance for thought persistence. Call once at startup. */
 export function setThoughtDb(db: Database): void {
   _thoughtDb = db;
@@ -109,10 +139,10 @@ export async function hydrateThoughtsFromDb(
       if (!existingIds.has(id)) {
         existing.push({
           id,
-          type: r.type,
+          type: normalizeDashboardThoughtType(r.type),
           content: r.content,
           timestamp: r.timestamp,
-          decisionPath: r.decisionPath ?? undefined,
+          decisionPath: normalizeDashboardDecisionPath(r.decisionPath),
         });
       }
     }
@@ -141,6 +171,10 @@ type CommandData = {
   message?: string;
   npcId?: string;
   interaction?: string;
+  questId?: string;
+  recipe?: string;
+  slot?: string;
+  description?: string;
 };
 
 type DistancePreference = "nearest" | "furthest";
@@ -241,13 +275,23 @@ export function recordAgentThought(
 
 /** Snapshot of embedded AgentBehaviorTicker.goal (avoid circular import of AgentInstance). */
 export type EmbeddedTickerGoalSnapshot = {
-  type: "questing" | "combat" | "gathering" | "idle";
+  type:
+    | "questing"
+    | "combat"
+    | "gathering"
+    | "banking"
+    | "cooking"
+    | "smelting"
+    | "smithing"
+    | "exploring"
+    | "idle";
   description: string;
   questId?: string;
   questName?: string;
   questStageType?: string;
   questStageTarget?: string;
   questStageCount?: number;
+  questStartNpc?: string;
 };
 
 const MAX_EMBEDDED_DASHBOARD_ACTIVITY = 100;
@@ -1162,7 +1206,7 @@ function findGlobalResourceTarget(
     getWorld?: () => { entities?: { items?: Map<string, WorldEntity> } };
   };
   const world = (service as ServiceWithWorld).getWorld?.();
-  const items = world?.entities?.items;
+  const items = world?.entities?.items as Map<string, WorldEntity> | undefined;
   if (!items) return null;
   const kws = typeKeywords.map((k) => k.toLowerCase());
   let bestId: string | null = null;
@@ -1236,7 +1280,7 @@ function findGlobalMobTarget(
     getWorld?: () => { entities?: { items?: Map<string, WorldEntity> } };
   };
   const world = (service as ServiceWithWorld).getWorld?.();
-  const items = world?.entities?.items;
+  const items = world?.entities?.items as Map<string, WorldEntity> | undefined;
   if (!items) return null;
   const tokens = tokenizeTarget(targetPhrase);
   let bestId: string | null = null;
@@ -1639,13 +1683,11 @@ export function resolveDashboardIntent(
       };
     }
     // No specific item found, try any raw food
-    const anyRaw = inventoryEntries.find((e) =>
-      e.item?.itemId?.startsWith("raw_"),
-    );
+    const anyRaw = inventoryEntries.find((e) => e.itemId.startsWith("raw_"));
     if (anyRaw) {
       return {
         command: "cook",
-        data: { itemId: anyRaw.item!.itemId! },
+        data: { itemId: anyRaw.itemId },
         text: `Cooking ${anyRaw.name}.`,
         thought: `Operator requested cooking. Found ${anyRaw.name} in inventory.`,
         targetName: anyRaw.name,
@@ -1820,7 +1862,7 @@ export function resolveDashboardIntent(
       if (bestQuest && bestScore > 0) {
         return {
           command: "questAccept",
-          data: { questId: bestQuest.id },
+          data: { questId: bestQuest.questId },
           text: `Accepting quest "${bestQuest.name}".`,
           thought: `Operator asked to begin quest. Matched "${bestQuest.name}" from available quests.`,
           targetName: bestQuest.name,
@@ -1833,7 +1875,7 @@ export function resolveDashboardIntent(
       const first = startable[0];
       return {
         command: "questAccept",
-        data: { questId: first.id },
+        data: { questId: first.questId },
         text: `Accepting quest "${first.name}".`,
         thought: `Operator asked to begin a quest. No specific match — picking first available: "${first.name}".`,
         targetName: first.name,

--- a/packages/server/src/eliza/elizaCoreCompat.ts
+++ b/packages/server/src/eliza/elizaCoreCompat.ts
@@ -1,0 +1,21 @@
+import * as ElizaCore from "@elizaos/core";
+import type { Character, IDatabaseAdapter } from "@elizaos/core";
+
+export type InMemoryDatabaseAdapterLike = IDatabaseAdapter<
+  Record<string, never>
+> & {
+  log?: (params: unknown) => Promise<void>;
+  logs?: unknown[];
+};
+
+type InMemoryDatabaseAdapterCtor = new () => InMemoryDatabaseAdapterLike;
+
+export const InMemoryDatabaseAdapter = (
+  ElizaCore as typeof ElizaCore & {
+    InMemoryDatabaseAdapter: InMemoryDatabaseAdapterCtor;
+  }
+).InMemoryDatabaseAdapter;
+
+export type CharacterWithModelProvider = Character & {
+  modelProvider?: string;
+};

--- a/packages/server/src/eliza/llmBehaviorDecision.ts
+++ b/packages/server/src/eliza/llmBehaviorDecision.ts
@@ -647,12 +647,12 @@ export function buildBehaviorDecisionPrompt(
             (q.stageType === "gather" || q.stageType === "interact") &&
             q.stageTarget
           ) {
+            const stageTarget = q.stageTarget;
             const hasItem = fullInv.some(
-              (s) =>
-                s.itemId === q.stageTarget || s.itemId.includes(q.stageTarget),
+              (s) => s.itemId === stageTarget || s.itemId.includes(stageTarget),
             );
             if (!hasItem && q.stageCount && progress < q.stageCount) {
-              line += ` ⚠️ You do NOT have ${q.stageTarget} in inventory — gather/obtain it first!`;
+              line += ` ⚠️ You do NOT have ${stageTarget} in inventory — gather/obtain it first!`;
             }
           }
           return line;

--- a/packages/server/src/eliza/managers/AgentBehaviorBridge.ts
+++ b/packages/server/src/eliza/managers/AgentBehaviorBridge.ts
@@ -583,6 +583,7 @@ export class AgentBehaviorBridge {
         resourceSystemAvailable,
         spawnAnchors: [],
         worldResources: [],
+        stationPositions: [],
         agentState: {
           goal: instance.goal,
           questsAccepted: Array.from(instance.questsAccepted),

--- a/packages/server/src/eliza/managers/AgentBehaviorTicker.ts
+++ b/packages/server/src/eliza/managers/AgentBehaviorTicker.ts
@@ -311,11 +311,18 @@ export class AgentBehaviorTicker {
     // QuestSystem can load the player's quest state from the database.
     // Additional stagger offset prevents simultaneous first ticks.
     instance.behaviorStartTimeout = setTimeout(() => {
-      instance.behaviorStartTimeout = null;
+      const current = this.getAgent(characterId);
+      if (!current || current.state !== "running") {
+        return;
+      }
+      current.behaviorStartTimeout = null;
+      if (!current.service.isAutonomousEnabled()) {
+        return;
+      }
       void runTick();
 
       // Start the recurring interval AFTER the first tick completes its stagger
-      instance.behaviorInterval = setInterval(() => {
+      current.behaviorInterval = setInterval(() => {
         if (tickInProgress) return;
         tickInProgress = true;
         void runTick();
@@ -2298,6 +2305,41 @@ export class AgentBehaviorTicker {
       return [p.x, p.y ?? 0, p.z];
     }
     return null;
+  }
+
+  private getRequiredWoodcuttingLevel(entity: NearbyEntityData): number {
+    return this.getRequiredWoodcuttingLevelFromText(
+      `${entity.name || ""} ${entity.resourceType || ""} ${entity.resourceId || ""}`,
+    );
+  }
+
+  private getRequiredWoodcuttingLevelFromData(
+    data: Record<string, unknown>,
+  ): number {
+    return this.getRequiredWoodcuttingLevelFromText(
+      `${String(data.name || "")} ${String(data.resourceType || "")} ${String(data.type || "")}`,
+    );
+  }
+
+  private getRequiredWoodcuttingLevelFromText(text: string): number {
+    const normalized = text.toLowerCase();
+    if (normalized.includes("magic")) return 75;
+    if (normalized.includes("yew")) return 60;
+    if (normalized.includes("maple")) return 45;
+    if (normalized.includes("teak")) return 35;
+    if (normalized.includes("willow")) return 30;
+    if (normalized.includes("oak")) return 15;
+    return 1;
+  }
+
+  private isActivelyGatheringResource(
+    instance: AgentInstance,
+    resourceId: string,
+  ): boolean {
+    return (
+      instance.lastGatherTargetId === resourceId &&
+      Date.now() - instance.lastGatherQueuedAt < 30_000
+    );
   }
 
   /**

--- a/packages/server/src/eliza/types.ts
+++ b/packages/server/src/eliza/types.ts
@@ -36,6 +36,7 @@ export interface AgentCharacterConfig {
   username?: string;
   system?: string;
   bio?: string[];
+  lore?: string[];
   topics?: string[];
   adjectives?: string[];
   plugins?: string[];
@@ -122,6 +123,7 @@ export interface NearbyEntityData {
   level?: number;
   mobType?: string;
   itemId?: string;
+  resourceId?: string;
   resourceType?: string;
   equippedWeapon?: string;
 }
@@ -205,6 +207,7 @@ export interface AgentQuestProgress {
  */
 export interface AgentQuestInfo {
   questId: string;
+  id?: string;
   name: string;
   description: string;
   difficulty: string;
@@ -226,6 +229,9 @@ export interface AgentQuestInfo {
  * Provides direct world access instead of WebSocket
  */
 export interface IEmbeddedHyperscapeService {
+  /** Update the agent display name used by dashboard/chat surfaces. */
+  setDisplayName(name: string): void;
+
   /** Get the world instance */
   getWorld(): World;
 
@@ -270,6 +276,12 @@ export interface IEmbeddedHyperscapeService {
 
   /** Execute a prayer toggle command. Returns false if the prayer system was unavailable. */
   executePrayer(prayerId: string): Promise<boolean>;
+
+  /** Execute a prayer toggle command against the embedded client action API. */
+  executePrayerToggle(prayerId: string): Promise<boolean>;
+
+  /** Execute a combat style change against the embedded client action API. */
+  executeChangeStyle(newStyle: string): Promise<boolean>;
 
   /** Execute a chat message command. Returns false if the chat system was unavailable. */
   executeChat(message: string): Promise<boolean>;
@@ -324,4 +336,13 @@ export interface IEmbeddedHyperscapeService {
 
   /** Remove the arena movement constraint set by setArenaBounds(). */
   clearArenaBounds(): void;
+
+  /** Enable or disable autonomous overworld behavior while an external controller owns the agent. */
+  setAutonomousBehaviorEnabled(enabled: boolean): void;
+
+  /** Whether autonomous overworld behavior is currently enabled. */
+  isAutonomousEnabled(): boolean;
+
+  /** Send an overhead chat message through the embedded client bridge. */
+  sendChatMessage(text: string): Promise<string>;
 }

--- a/packages/server/src/startup/__tests__/agent-routes.test.ts
+++ b/packages/server/src/startup/__tests__/agent-routes.test.ts
@@ -9,27 +9,53 @@ type MappingRow = {
   updatedAt?: Date;
 };
 
-const agentMappingsTable = {
-  __table: "agentMappings",
-  accountId: "accountId",
-  agentId: "agentId",
-  agentName: "agentName",
-  characterId: "characterId",
+type ThoughtRow = {
+  characterId: string;
+  content: string;
+  decisionPath?: string | null;
+  timestamp: number;
+  type: string;
 };
 
-const usersTable = {
-  __table: "users",
-  id: "id",
-};
-
-const charactersTable = {
-  __table: "characters",
-  accountId: "accountId",
-  id: "id",
-};
+const {
+  agentMappingsTable,
+  agentThoughtsTable,
+  charactersTable,
+  serverNetworkState,
+  usersTable,
+} = vi.hoisted(() => ({
+  agentMappingsTable: {
+    __table: "agentMappings",
+    accountId: "accountId",
+    agentId: "agentId",
+    agentName: "agentName",
+    characterId: "characterId",
+  },
+  agentThoughtsTable: {
+    __table: "agentThoughts",
+    characterId: "characterId",
+    content: "content",
+    decisionPath: "decisionPath",
+    timestamp: "timestamp",
+    type: "type",
+  },
+  usersTable: {
+    __table: "users",
+    id: "id",
+  },
+  charactersTable: {
+    __table: "characters",
+    accountId: "accountId",
+    id: "id",
+  },
+  serverNetworkState: {
+    agentThoughts: new Map<string, ThoughtRow[]>(),
+  },
+}));
 
 vi.mock("../../database/schema.js", () => ({
   agentMappings: agentMappingsTable,
+  agentThoughts: agentThoughtsTable,
   characters: charactersTable,
   users: usersTable,
 }));
@@ -38,7 +64,10 @@ vi.mock("drizzle-orm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("drizzle-orm")>();
   return {
     ...actual,
+    and: (...conditions: unknown[]) => ({ op: "and", conditions }),
+    desc: (column: string) => ({ direction: "desc", column }),
     eq: (column: string, value: unknown) => ({ column, value }),
+    gt: (column: string, value: unknown) => ({ column, value, op: "gt" }),
   };
 });
 
@@ -47,7 +76,24 @@ vi.mock("../../eliza/index.js", () => ({
   getRunningAgents: () => new Map(),
 }));
 
+vi.mock("../../systems/ServerNetwork/index.js", () => ({
+  ServerNetwork: serverNetworkState,
+}));
+
 import { registerAgentRoutes } from "../routes/agent-routes";
+import { createJWT } from "../../shared/utils";
+
+async function withAuth<T extends Record<string, unknown>>(
+  userId: string,
+  request: T,
+): Promise<T & { headers: { authorization: string } }> {
+  return {
+    ...request,
+    headers: {
+      authorization: `Bearer ${await createJWT({ userId })}`,
+    },
+  };
+}
 
 function createReplyRecorder() {
   return {
@@ -66,23 +112,35 @@ function createReplyRecorder() {
 
 function createFastifyRecorder() {
   const routes = new Map<string, Function>();
+  const pickHandler = (args: unknown[]): Function => {
+    const handler = args[args.length - 1];
+    if (typeof handler !== "function") {
+      throw new Error("Expected route handler");
+    }
+    return handler;
+  };
   const fastify = {
-    delete(path: string, handler: Function) {
-      routes.set(`DELETE ${path}`, handler);
+    delete(path: string, ...args: unknown[]) {
+      routes.set(`DELETE ${path}`, pickHandler(args));
       return this;
     },
-    get(path: string, handler: Function) {
-      routes.set(`GET ${path}`, handler);
+    get(path: string, ...args: unknown[]) {
+      routes.set(`GET ${path}`, pickHandler(args));
       return this;
     },
-    post(path: string, handler: Function) {
-      routes.set(`POST ${path}`, handler);
+    post(path: string, ...args: unknown[]) {
+      routes.set(`POST ${path}`, pickHandler(args));
       return this;
     },
-    put(path: string, handler: Function) {
-      routes.set(`PUT ${path}`, handler);
+    patch(path: string, ...args: unknown[]) {
+      routes.set(`PATCH ${path}`, pickHandler(args));
       return this;
     },
+    put(path: string, ...args: unknown[]) {
+      routes.set(`PUT ${path}`, pickHandler(args));
+      return this;
+    },
+    rateLimit: () => async () => {},
   };
 
   return {
@@ -91,9 +149,13 @@ function createFastifyRecorder() {
   };
 }
 
-function createMockDatabase(initialMappings: MappingRow[]) {
+function createMockDatabase(
+  initialMappings: MappingRow[],
+  initialThoughts: ThoughtRow[] = [],
+) {
   const state = {
     mappings: [...initialMappings],
+    thoughts: [...initialThoughts],
   };
 
   const db = {
@@ -144,28 +206,106 @@ function createMockDatabase(initialMappings: MappingRow[]) {
       },
     },
     select: () => ({
-      from: (table: { __table: string }) => ({
-        where: async (condition: {
-          column: keyof MappingRow;
-          value: unknown;
-        }) => {
-          if (table.__table === "agentMappings") {
-            return state.mappings.filter(
-              (mapping) => mapping[condition.column] === condition.value,
+      from: (table: { __table: string }) => {
+        const applyCondition = (
+          row: MappingRow | ThoughtRow,
+          condition: {
+            column?: string;
+            conditions?: Array<{
+              column?: string;
+              op?: string;
+              value?: unknown;
+            }>;
+            op?: string;
+            value?: unknown;
+          },
+        ): boolean => {
+          if (condition.op === "and" && condition.conditions) {
+            return condition.conditions.every((entry) =>
+              applyCondition(row, entry),
             );
           }
-          return [];
-        },
-      }),
+          if (!condition.column) {
+            return true;
+          }
+          const value = (row as Record<string, unknown>)[condition.column];
+          if (condition.op === "gt") {
+            return Number(value) > Number(condition.value);
+          }
+          return value === condition.value;
+        };
+        const filterRows = (condition: {
+          column?: string;
+          conditions?: Array<{ column?: string; op?: string; value?: unknown }>;
+          op?: string;
+          value?: unknown;
+        }) => {
+          if (table.__table === "agentMappings") {
+            return state.mappings.filter((mapping) =>
+              applyCondition(mapping, condition),
+            );
+          }
+          if (table.__table === "agentThoughts") {
+            return state.thoughts.filter((thought) =>
+              applyCondition(thought, condition),
+            );
+          }
+          return [] as Array<MappingRow | ThoughtRow>;
+        };
+        return {
+          where: (condition: {
+            column?: string;
+            conditions?: Array<{
+              column?: string;
+              op?: string;
+              value?: unknown;
+            }>;
+            op?: string;
+            value?: unknown;
+          }) => {
+            const rows = filterRows(condition);
+            return {
+              then: (
+                onfulfilled: (value: Array<MappingRow | ThoughtRow>) => unknown,
+              ) => Promise.resolve(onfulfilled(rows)),
+              orderBy: (order?: {
+                column?: string;
+                direction?: "desc" | "asc";
+              }) => {
+                const sorted = [...rows];
+                if (order?.column) {
+                  sorted.sort((left, right) => {
+                    const leftValue = (left as Record<string, unknown>)[
+                      order.column!
+                    ];
+                    const rightValue = (right as Record<string, unknown>)[
+                      order.column!
+                    ];
+                    const direction = order.direction === "desc" ? -1 : 1;
+                    if (leftValue === rightValue) return 0;
+                    return leftValue! > rightValue! ? direction : -direction;
+                  });
+                }
+                return {
+                  limit: async (count: number) => sorted.slice(0, count),
+                };
+              },
+            };
+          },
+        };
+      },
     }),
   };
 
   return { db, state };
 }
 
-function setupRoutes(initialMappings: MappingRow[]) {
+function setupRoutes(
+  initialMappings: MappingRow[],
+  initialThoughts: ThoughtRow[] = [],
+) {
   const { fastify, routes } = createFastifyRecorder();
-  const { db, state } = createMockDatabase(initialMappings);
+  const { db, state } = createMockDatabase(initialMappings, initialThoughts);
   const world = {
     getSystem: (name: string) => (name === "database" ? { db } : undefined),
   };
@@ -175,6 +315,7 @@ function setupRoutes(initialMappings: MappingRow[]) {
   return {
     deleteMapping: routes.get("DELETE /api/agents/mappings/:agentId")!,
     getMapping: routes.get("GET /api/agents/mapping/:agentId")!,
+    getThoughts: routes.get("GET /api/agents/:agentId/thoughts")!,
     listMappings: routes.get("GET /api/agents/mappings/:accountId")!,
     saveMapping: routes.get("POST /api/agents/mappings")!,
     state,
@@ -186,10 +327,79 @@ describe("agent route mapping cache", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    serverNetworkState.agentThoughts.clear();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("requires authentication for account-scoped mapping routes", async () => {
+    const { deleteMapping, listMappings, saveMapping } = setupRoutes([
+      {
+        agentId: "agent-1",
+        accountId: "account-old",
+        characterId: "character-1",
+        agentName: "Alpha",
+      },
+    ]);
+
+    const listReply = createReplyRecorder();
+    await listMappings(
+      { params: { accountId: "account-old" } } as never,
+      listReply as never,
+    );
+    expect(listReply.statusCode).toBe(401);
+
+    const saveReply = createReplyRecorder();
+    await saveMapping(
+      {
+        body: {
+          agentId: "agent-1",
+          accountId: "account-old",
+          characterId: "character-1",
+          agentName: "Alpha",
+        },
+      } as never,
+      saveReply as never,
+    );
+    expect(saveReply.statusCode).toBe(401);
+
+    const deleteReply = createReplyRecorder();
+    await deleteMapping(
+      { params: { agentId: "agent-1" } } as never,
+      deleteReply as never,
+    );
+    expect(deleteReply.statusCode).toBe(401);
+  });
+
+  it("rejects cross-account mapping access", async () => {
+    const { deleteMapping, listMappings } = setupRoutes([
+      {
+        agentId: "agent-1",
+        accountId: "account-owner",
+        characterId: "character-1",
+        agentName: "Alpha",
+      },
+    ]);
+
+    const listReply = createReplyRecorder();
+    await listMappings(
+      (await withAuth("account-other", {
+        params: { accountId: "account-owner" },
+      })) as never,
+      listReply as never,
+    );
+    expect(listReply.statusCode).toBe(403);
+
+    const deleteReply = createReplyRecorder();
+    await deleteMapping(
+      (await withAuth("account-other", {
+        params: { agentId: "agent-1" },
+      })) as never,
+      deleteReply as never,
+    );
+    expect(deleteReply.statusCode).toBe(403);
   });
 
   it("invalidates old and new account mapping lists when ownership changes", async () => {
@@ -204,25 +414,27 @@ describe("agent route mapping cache", () => {
 
     const firstListReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       firstListReply as never,
     );
     expect(firstListReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-1"]),
+      count: 2,
       success: true,
     });
 
     const saveReply = createReplyRecorder();
     await saveMapping(
-      {
+      (await withAuth("account-new", {
         body: {
           agentId: "agent-1",
           accountId: "account-new",
           characterId: "character-2",
           agentName: "Beta",
         },
-      } as never,
+      })) as never,
       saveReply as never,
     );
     expect(saveReply.payload).toMatchObject({ success: true });
@@ -237,7 +449,9 @@ describe("agent route mapping cache", () => {
 
     const oldAccountReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       oldAccountReply as never,
     );
     expect(oldAccountReply.payload).toMatchObject({
@@ -248,12 +462,14 @@ describe("agent route mapping cache", () => {
 
     const newAccountReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-new" } } as never,
+      (await withAuth("account-new", {
+        params: { accountId: "account-new" },
+      })) as never,
       newAccountReply as never,
     );
     expect(newAccountReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-2"]),
+      count: 2,
       success: true,
     });
 
@@ -282,12 +498,14 @@ describe("agent route mapping cache", () => {
 
     const listReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       listReply as never,
     );
     expect(listReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-1"]),
+      count: 2,
       success: true,
     });
 
@@ -303,7 +521,9 @@ describe("agent route mapping cache", () => {
 
     const deleteReply = createReplyRecorder();
     await deleteMapping(
-      { params: { agentId: "agent-1" } } as never,
+      (await withAuth("account-old", {
+        params: { agentId: "agent-1" },
+      })) as never,
       deleteReply as never,
     );
     expect(deleteReply.payload).toMatchObject({ success: true });
@@ -321,7 +541,9 @@ describe("agent route mapping cache", () => {
 
     const deletedListReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       deletedListReply as never,
     );
     expect(deletedListReply.payload).toMatchObject({
@@ -343,14 +565,14 @@ describe("agent route mapping cache", () => {
 
     const saveReply = createReplyRecorder();
     await saveMapping(
-      {
+      (await withAuth("account-new", {
         body: {
           agentId: "agent-2",
           accountId: "account-new",
           characterId: "character-2",
           agentName: "Gamma",
         },
-      } as never,
+      })) as never,
       saveReply as never,
     );
     expect(saveReply.payload).toMatchObject({ success: true });
@@ -367,6 +589,54 @@ describe("agent route mapping cache", () => {
       agentName: "Gamma",
       characterId: "character-2",
       success: true,
+    });
+  });
+
+  it("defaults invalid thoughts limit before cold-start DB hydrate", async () => {
+    const { getThoughts } = setupRoutes(
+      [
+        {
+          agentId: "agent-1",
+          accountId: "account-1",
+          characterId: "character-1",
+          agentName: "Alpha",
+        },
+      ],
+      [
+        {
+          characterId: "character-1",
+          content: "fresh thought",
+          decisionPath: null,
+          timestamp: 200,
+          type: "reasoning",
+        },
+        {
+          characterId: "character-1",
+          content: "older thought",
+          decisionPath: null,
+          timestamp: 100,
+          type: "reasoning",
+        },
+      ],
+    );
+
+    const reply = createReplyRecorder();
+    await getThoughts(
+      {
+        params: { agentId: "agent-1" },
+        query: { limit: "foo" },
+      } as never,
+      reply as never,
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(reply.payload).toMatchObject({
+      success: true,
+      count: 2,
+      thoughts: [
+        expect.objectContaining({ content: "fresh thought", timestamp: 200 }),
+        expect.objectContaining({ content: "older thought", timestamp: 100 }),
+      ],
     });
   });
 });

--- a/packages/server/src/startup/routes/agent-routes.ts
+++ b/packages/server/src/startup/routes/agent-routes.ts
@@ -17,6 +17,7 @@
 
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import type { World } from "@hyperscape/shared";
+import { RateLimiterMemory } from "rate-limiter-flexible";
 import { getDefaultPublicWsUrl } from "../../shared/public-ws-url.js";
 import { createJWT } from "../../shared/utils.js";
 import {
@@ -31,6 +32,14 @@ import type {
 // Command acknowledgment delay (ms) - allows plugin to process before response
 const COMMAND_ACK_DELAY_MS = 100;
 const AGENT_MAPPING_CACHE_TTL_MS = 5000;
+const AGENT_MANAGEMENT_RATE_LIMIT = {
+  max: 60,
+  timeWindow: "1 minute",
+};
+const AGENT_MANAGEMENT_CODEQL_LIMITER = new RateLimiterMemory({
+  points: 60,
+  duration: 60,
+});
 
 type AgentRouteCharacterRecord = {
   accountId: string;
@@ -49,6 +58,20 @@ type AgentMappingRecord = {
 type CachedValue<T> = {
   expiresAt: number;
   value: T;
+};
+
+function normalizeThoughtsLimit(rawLimit: string | undefined): number {
+  const parsed = Number.parseInt(rawLimit || "100", 10);
+  if (!Number.isFinite(parsed)) {
+    return 100;
+  }
+  return Math.max(1, Math.min(parsed, 200));
+}
+
+type AgentRouteSelectQuery = PromiseLike<unknown[]> & {
+  orderBy: (order: unknown) => {
+    limit: (count: number) => Promise<unknown[]>;
+  };
 };
 
 type AgentRouteDb = {
@@ -75,7 +98,7 @@ type AgentRouteDb = {
   };
   select: (fields?: unknown) => {
     from: (table: unknown) => {
-      where: (condition: unknown) => Promise<unknown[]>;
+      where: (condition: unknown) => AgentRouteSelectQuery;
     };
   };
   update: (table: unknown) => {
@@ -107,11 +130,10 @@ export function registerAgentRoutes(
   world: World,
 ): void {
   console.log("[AgentRoutes] Registering agent credential routes...");
-
   const getVerifiedUserId = async (
     request: FastifyRequest,
   ): Promise<string | null> => {
-    const authHeader = request.headers.authorization;
+    const authHeader = request.headers?.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return null;
     }
@@ -141,6 +163,29 @@ export function registerAgentRoutes(
     return null;
   };
 
+  const authorizeAccountAccess = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    accountId: string,
+  ): Promise<boolean> => {
+    const verifiedUserId = await getVerifiedUserId(request);
+    if (!verifiedUserId) {
+      await reply.status(401).send({
+        success: false,
+        error: "Unauthorized",
+      });
+      return false;
+    }
+    if (verifiedUserId !== accountId) {
+      await reply.status(403).send({
+        success: false,
+        error: "Forbidden",
+      });
+      return false;
+    }
+    return true;
+  };
+
   const agentMappingByIdCache = new Map<
     string,
     CachedValue<AgentMappingRecord | null>
@@ -160,6 +205,23 @@ export function registerAgentRoutes(
     const databaseSystem = getDatabaseSystem();
     return databaseSystem?.db ?? databaseSystem?.getDb?.() ?? null;
   };
+
+  const withAgentManagementRateLimit =
+    (
+      handler: (
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) => Promise<unknown>,
+    ) =>
+    async (request: FastifyRequest, reply: FastifyReply): Promise<unknown> => {
+      try {
+        await AGENT_MANAGEMENT_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
+
+      return handler(request, reply);
+    };
 
   const getCachedValue = <T>(
     cache: Map<string, CachedValue<T>>,
@@ -417,95 +479,107 @@ export function registerAgentRoutes(
    *   serverUrl: "ws://localhost:5556/ws"
    * }
    */
-  fastify.post("/api/agents/credentials", async (request, reply) => {
-    try {
-      const body = request.body as {
-        characterId: string;
-        accountId: string;
-      };
+  fastify.post(
+    "/api/agents/credentials",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const body = request.body as {
+          characterId: string;
+          accountId: string;
+        };
 
-      if (!body.characterId || !body.accountId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required fields: characterId, accountId",
+        if (!body.characterId || !body.accountId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required fields: characterId, accountId",
+          });
+        }
+
+        const { characterId, accountId } = body;
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Generating credentials for:", {
+          characterId,
+          accountId,
         });
-      }
 
-      const { characterId, accountId } = body;
+        // Verify character exists and belongs to this account
+        const databaseSystem = world.getSystem("database") as
+          | {
+              getCharactersAsync: (
+                accountId: string,
+              ) => Promise<Array<{ id: string; name: string }>>;
+            }
+          | undefined;
 
-      console.log("[AgentRoutes] Generating credentials for:", {
-        characterId,
-        accountId,
-      });
+        if (!databaseSystem) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
 
-      // Verify character exists and belongs to this account
-      const databaseSystem = world.getSystem("database") as
-        | {
-            getCharactersAsync: (
-              accountId: string,
-            ) => Promise<Array<{ id: string; name: string }>>;
-          }
-        | undefined;
+        const characters = await databaseSystem.getCharactersAsync(accountId);
+        const character = characters.find((c) => c.id === characterId);
 
-      if (!databaseSystem) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
+        if (!character) {
+          console.warn(
+            `[AgentRoutes] Character ${characterId} not found or not owned by ${accountId}`,
+          );
+          return reply.status(403).send({
+            success: false,
+            error: "Character not found or access denied",
+          });
+        }
+
+        console.log("[AgentRoutes] Character verified:", character.name);
+
+        // Generate 7-day Hyperscape JWT
+        const authToken = await createJWT({
+          userId: accountId,
+          characterId: characterId,
+          isAgent: true,
+        });
+
+        console.log(
+          `[AgentRoutes] ✅ Generated 7-day JWT for agent: ${character.name}`,
+        );
+
+        // Get server URL from environment or use default
+        const serverUrl =
+          process.env.HYPERSCAPE_SERVER_URL ||
+          process.env.PUBLIC_WS_URL ||
+          getDefaultPublicWsUrl();
+
+        return reply.send({
+          success: true,
+          authToken,
+          characterId,
+          serverUrl,
+          message: `Credentials generated for ${character.name} (expires in 7 days)`,
+        });
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to generate credentials:",
+          error,
+        );
+
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to generate credentials",
         });
       }
-
-      const characters = await databaseSystem.getCharactersAsync(accountId);
-      const character = characters.find((c) => c.id === characterId);
-
-      if (!character) {
-        console.warn(
-          `[AgentRoutes] Character ${characterId} not found or not owned by ${accountId}`,
-        );
-        return reply.status(403).send({
-          success: false,
-          error: "Character not found or access denied",
-        });
-      }
-
-      console.log("[AgentRoutes] Character verified:", character.name);
-
-      // Generate 7-day Hyperscape JWT
-      const authToken = await createJWT({
-        userId: accountId,
-        characterId: characterId,
-        isAgent: true,
-      });
-
-      console.log(
-        `[AgentRoutes] ✅ Generated 7-day JWT for agent: ${character.name}`,
-      );
-
-      // Get server URL from environment or use default
-      const serverUrl =
-        process.env.HYPERSCAPE_SERVER_URL ||
-        process.env.PUBLIC_WS_URL ||
-        getDefaultPublicWsUrl();
-
-      return reply.send({
-        success: true,
-        authToken,
-        characterId,
-        serverUrl,
-        message: `Credentials generated for ${character.name} (expires in 7 days)`,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to generate credentials:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to generate credentials",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/wallet-auth
@@ -565,35 +639,7 @@ export function registerAgentRoutes(
       const accountId = `wallet:${walletType}:${walletAddress}`;
 
       // Get database access
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              select: (fields?: unknown) => {
-                from: (table: unknown) => {
-                  where: (condition: unknown) => Promise<unknown[]>;
-                };
-              };
-              insert: (table: unknown) => {
-                values: (values: Record<string, unknown>) => {
-                  onConflictDoUpdate: (config: {
-                    target: unknown;
-                    set: unknown;
-                  }) => Promise<unknown>;
-                } & Promise<unknown>;
-              };
-              query: {
-                characters: {
-                  findFirst: (opts: {
-                    where: (
-                      chars: { accountId: unknown },
-                      ops: { eq: (a: unknown, b: string) => unknown },
-                    ) => unknown;
-                  }) => Promise<{ id: string; name: string } | null>;
-                };
-              };
-            };
-          }
-        | undefined;
+      const databaseSystem = getDatabaseSystem();
 
       if (!databaseSystem?.db) {
         return reply.status(500).send({
@@ -640,7 +686,15 @@ export function registerAgentRoutes(
           createdAt: Date.now(),
         });
 
-        character = { id: characterId, name: agentName };
+        character = {
+          id: characterId,
+          accountId,
+          name: agentName,
+        };
+      }
+
+      if (!character) {
+        throw new Error("Failed to resolve character after wallet auth");
       }
 
       // Generate 7-day JWT
@@ -741,72 +795,84 @@ export function registerAgentRoutes(
    *   agentIds: ["agent-id-1", "agent-id-2", ...]
    * }
    */
-  fastify.get("/api/agents/mappings/:accountId", async (request, reply) => {
-    try {
-      const params = request.params as { accountId: string };
-      const { accountId } = params;
+  fastify.get(
+    "/api/agents/mappings/:accountId",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const params = request.params as { accountId: string };
+        const { accountId } = params;
 
-      if (!accountId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required parameter: accountId",
+        if (!accountId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required parameter: accountId",
+          });
+        }
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Fetching agent mappings for:", accountId);
+
+        const db = getDatabaseDb();
+        if (!db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
+
+        const mappings = await listAgentMappingsByAccount(db, accountId);
+
+        const agentIds = mappings.flatMap((m) => [m.agentId, m.characterId]);
+
+        // Model duel agents are public streaming participants; include them in
+        // mapping lookup so dashboards can discover live duel roster.
+        const { getRunningAgents } = await import("../../eliza/index.js");
+        const runningModelAgents = getRunningAgents() as Map<
+          string,
+          {
+            characterId: string;
+          }
+        >;
+
+        for (const [, runningAgent] of runningModelAgents) {
+          if (runningAgent.characterId) {
+            agentIds.push(runningAgent.characterId);
+          }
+        }
+
+        const uniqueAgentIds = Array.from(new Set(agentIds));
+
+        console.log(
+          `[AgentRoutes] Found ${uniqueAgentIds.length} agent(s) for ${accountId}`,
+        );
+
+        return reply.send({
+          success: true,
+          agentIds: uniqueAgentIds,
+          count: uniqueAgentIds.length,
         });
-      }
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to fetch agent mappings:",
+          error,
+        );
 
-      console.log("[AgentRoutes] Fetching agent mappings for:", accountId);
-
-      const db = getDatabaseDb();
-      if (!db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to fetch agent mappings",
         });
       }
-
-      const mappings = await listAgentMappingsByAccount(db, accountId);
-
-      const agentIds = mappings.flatMap((m) => [m.agentId, m.characterId]);
-
-      // Model duel agents are public streaming participants; include them in
-      // mapping lookup so dashboards can discover live duel roster.
-      const { getRunningAgents } = await import("../../eliza/index.js");
-      const runningModelAgents = getRunningAgents() as Map<
-        string,
-        {
-          characterId: string;
-        }
-      >;
-
-      for (const [, runningAgent] of runningModelAgents) {
-        if (runningAgent.characterId) {
-          agentIds.push(runningAgent.characterId);
-        }
-      }
-
-      const uniqueAgentIds = Array.from(new Set(agentIds));
-
-      console.log(
-        `[AgentRoutes] Found ${uniqueAgentIds.length} agent(s) for ${accountId}`,
-      );
-
-      return reply.send({
-        success: true,
-        agentIds: uniqueAgentIds,
-        count: uniqueAgentIds.length,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to fetch agent mappings:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to fetch agent mappings",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/mappings
@@ -827,121 +893,130 @@ export function registerAgentRoutes(
    *   success: true
    * }
    */
-  fastify.post("/api/agents/mappings", async (request, reply) => {
-    try {
-      const body = request.body as {
-        agentId: string;
-        accountId: string;
-        characterId: string;
-        agentName: string;
-      };
+  fastify.post(
+    "/api/agents/mappings",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const body = request.body as {
+          agentId: string;
+          accountId: string;
+          characterId: string;
+          agentName: string;
+        };
 
-      if (
-        !body.agentId ||
-        !body.accountId ||
-        !body.characterId ||
-        !body.agentName
-      ) {
-        return reply.status(400).send({
-          success: false,
-          error:
-            "Missing required fields: agentId, accountId, characterId, agentName",
+        if (
+          !body.agentId ||
+          !body.accountId ||
+          !body.characterId ||
+          !body.agentName
+        ) {
+          return reply.status(400).send({
+            success: false,
+            error:
+              "Missing required fields: agentId, accountId, characterId, agentName",
+          });
+        }
+
+        const { agentId, accountId, characterId, agentName } = body;
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Saving agent mapping:", {
+          agentId,
+          accountId,
+          characterId,
+          agentName,
         });
-      }
 
-      const { agentId, accountId, characterId, agentName } = body;
-
-      console.log("[AgentRoutes] Saving agent mapping:", {
-        agentId,
-        accountId,
-        characterId,
-        agentName,
-      });
-
-      // Get database system
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              insert: (table: unknown) => {
-                values: (values: unknown) => {
-                  onConflictDoUpdate: (config: {
-                    target: unknown;
-                    set: unknown;
-                  }) => Promise<unknown>;
+        // Get database system
+        const databaseSystem = world.getSystem("database") as
+          | {
+              db: {
+                insert: (table: unknown) => {
+                  values: (values: unknown) => {
+                    onConflictDoUpdate: (config: {
+                      target: unknown;
+                      set: unknown;
+                    }) => Promise<unknown>;
+                  };
                 };
               };
-            };
-          }
-        | undefined;
+            }
+          | undefined;
 
-      if (!databaseSystem || !databaseSystem.db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
-        return reply.status(500).send({
-          success: false,
-          error: "Database system not available",
-        });
-      }
+        if (!databaseSystem || !databaseSystem.db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
 
-      // Import schema
-      const { agentMappings } = await import("../../database/schema.js");
-      const existingMapping = await getAgentMappingById(
-        databaseSystem.db as AgentRouteDb,
-        agentId,
-        true,
-      );
+        // Import schema
+        const { agentMappings } = await import("../../database/schema.js");
+        const existingMapping = await getAgentMappingById(
+          databaseSystem.db as AgentRouteDb,
+          agentId,
+          true,
+        );
 
-      // Insert or update mapping
-      await databaseSystem.db
-        .insert(agentMappings)
-        .values({
+        // Insert or update mapping
+        await databaseSystem.db
+          .insert(agentMappings)
+          .values({
+            agentId,
+            accountId,
+            characterId,
+            agentName,
+            streamingDuelEnabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: agentMappings.agentId,
+            set: {
+              accountId,
+              characterId,
+              agentName,
+              updatedAt: new Date(),
+            },
+          });
+        invalidateAgentMappingCache(
+          agentId,
+          existingMapping?.accountId,
+          accountId,
+        );
+        primeAgentMappingCache({
           agentId,
           accountId,
           characterId,
           agentName,
           streamingDuelEnabled: true,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .onConflictDoUpdate({
-          target: agentMappings.agentId,
-          set: {
-            accountId,
-            characterId,
-            agentName,
-            updatedAt: new Date(),
-          },
         });
-      invalidateAgentMappingCache(
-        agentId,
-        existingMapping?.accountId,
-        accountId,
-      );
-      primeAgentMappingCache({
-        agentId,
-        accountId,
-        characterId,
-        agentName,
-        streamingDuelEnabled: true,
-      });
 
-      console.log(`[AgentRoutes] ✅ Agent mapping saved for: ${agentName}`);
+        console.log(`[AgentRoutes] ✅ Agent mapping saved for: ${agentName}`);
 
-      return reply.send({
-        success: true,
-        message: `Agent mapping saved for ${agentName}`,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to save agent mapping:", error);
+        return reply.send({
+          success: true,
+          message: `Agent mapping saved for ${agentName}`,
+        });
+      } catch (error) {
+        console.error("[AgentRoutes] ❌ Failed to save agent mapping:", error);
 
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to save agent mapping",
-      });
-    }
-  });
+        return reply.status(500).send({
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to save agent mapping",
+        });
+      }
+    }),
+  );
 
   /**
    * GET /api/agents/mapping/:agentId
@@ -1150,54 +1225,81 @@ export function registerAgentRoutes(
    *   message: "Agent mapping deleted"
    * }
    */
-  fastify.delete("/api/agents/mappings/:agentId", async (request, reply) => {
-    try {
-      const params = request.params as { agentId: string };
-      const { agentId } = params;
+  fastify.delete(
+    "/api/agents/mappings/:agentId",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const params = request.params as { agentId: string };
+        const { agentId } = params;
 
-      if (!agentId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required parameter: agentId",
+        if (!agentId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required parameter: agentId",
+          });
+        }
+
+        console.log("[AgentRoutes] Deleting agent mapping for:", agentId);
+
+        const db = getDatabaseDb();
+        if (!db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
+
+        const existingMapping = await getAgentMappingById(db, agentId, true);
+        if (!existingMapping) {
+          return reply.status(404).send({
+            success: false,
+            error: "Agent mapping not found",
+          });
+        }
+        if (
+          !(await authorizeAccountAccess(
+            request,
+            reply,
+            existingMapping.accountId,
+          ))
+        ) {
+          return;
+        }
+
+        const { agentMappings } = await schemaModulePromise;
+        const { eq } = await drizzleModulePromise;
+
+        await db
+          .delete(agentMappings)
+          .where(eq(agentMappings.agentId, agentId));
+        invalidateAgentMappingCache(agentId, existingMapping?.accountId);
+
+        console.log(`[AgentRoutes] ✅ Agent mapping deleted for: ${agentId}`);
+
+        return reply.send({
+          success: true,
+          message: "Agent mapping deleted",
         });
-      }
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to delete agent mapping:",
+          error,
+        );
 
-      console.log("[AgentRoutes] Deleting agent mapping for:", agentId);
-
-      const db = getDatabaseDb();
-      if (!db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to delete agent mapping",
         });
       }
-
-      const existingMapping = await getAgentMappingById(db, agentId, true);
-      const { agentMappings } = await schemaModulePromise;
-      const { eq } = await drizzleModulePromise;
-
-      await db.delete(agentMappings).where(eq(agentMappings.agentId, agentId));
-      invalidateAgentMappingCache(agentId, existingMapping?.accountId);
-
-      console.log(`[AgentRoutes] ✅ Agent mapping deleted for: ${agentId}`);
-
-      return reply.send({
-        success: true,
-        message: "Agent mapping deleted",
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to delete agent mapping:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to delete agent mapping",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/:agentId/message
@@ -2880,7 +2982,7 @@ export function registerAgentRoutes(
       }
 
       // Parse query params
-      const limit = Math.min(parseInt(query.limit || "100", 10), 200);
+      const limit = normalizeThoughtsLimit(query.limit);
       const since = query.since ? parseInt(query.since, 10) : 0;
 
       const db = getDatabaseDb();
@@ -2926,13 +3028,23 @@ export function registerAgentRoutes(
         try {
           const { agentThoughts: agentThoughtsTable } =
             await import("../../database/schema.js");
-          const { desc, eq } = await import("drizzle-orm");
-          const rows = await db
+          const { and, desc, eq, gt } = await import("drizzle-orm");
+          const conditions = [eq(agentThoughtsTable.characterId, characterId)];
+          if (since > 0) {
+            conditions.push(gt(agentThoughtsTable.timestamp, since));
+          }
+          const rows = (await db
             .select()
             .from(agentThoughtsTable)
-            .where(eq(agentThoughtsTable.characterId, characterId))
+            .where(and(...conditions))
             .orderBy(desc(agentThoughtsTable.timestamp))
-            .limit(limit);
+            .limit(limit)) as Array<{
+            characterId: string;
+            type: string;
+            content: string;
+            timestamp: number;
+            decisionPath?: string | null;
+          }>;
           thoughts = rows.map((r) => ({
             id: `${r.characterId}-thought-${r.timestamp}`,
             type: r.type,
@@ -2952,11 +3064,10 @@ export function registerAgentRoutes(
       }
 
       // Filter by since timestamp and limit
-      let filteredThoughts = thoughts;
-      if (since > 0) {
-        filteredThoughts = thoughts.filter((t) => t.timestamp > since);
-      }
-      filteredThoughts = filteredThoughts.slice(0, limit);
+      const filteredThoughts =
+        since > 0
+          ? thoughts.filter((t) => t.timestamp > since).slice(0, limit)
+          : thoughts.slice(0, limit);
 
       return reply.send({
         success: true,
@@ -3087,42 +3198,7 @@ export function registerAgentRoutes(
       const inputCharacterId = body.characterId;
 
       // Get character from database to retrieve accountId and name
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              select: (fields?: unknown) => {
-                from: (table: unknown) => {
-                  where: (condition: unknown) => Promise<unknown[]>;
-                };
-              };
-              insert: (table: unknown) => {
-                values: (values: Record<string, unknown>) => {
-                  onConflictDoUpdate: (config: {
-                    set: Record<string, unknown>;
-                    target: unknown;
-                  }) => Promise<unknown>;
-                } & Promise<unknown>;
-              };
-              delete: (table: unknown) => {
-                where: (condition: unknown) => Promise<unknown>;
-              };
-              query: {
-                characters: {
-                  findFirst: (opts: {
-                    where: (
-                      chars: { id: unknown },
-                      ops: { eq: (a: unknown, b: string) => unknown },
-                    ) => unknown;
-                  }) => Promise<{
-                    id: string;
-                    accountId: string;
-                    name: string;
-                  } | null>;
-                };
-              };
-            };
-          }
-        | undefined;
+      const databaseSystem = getDatabaseSystem();
 
       if (!databaseSystem?.db) {
         return reply.status(500).send({

--- a/packages/shared/src/systems/client/ClientNetwork.ts
+++ b/packages/shared/src/systems/client/ClientNetwork.ts
@@ -397,14 +397,10 @@ export class ClientNetwork extends SystemBase {
     this.world.emit(EventType.INVENTORY_UPDATED, { ...cached });
   }
 
-  /**
-   * Schedule a single delayed prune check. Re-schedules itself only while
-   * there are still pending optimistic actions, so the timer stops when idle
-   * instead of ticking every 1s unconditionally.
-   */
+  /** Start the periodic rollback pruner (once, lazily on first optimistic call). */
   private ensureInventoryPruner(): void {
     if (this.inventoryPrunerInterval) return;
-    const runPrune = () => {
+    this.inventoryPrunerInterval = setInterval(() => {
       const rollbacks = this.inventoryTracker.pruneStale();
       for (const snapshot of rollbacks) {
         this.lastInventoryByPlayerId[snapshot.playerId] = snapshot;
@@ -413,20 +409,11 @@ export class ClientNetwork extends SystemBase {
           "[ClientNetwork] Optimistic inventory action timed out, rolling back",
         );
       }
-      // Re-schedule only if more actions are still pending
-      if (this.inventoryTracker.hasPending()) {
-        this.inventoryPrunerInterval = setTimeout(
-          runPrune,
-          1000,
-        ) as unknown as ReturnType<typeof setInterval>;
-      } else {
+      if (!this.inventoryTracker.hasPending()) {
+        clearInterval(this.inventoryPrunerInterval!);
         this.inventoryPrunerInterval = null;
       }
-    };
-    this.inventoryPrunerInterval = setTimeout(
-      runPrune,
-      1000,
-    ) as unknown as ReturnType<typeof setInterval>;
+    }, 1000);
   }
 
   public getSpectatorFollowEntity(): string | undefined {
@@ -582,32 +569,7 @@ export class ClientNetwork extends SystemBase {
       }
     }
 
-    // For embedded spectator viewfinders (dashboard agent live view), the spectator
-    // JWT is passed as a URL param on the iframe and stored in __HYPERSCAPE_CONFIG__.authToken.
-    // It is intentionally NOT put in the WebSocket URL by EmbeddedGameClient (security
-    // concern about token leaking in logs), but the server requires it to pass the
-    // STREAMING_PUBLIC_DELAY_MS access gate for agent spectating.  Use it here if no
-    // other authToken was found, so the connection is authenticated.
-    if (
-      !authToken &&
-      !urlHasAuthToken &&
-      typeof window !== "undefined" &&
-      !isPlaywrightRuntime
-    ) {
-      const embeddedAuth = (
-        window as {
-          __HYPERSCAPE_CONFIG__?: { authToken?: string };
-        }
-      ).__HYPERSCAPE_CONFIG__?.authToken;
-      if (embeddedAuth) {
-        authToken = embeddedAuth;
-      }
-    }
-
-    // Build WebSocket URL with authToken included.
-    // Note: For `mode=streaming`, the server may require `authToken` + `privyUserId` in the
-    // query string at connect time (`verifyStreamingViewerCredentials`) when public delay is
-    // enabled — streaming does not use the deferred first-message auth path on the server.
+    // Build WebSocket URL with authToken included
     let url: string;
     if (urlHasAuthToken) {
       // URL already has authToken (legacy embedded mode) - use as-is
@@ -651,43 +613,23 @@ export class ClientNetwork extends SystemBase {
       ).__HYPERSCAPE_CONFIG__;
 
       if (isEmbedded && embeddedConfig) {
-        this.isEmbeddedSpectator = embeddedConfig.mode === "spectator";
-        // Use followEntity as fallback so the onStreamingState guard fires even
-        // when the dashboard specifies an agent via followEntity (not characterId).
-        const originalFollowTarget =
-          embeddedConfig.characterId || embeddedConfig.followEntity || null;
-        this.embeddedCharacterId = originalFollowTarget;
-        // Freeze the original follow target on window so it survives HMR re-instantiation
-        // and can't be overwritten by streaming state broadcasts.
-        if (
-          originalFollowTarget &&
-          !(window as { __HYPERSCAPE_ORIGINAL_FOLLOW__?: string })
-            .__HYPERSCAPE_ORIGINAL_FOLLOW__
-        ) {
-          (
-            window as { __HYPERSCAPE_ORIGINAL_FOLLOW__?: string }
-          ).__HYPERSCAPE_ORIGINAL_FOLLOW__ = originalFollowTarget;
+        this.isEmbeddedSpectator =
+          embeddedConfig.mode === "spectator" ||
+          embeddedConfig.mode === "stream";
+        this.embeddedCharacterId = embeddedConfig.characterId || null;
+        const explicitFollow =
+          embeddedConfig.followEntity || embeddedConfig.characterId || null;
+        if (this.isEmbeddedSpectator && explicitFollow) {
+          const w = window as Window & {
+            __HYPERSCAPE_ORIGINAL_FOLLOW__?: string;
+          };
+          w.__HYPERSCAPE_ORIGINAL_FOLLOW__ ??= explicitFollow;
         }
 
         this.logger.debug("[ClientNetwork] Embedded config loaded", {
           isSpectator: this.isEmbeddedSpectator,
           hasCharacterId: !!this.embeddedCharacterId,
         });
-
-        // CRITICAL: Add mode, characterId, and followEntity to the WebSocket URL
-        // so the server's ConnectionHandler can use them to target the correct agent.
-        // Without these params, params.characterId and params.followEntity are undefined
-        // on the server, so requestedCharacterId is null and the server falls back to
-        // whatever streaming duel is active — causing the "random guy near a tree" bug.
-        if (embeddedConfig.mode && !url.includes("mode=")) {
-          url += `${url.includes("?") ? "&" : "?"}mode=${encodeURIComponent(embeddedConfig.mode)}`;
-        }
-        if (embeddedConfig.characterId && !url.includes("characterId=")) {
-          url += `&characterId=${encodeURIComponent(embeddedConfig.characterId)}`;
-        }
-        if (embeddedConfig.followEntity && !url.includes("followEntity=")) {
-          url += `&followEntity=${encodeURIComponent(embeddedConfig.followEntity)}`;
-        }
       }
     }
 
@@ -2019,13 +1961,12 @@ export class ClientNetwork extends SystemBase {
     const now = performance.now();
     const renderTime = now - this.interpolationDelay;
 
-    // OPTIMIZATION: Use cached array, only rebuild when states change.
-    // forEach avoids the iterator object allocation that .entries() creates.
+    // OPTIMIZATION: Use cached array, only rebuild when states change
     if (this._interpolationStatesDirty) {
       this._interpolationStatesArray.length = 0;
-      this.interpolationStates.forEach((state, entityId) => {
-        this._interpolationStatesArray.push([entityId, state]);
-      });
+      for (const entry of this.interpolationStates.entries()) {
+        this._interpolationStatesArray.push(entry);
+      }
       this._interpolationStatesDirty = false;
       this._interpolationRotationIndex = 0; // Reset rotation on change
     }
@@ -5167,7 +5108,7 @@ export class ClientNetwork extends SystemBase {
 
     // Clean up optimistic inventory tracker on disconnect
     if (this.inventoryPrunerInterval) {
-      clearTimeout(this.inventoryPrunerInterval);
+      clearInterval(this.inventoryPrunerInterval);
       this.inventoryPrunerInterval = null;
     }
     this.inventoryTracker.clear();
@@ -5450,26 +5391,17 @@ export class ClientNetwork extends SystemBase {
         ? data.cameraTarget
         : null;
 
-    // Embedded spectators should follow scheduler camera target changes
-    // (prevents stale followEntity from pinning the camera to inactive agents).
-    if (!this.isEmbeddedSpectator || !nextTargetId) {
-      return;
-    }
-
-    // Dashboard viewfinders have an explicit embeddedCharacterId — they are
-    // deliberately watching a specific agent and must NOT be hijacked by the
-    // streaming scheduler's cameraTarget (which points at whoever is currently
-    // dueling, not the agent the dashboard selected).  Only anonymous/streaming
-    // viewers with no pinned character should follow the scheduler's camera.
-    // Check instance field AND the frozen window value so HMR re-instantiation
-    // (which resets class fields to null) doesn't bypass this guard.
-    const frozenFollow =
-      this.embeddedCharacterId ||
-      (typeof window !== "undefined" &&
+    const hasDashboardFollowLock =
+      typeof window !== "undefined" &&
+      Boolean(
         (window as { __HYPERSCAPE_ORIGINAL_FOLLOW__?: string })
-          .__HYPERSCAPE_ORIGINAL_FOLLOW__) ||
-      null;
-    if (frozenFollow) {
+          .__HYPERSCAPE_ORIGINAL_FOLLOW__,
+      );
+
+    // Stream capture spectators should follow scheduler camera target changes.
+    // Dashboard viewfinders with an explicit follow target must stay pinned to
+    // that agent; the frozen value survives HMR/config churn.
+    if (!this.isEmbeddedSpectator || hasDashboardFollowLock || !nextTargetId) {
       return;
     }
 

--- a/packages/shared/src/systems/client/__tests__/ClientNetworkInventoryPruner.test.ts
+++ b/packages/shared/src/systems/client/__tests__/ClientNetworkInventoryPruner.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClientNetwork } from "../ClientNetwork";
+import type { World } from "../../../types";
+
+type ClientNetworkHarness = ClientNetwork & {
+  inventoryPrunerInterval: ReturnType<typeof setInterval> | null;
+  lastInventoryByPlayerId: Record<
+    string,
+    {
+      playerId: string;
+      items: Array<{ slot: number; itemId: string; quantity: number }>;
+      coins: number;
+      maxSlots: number;
+    }
+  >;
+};
+
+const createWorld = () =>
+  ({
+    emit: vi.fn(),
+  }) as unknown as World;
+
+describe("ClientNetwork inventory pruner", () => {
+  let nowMs = 0;
+
+  beforeEach(() => {
+    nowMs = 0;
+    vi.useFakeTimers();
+    vi.spyOn(performance, "now").mockImplementation(() => nowMs);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("stops polling once no optimistic inventory actions remain pending", () => {
+    const world = createWorld();
+    const network = new ClientNetwork(world) as ClientNetworkHarness;
+
+    network.lastInventoryByPlayerId.player = {
+      playerId: "player",
+      items: [{ slot: 1, itemId: "logs", quantity: 2 }],
+      coins: 0,
+      maxSlots: 28,
+    };
+
+    network.applyOptimisticRemoval("player", 1, 1);
+
+    expect(network.inventoryPrunerInterval).not.toBeNull();
+
+    nowMs = 6_000;
+    vi.advanceTimersByTime(1_000);
+
+    expect(network.inventoryPrunerInterval).toBeNull();
+  });
+});

--- a/packages/shared/src/systems/client/network/ConnectionManager.ts
+++ b/packages/shared/src/systems/client/network/ConnectionManager.ts
@@ -233,7 +233,9 @@ export class ConnectionManager {
       ).__HYPERSCAPE_CONFIG__;
 
       if (isEmbedded && embeddedConfig) {
-        this.isEmbeddedSpectator = embeddedConfig.mode === "spectator";
+        this.isEmbeddedSpectator =
+          embeddedConfig.mode === "spectator" ||
+          embeddedConfig.mode === "stream";
         const characterId = embeddedConfig.characterId || null;
         onEmbeddedConfig(characterId);
 
@@ -244,11 +246,17 @@ export class ConnectionManager {
       }
     }
 
-    // Capture whether we're using first-message auth for the open handler.
-    // Use first-message auth whenever URL auth is unavailable.
-    const useFirstMessageAuth = !urlHasAuthToken;
     const isStreamingConnection = /[?&]mode=streaming(?:[&#]|$)/.test(url);
-    const connectionTimeoutMs = isStreamingConnection ? 120_000 : 30_000;
+    const isSpectatorConnection = /[?&]mode=spectator(?:[&#]|$)/.test(url);
+    const allowsAnonymousMode =
+      isStreamingConnection ||
+      isSpectatorConnection ||
+      this.isEmbeddedSpectator;
+    // Streaming/spectator connections are read-only public viewers. They must
+    // not send an empty authenticate packet when URL auth is absent.
+    const useFirstMessageAuth = !urlHasAuthToken && !allowsAnonymousMode;
+    const connectionTimeoutMs =
+      isStreamingConnection || isSpectatorConnection ? 120_000 : 30_000;
 
     return new Promise((resolve, reject) => {
       this.ws = new WebSocket(url);


### PR DESCRIPTION
## Summary
This draft isolates agent-route hardening, Eliza/dashboard fixes, and the client optimistic-inventory guardrail work from the broader umbrella branch.

## Includes
- agent management/thought-route changes
- Eliza/dashboard interoperability fixes
- optimistic inventory rollback/pruner fix and related client guardrails

## Excludes
- streaming authority / payout / raw-time contract work
- terrain and compute stability work

## Validation
- split from `enoomian/streaming-authority-compute`
- includes the current thoughts-limit and inventory-pruner review fixes
- left draft while focused validation is completed on the narrowed slice