### PR TITLE
Split server streaming and agent hardening out of #1178

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@hyperscape/hyperscape",
@@ -360,7 +361,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@hyperscape/impostor": "workspace:*",
-        "@hyperscape/shared": "workspace:*",
         "delaunator": "^5.0.1",
       },
       "devDependencies": {
@@ -391,6 +391,7 @@
         "@elizaos/core": "alpha",
         "@elizaos/plugin-anthropic": "alpha",
         "@elizaos/plugin-elizacloud": "alpha",
+        "@elizaos/plugin-goals": "2.0.0-alpha.9",
         "@elizaos/plugin-groq": "alpha",
         "@elizaos/plugin-openai": "alpha",
         "@elizaos/plugin-sql": "alpha",
@@ -417,6 +418,7 @@
         "moment": "^2.30.1",
         "msgpackr": "^1.11.5",
         "pg": "^8.13.1",
+        "rate-limiter-flexible": "^11.0.1",
         "socket.io-client": "^4.8.1",
         "source-map-support": "^0.5.21",
         "uWebSockets.js": "uNetworking/uWebSockets.js#v20.60.0",
@@ -644,6 +646,7 @@
     "esbuild": ">=0.24.3",
     "h3": ">=1.15.5",
     "hono": ">=4.11.4",
+    "jsdom": "27.0.1",
     "jsondiffpatch": ">=0.7.2",
     "jws": "^3.2.3",
     "lodash": ">=4.17.23",
@@ -668,6 +671,8 @@
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.66", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.64", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA=="],
 
     "@ai-sdk/groq": ["@ai-sdk/groq@3.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-I/tUoHuOvGXbIr1dJ0CLRLA7W0UPDMtrYT5mgeb3O+P+6I5BAm/7riPwr22Xw5YTzpwQxcoDQlIczOU9XDXBpA=="],
 
@@ -715,7 +720,7 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.32.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
 
@@ -723,9 +728,9 @@
 
     "@ark/util": ["@ark/util@0.2.2", "", {}, "sha512-ryZ4+f3SlReQRH9nTFLK5EeU1Pan5ZfS+ACPSk0ir5uujJouFmvOdnkVfeAJAgeOb3kKmUM9kjelv1cwH2ScZg=="],
 
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.0.1", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.6" } }, "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw=="],
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.2", "", { "dependencies": { "@csstools/css-calc": "^3.0.0", "@csstools/css-color-parser": "^4.0.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.5" } }, "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg=="],
 
-    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.3", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7" } }, "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA=="],
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.8.1", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.6" } }, "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
@@ -1027,8 +1032,6 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
-    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
-
     "@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.1", "", {}, "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ=="],
 
     "@capacitor/android": ["@capacitor/android@8.2.0", "", { "peerDependencies": { "@capacitor/core": "^8.2.0" } }, "sha512-XLm5OsWLPfXQxDxzFS7SOdMEgGvW+2c7TGLXkTR2cSKdkWK5Abns4imlT5qghKYhjM9r74IrDkBWg/9ALUGNKQ=="],
@@ -1051,7 +1054,7 @@
 
     "@csstools/cascade-layer-name-parser": ["@csstools/cascade-layer-name-parser@2.0.5", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A=="],
 
-    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
 
@@ -1235,19 +1238,21 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.15", "", {}, "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ=="],
 
-    "@elizaos/core": ["@elizaos/core@2.0.0-alpha.76", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-qxPxa64LlBtIX5NndeZ2bFB1O32vkC+g6lvAdffkZmCl7d3N6Yd5GOUpXhxxCJSyAPVdcgg6WlqCLRWWk4Tt9A=="],
+    "@elizaos/core": ["@elizaos/core@2.0.0-alpha.196", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.13", "@ai-sdk/google": "^3.0.8", "@ai-sdk/openai": "^3.0.9", "@anthropic-ai/sdk": "^0.90.0", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^1.8.0", "@openrouter/ai-sdk-provider": "^2.0.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "ai": "^6.0.30", "coding-agent-adapters": "0.16.3", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^22.0.0", "fs-extra": "^11.3.2", "git-workspace-service": "0.4.5", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "mammoth": "^1.9.0", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^8.0.0", "unique-names-generator": "^4.7.1", "unpdf": "^1.4.0", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-CfzZ/+/G+6ELT6dFjRtgrRamYShCo3bjYez2OfolQnqGhq9/BYYY2lcUctv/k+KlNQISskTeQYxEBcScvHmzBg=="],
 
-    "@elizaos/plugin-anthropic": ["@elizaos/plugin-anthropic@2.0.0-alpha.9", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.9", "@elizaos/core": "alpha", "ai": "^6.0.23", "jsonrepair": "^3.12.0", "undici": "^7.16.0" } }, "sha512-yiCtx6IEnpHipqJGIbDR/S+/erGPb3bI2cvQrIxwKNzkqMG97uezE4hjp2rIFSNHOsyTwndU5+J5GqyMMZc4Ig=="],
+    "@elizaos/plugin-anthropic": ["@elizaos/plugin-anthropic@2.0.0-alpha.14", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.9", "ai": "^6.0.23", "jsonrepair": "^3.12.0", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.116" } }, "sha512-IuxsqBUF8FiJQVcaCrZPGAX2k2QeFP6iLDVRWTvSksiuSrxaQi+Ptx6S8saJm0OpefZn9zKIZruoUvC8VfNAsg=="],
 
-    "@elizaos/plugin-elizacloud": ["@elizaos/plugin-elizacloud@2.0.0-alpha.7", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@elizaos/core": "2.0.0-alpha.3", "ai": "^6.0.30", "js-tiktoken": "^1.0.21", "undici": "^7.16.0" }, "peerDependencies": { "zod": "^4.3.6" } }, "sha512-9q/QNqnKKidmVq70yIch8uxRfartvdT0dgrcsYfXYJTImuLyEcKG2PRt8kkoRHO6+8jTwkUuSESMuTilfV0Pfw=="],
+    "@elizaos/plugin-elizacloud": ["@elizaos/plugin-elizacloud@2.0.0-alpha.8", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@elizaos/core": "2.0.0-alpha.114", "ai": "^6.0.30", "js-tiktoken": "^1.0.21", "undici": "^7.16.0" }, "peerDependencies": { "zod": "^4.3.6" } }, "sha512-B311icfV64/FLY3w+Dsa204F2Hga8WZ/gg3/lBrTUgJNy8yACHx0c43uEgQAqRLEAd8EFEJ02XXgbxuikhHfRg=="],
+
+    "@elizaos/plugin-goals": ["@elizaos/plugin-goals@2.0.0-alpha.9", "", { "dependencies": { "@elizaos/core": "2.0.0-alpha.3", "@radix-ui/react-checkbox": "^1.1.4", "@radix-ui/react-collapsible": "^1.1.3", "@radix-ui/react-label": "^2.1.2", "@radix-ui/react-select": "^2.2.2", "@radix-ui/react-separator": "^1.1.2", "@radix-ui/react-slot": "^1.1.2", "class-variance-authority": "^0.7.1" } }, "sha512-SpcqzApEW4G9fOyocf+OnLcu0q8Fz9i8W/hVRrvlK0dOrTzKlifP4sQJkKeIQNiGO6r6CqSYEH9uAbzp8oE3AQ=="],
 
     "@elizaos/plugin-groq": ["@elizaos/plugin-groq@2.0.0-alpha.10", "", { "dependencies": { "@ai-sdk/groq": "^3.0.4", "@elizaos/core": "alpha", "ai": "^6.0.0" } }, "sha512-VjceRHNUFFaQnXTxrC1Mi7Zs0szmx999Kw/+byjd7uCJXhCg0M/lXEdSM7z9i5/zjAZL3q6stQEMaOmJczNMIQ=="],
 
-    "@elizaos/plugin-openai": ["@elizaos/plugin-openai@2.0.0-alpha.13", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "@elizaos/core": "alpha", "ai": "^6.0.30", "js-tiktoken": "^1.0.21", "undici": "^7.16.0" }, "peerDependencies": { "zod": "^4.3.6" } }, "sha512-ho6vxXwoU5kdbT8Rl5Y1iZ9yTXqkUcWgXdb2Wpr2/1tIaVP16yG9IrFrd0OAaF4crUX6wWJWQByfnGgxi8/GqA=="],
+    "@elizaos/plugin-openai": ["@elizaos/plugin-openai@2.0.0-alpha.16", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "ai": "^6.0.30", "js-tiktoken": "^1.0.21", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.114", "zod": "^4.3.6" } }, "sha512-l4WaO5/m/Urx+j3/3nUrJ75kFTop7Ct6CbSRqCuhsrMdqE/GE83RrghmOu60IvWpex45P4Gx5mhSsras9+30gg=="],
 
-    "@elizaos/plugin-sql": ["@elizaos/plugin-sql@2.0.0-alpha.17", "", { "dependencies": { "@electric-sql/pglite": "^0.3.3", "@elizaos/core": "alpha", "@neondatabase/serverless": "^1.0.2", "dotenv": "^17.2.3", "drizzle-kit": "^0.31.8", "drizzle-orm": "^0.45.1", "pg": "^8.16.3", "uuid": "^13.0.0" } }, "sha512-O3I7ZX73DFMMCXWtjITi4QBYdo/01MI0neNBfqf6kbCBsE6j1r3ejZDoPBbRi/Ticsj3jlCc9nuwiOnKgWt+mQ=="],
+    "@elizaos/plugin-sql": ["@elizaos/plugin-sql@2.0.0-alpha.19", "", { "dependencies": { "@electric-sql/pglite": "^0.3.3", "@elizaos/core": "workspace:*", "@neondatabase/serverless": "^1.0.2", "dotenv": "^17.2.3", "drizzle-kit": "^0.31.8", "drizzle-orm": "^0.45.1", "pg": "^8.16.3", "uuid": "^13.0.0" } }, "sha512-LKHzdcD/yMDEZJ2MzJUwIDbYScAlp/oDc3O5x6Byd1Z10VrkWbKIU26+aAPuqTQwlTJMfvddY6u/I9lRxeGyIw=="],
 
-    "@elizaos/prompts": ["@elizaos/prompts@2.0.0-alpha.76", "", {}, "sha512-ZUASVWPpKgkqi4q1gGkTuh6KRk43KkZaeQayFRXZYxpKbAEvKqRdv7vZfXpZYXrwCmDLp62DYFGKPNsQ0oLMBA=="],
+    "@elizaos/prompts": ["@elizaos/prompts@2.0.0-alpha.196", "", {}, "sha512-+IFlaufZ58L0ZbyPuKiHruELGWNrkkqeuV99V2Jl5T1TprfIJv1RiT9qCEhYiYXsGZ8glHoSMGxdBkG6Qd4fBw=="],
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
 
@@ -1408,8 +1413,6 @@
     "@ethersproject/web": ["@ethersproject/web@5.8.0", "", { "dependencies": { "@ethersproject/base64": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw=="],
 
     "@ethersproject/wordlists": ["@ethersproject/wordlists@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg=="],
-
-    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@farcaster/miniapp-core": ["@farcaster/miniapp-core@0.5.1", "", { "dependencies": { "@solana/web3.js": "^1.98.2", "ox": "^0.4.4", "zod": "^3.25.0" } }, "sha512-5QFn9zTV8GHUqZF31X9iwq9tNlnoOgP/o0UXb+QmdNeJsWXrhUFBKYl+C7KQOhVw2xqWKhBSDgYIHOkSRua3vg=="],
 
@@ -1933,7 +1936,7 @@
 
     "@nicolo-ribaudo/eslint-scope-5-internals": ["@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1", "", { "dependencies": { "eslint-scope": "5.1.1" } }, "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg=="],
 
-    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
@@ -2004,6 +2007,44 @@
     "@npmcli/fs": ["@npmcli/fs@5.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og=="],
 
     "@npmcli/redact": ["@npmcli/redact@4.0.0", "", {}, "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q=="],
+
+    "@octokit/auth-app": ["@octokit/auth-app@6.1.4", "", { "dependencies": { "@octokit/auth-oauth-app": "^7.1.0", "@octokit/auth-oauth-user": "^4.1.0", "@octokit/request": "^8.3.1", "@octokit/request-error": "^5.1.0", "@octokit/types": "^13.1.0", "deprecation": "^2.3.1", "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1", "universal-github-app-jwt": "^1.1.2", "universal-user-agent": "^6.0.0" } }, "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ=="],
+
+    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@7.1.0", "", { "dependencies": { "@octokit/auth-oauth-device": "^6.1.0", "@octokit/auth-oauth-user": "^4.1.0", "@octokit/request": "^8.3.1", "@octokit/types": "^13.0.0", "@types/btoa-lite": "^1.0.0", "btoa-lite": "^1.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA=="],
+
+    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@6.1.0", "", { "dependencies": { "@octokit/oauth-methods": "^4.1.0", "@octokit/request": "^8.3.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw=="],
+
+    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@4.1.0", "", { "dependencies": { "@octokit/auth-oauth-device": "^6.1.0", "@octokit/oauth-methods": "^4.1.0", "@octokit/request": "^8.3.1", "@octokit/types": "^13.0.0", "btoa-lite": "^1.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@4.0.0", "", {}, "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="],
+
+    "@octokit/core": ["@octokit/core@5.2.2", "", { "dependencies": { "@octokit/auth-token": "^4.0.0", "@octokit/graphql": "^7.1.0", "@octokit/request": "^8.4.1", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.0.0", "before-after-hook": "^2.2.0", "universal-user-agent": "^6.0.0" } }, "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
+
+    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@6.0.2", "", {}, "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA=="],
+
+    "@octokit/oauth-methods": ["@octokit/oauth-methods@4.1.0", "", { "dependencies": { "@octokit/oauth-authorization-url": "^6.0.2", "@octokit/request": "^8.3.1", "@octokit/request-error": "^5.1.0", "@octokit/types": "^13.0.0", "btoa-lite": "^1.0.0" } }, "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@11.4.4-cjs.2", "", { "dependencies": { "@octokit/types": "^13.7.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@4.0.1", "", { "peerDependencies": { "@octokit/core": "5" } }, "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1", "", { "dependencies": { "@octokit/types": "^13.8.0" }, "peerDependencies": { "@octokit/core": "^5" } }, "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ=="],
+
+    "@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
+
+    "@octokit/rest": ["@octokit/rest@20.1.2", "", { "dependencies": { "@octokit/core": "^5.0.2", "@octokit/plugin-paginate-rest": "11.4.4-cjs.2", "@octokit/plugin-request-log": "^4.0.0", "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1" } }, "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA=="],
+
+    "@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.8.0", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oDDW/0KMqz4suHVloB9sNv0YyKLGNYf1FTevXH6adDkid5dsmbbcYuiEsbIhpZSZtHa6o5AVjK1jEAfePOLxww=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -2146,6 +2187,68 @@
     "@privy-io/urls": ["@privy-io/urls@0.0.3", "", {}, "sha512-cococ82ycPJc+wSCHUG0TrVJXF2PIkmDH8TLV+oGqBr14Q7ziRI63aCFIp6FpSRhdDDo9jmB0VR9NjCak4ptMA=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA=="],
+
+    "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
+
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-checkbox": ["@radix-ui/react-checkbox@1.3.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw=="],
+
+    "@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.12", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-label": ["@radix-ui/react-label@2.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
+
+    "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.8", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-previous": ["@radix-ui/react-use-previous@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
     "@react-aria/focus": ["@react-aria/focus@3.21.5", "", { "dependencies": { "@react-aria/interactions": "^3.27.1", "@react-aria/utils": "^3.33.1", "@react-types/shared": "^3.33.1", "@swc/helpers": "^0.5.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q=="],
 
@@ -2729,6 +2832,8 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@toon-format/toon": ["@toon-format/toon@2.1.0", "", {}, "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg=="],
+
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@trpc/client": ["@trpc/client@10.34.0", "", { "peerDependencies": { "@trpc/server": "10.34.0" } }, "sha512-nqtDTIqSY/9syo2EjSy4WWWXPU9GsamEh9Tsg698gLAh1nhgFc5+/YYeb+Ne1pbvWGZ5/3t9Dcz3h4wMyyJ9gQ=="],
@@ -2766,6 +2871,8 @@
     "@types/bonjour": ["@types/bonjour@3.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ=="],
 
     "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
+
+    "@types/btoa-lite": ["@types/btoa-lite@1.0.2", "", {}, "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
@@ -3187,6 +3294,8 @@
 
     "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
+    "adapter-types": ["adapter-types@0.2.0", "", {}, "sha512-T6YjdynGF9u1+D+DnqjsGmyW/dkq+kVRpz/wgVGcK2EHBAz9ETCX9Kz9ZHZdqyd0B2s/YJ0euGHiwhOFoGe0NA=="],
+
     "address": ["address@1.2.2", "", {}, "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA=="],
 
     "adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
@@ -3195,7 +3304,7 @@
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
 
-    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
@@ -3246,6 +3355,8 @@
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
@@ -3375,6 +3486,8 @@
 
     "bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
 
+    "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+
     "better-ajv-errors": ["better-ajv-errors@2.0.3", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@humanwhocodes/momoa": "^2.0.4", "chalk": "^4.1.2", "jsonpointer": "^5.0.1", "leven": "^3.1.0 < 4" }, "peerDependencies": { "ajv": "4.11.8 - 8" } }, "sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg=="],
 
     "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
@@ -3392,6 +3505,8 @@
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "blakejs": ["blakejs@1.2.1", "", {}, "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
@@ -3417,16 +3532,6 @@
 
     "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
 
-    "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
-
-    "browserify-cipher": ["browserify-cipher@1.0.1", "", { "dependencies": { "browserify-aes": "^1.0.4", "browserify-des": "^1.0.0", "evp_bytestokey": "^1.0.0" } }, "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w=="],
-
-    "browserify-des": ["browserify-des@1.0.2", "", { "dependencies": { "cipher-base": "^1.0.1", "des.js": "^1.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A=="],
-
-    "browserify-rsa": ["browserify-rsa@4.1.1", "", { "dependencies": { "bn.js": "^5.2.1", "randombytes": "^2.1.0", "safe-buffer": "^5.2.1" } }, "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ=="],
-
-    "browserify-sign": ["browserify-sign@4.2.5", "", { "dependencies": { "bn.js": "^5.2.2", "browserify-rsa": "^4.1.1", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "elliptic": "^6.6.1", "inherits": "^2.0.4", "parse-asn1": "^5.1.9", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1" } }, "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw=="],
-
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bs-logger": ["bs-logger@0.2.6", "", { "dependencies": { "fast-json-stable-stringify": "2.x" } }, "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog=="],
@@ -3435,6 +3540,8 @@
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
+    "btoa-lite": ["btoa-lite@1.0.0", "", {}, "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="],
+
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
@@ -3442,8 +3549,6 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
-
-    "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
@@ -3539,11 +3644,11 @@
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
-    "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
-
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "clarinet": ["clarinet@github:latticexyz/clarinet#9c30657", {}, "latticexyz-clarinet-9c30657"],
+
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
@@ -3568,6 +3673,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
+
+    "coding-agent-adapters": ["coding-agent-adapters@0.16.3", "", { "dependencies": { "adapter-types": "^0.2.0", "pino": "^9.6.0" }, "peerDependencies": { "agent-adapter-monitor": "^0.3.0" }, "optionalPeers": ["agent-adapter-monitor"] }, "sha512-eY2fiJ95sIYl2PUok7EP2XREQ+Mjpz88itv0rJV9ChS0g94PwfqDE6Vm1/qhBqOCt6CIE6HD0FMHzZlM+51nig=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -3653,12 +3760,6 @@
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
-    "create-ecdh": ["create-ecdh@4.0.4", "", { "dependencies": { "bn.js": "^4.1.0", "elliptic": "^6.5.3" } }, "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A=="],
-
-    "create-hash": ["create-hash@1.2.0", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "md5.js": "^1.3.4", "ripemd160": "^2.0.1", "sha.js": "^2.4.0" } }, "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg=="],
-
-    "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
-
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
     "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
@@ -3668,8 +3769,6 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
-
-    "crypto-browserify": ["crypto-browserify@3.12.1", "", { "dependencies": { "browserify-cipher": "^1.0.1", "browserify-sign": "^4.2.3", "create-ecdh": "^4.0.4", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "diffie-hellman": "^5.0.3", "hash-base": "~3.0.4", "inherits": "^2.0.4", "pbkdf2": "^3.1.2", "public-encrypt": "^4.0.3", "randombytes": "^2.1.0", "randomfill": "^1.0.4" } }, "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ=="],
 
     "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
 
@@ -3693,8 +3792,6 @@
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
-    "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
-
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
@@ -3712,6 +3809,8 @@
     "cssnano-utils": ["cssnano-utils@4.0.2", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -3785,7 +3884,7 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
-    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+    "data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -3849,13 +3948,13 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
+
     "deps-regex": ["deps-regex@0.2.0", "", {}, "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "derive-valtio": ["derive-valtio@0.1.0", "", { "peerDependencies": { "valtio": "*" } }, "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A=="],
-
-    "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
@@ -3873,6 +3972,8 @@
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
     "detect-port": ["detect-port@1.6.1", "", { "dependencies": { "address": "^1.0.1", "debug": "4" }, "bin": { "detect": "bin/detect-port.js", "detect-port": "bin/detect-port.js" } }, "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -3883,9 +3984,9 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
-    "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
-
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
@@ -3924,6 +4025,8 @@
     "drizzle-orm": ["drizzle-orm@0.44.7", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ=="],
 
     "dts-bundle-generator": ["dts-bundle-generator@9.5.1", "", { "dependencies": { "typescript": ">=5.0.2", "yargs": "^17.6.0" }, "bin": { "dts-bundle-generator": "dist/bin/dts-bundle-generator.js" } }, "sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -4125,8 +4228,6 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
-
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -4237,7 +4338,7 @@
 
     "file-loader": ["file-loader@6.2.0", "", { "dependencies": { "loader-utils": "^2.0.0", "schema-utils": "^3.0.0" }, "peerDependencies": { "webpack": "^4.0.0 || ^5.0.0" } }, "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw=="],
 
-    "file-type": ["file-type@21.3.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA=="],
+    "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -4273,7 +4374,7 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "forge-std": ["forge-std@github:foundry-rs/forge-std#f5495c9", {}, "foundry-rs-forge-std-f5495c9"],
+    "forge-std": ["forge-std@github:foundry-rs/forge-std#2999b65", {}, "foundry-rs-forge-std-2999b65", "sha512-kNfmnlt5OmqFrR1fHVC0TjAPBCTzgKdI6XeW2qQeDZcLAgBjyL5NswrEVwUuakmeQqMRnWjXLpnw7N7LLhkoEQ=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -4323,6 +4424,8 @@
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
     "get-own-enumerable-property-symbols": ["get-own-enumerable-property-symbols@3.0.2", "", {}, "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="],
 
     "get-package-type": ["get-package-type@0.1.0", "", {}, "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="],
@@ -4340,6 +4443,8 @@
     "getopts": ["getopts@2.3.0", "", {}, "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+
+    "git-workspace-service": ["git-workspace-service@0.4.5", "", { "dependencies": { "@octokit/auth-app": "^6.0.0", "@octokit/rest": "^20.0.0", "pino": "^9.0.0" } }, "sha512-T5mMXDku9s/Gz3yus/CudzqUg2KbaGvF4Y4lgDYZYDGbeFiGWYuJLzVexWQMaiOuctw5XKvRKQYLyB2nwXsMSQ=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
@@ -4403,8 +4508,6 @@
 
     "has-yarn": ["has-yarn@3.0.0", "", {}, "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA=="],
 
-    "hash-base": ["hash-base@3.0.5", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1" } }, "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg=="],
-
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
@@ -4453,7 +4556,7 @@
 
     "hpack.js": ["hpack.js@2.1.6", "", { "dependencies": { "inherits": "^2.0.1", "obuf": "^1.0.0", "readable-stream": "^2.0.1", "wbuf": "^1.1.0" } }, "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ=="],
 
-    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -4485,7 +4588,7 @@
 
     "http2-wrapper": ["http2-wrapper@2.2.1", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.2.0" } }, "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ=="],
 
-    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
@@ -4799,6 +4902,8 @@
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-stable-stringify": ["json-stable-stringify@1.3.0", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "isarray": "^2.0.5", "jsonify": "^0.0.1", "object-keys": "^1.1.1" } }, "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg=="],
@@ -4822,6 +4927,8 @@
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "jwa": ["jwa@1.4.2", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw=="],
 
@@ -4969,13 +5076,15 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
 
-    "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
 
@@ -4997,6 +5106,8 @@
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
+
     "map-obj": ["map-obj@5.0.0", "", {}, "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
@@ -5010,8 +5121,6 @@
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "md5": ["md5@2.3.0", "", { "dependencies": { "charenc": "0.0.2", "crypt": "0.0.2", "is-buffer": "~1.1.6" } }, "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g=="],
-
-    "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
 
     "mdast-util-directive": ["mdast-util-directive@3.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q=="],
 
@@ -5186,8 +5295,6 @@
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mikktspace": ["mikktspace@1.1.1", "", {}, "sha512-w+n5O2YLFsv/aRi3QUF0jxR+mEsl2J08ZkRItJHE08MWqiDIy8amyZN9vetBfbLhlWGMb8G3mzSPwtKHvBF7hQ=="],
-
-    "miller-rabin": ["miller-rabin@4.0.1", "", { "dependencies": { "bn.js": "^4.0.0", "brorand": "^1.0.1" }, "bin": { "miller-rabin": "bin/miller-rabin" } }, "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="],
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
@@ -5401,6 +5508,8 @@
 
     "openurl": ["openurl@1.1.1", "", {}, "sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA=="],
 
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -5440,8 +5549,6 @@
     "param-case": ["param-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
-
-    "parse-asn1": ["parse-asn1@5.1.9", "", { "dependencies": { "asn1.js": "^4.10.1", "browserify-aes": "^1.2.0", "evp_bytestokey": "^1.0.3", "pbkdf2": "^3.1.5", "safe-buffer": "^5.2.1" } }, "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg=="],
 
     "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
 
@@ -5492,8 +5599,6 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
-
-    "pbkdf2": ["pbkdf2@3.1.5", "", { "dependencies": { "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "ripemd160": "^2.0.3", "safe-buffer": "^5.2.1", "sha.js": "^2.4.12", "to-buffer": "^1.2.1" } }, "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ=="],
 
     "pdfjs-dist": ["pdfjs-dist@5.5.207", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.95", "node-readable-to-web-readable-stream": "^0.4.2" } }, "sha512-WMqqw06w1vUt9ZfT0gOFhMf3wHsWhaCrxGrckGs5Cci6ybDW87IvPaOd2pnBwT6BJuP/CzXDZxjFgmSULLdsdw=="],
 
@@ -5777,8 +5882,6 @@
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
-    "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
-
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "pumpify": ["pumpify@2.0.1", "", { "dependencies": { "duplexify": "^4.1.1", "inherits": "^2.0.3", "pump": "^3.0.0" } }, "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw=="],
@@ -5821,9 +5924,9 @@
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
-    "randomfill": ["randomfill@1.0.4", "", { "dependencies": { "randombytes": "^2.0.5", "safe-buffer": "^5.1.0" } }, "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw=="],
-
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "rate-limiter-flexible": ["rate-limiter-flexible@11.0.1", "", {}, "sha512-hvyCUefjRund2N6hro2H8Dql7OvB6+B3Qv2FLWWbdsdyQScXf4+N0tM0Bryz11awTtNxx6C1QbHYb1rCiAx7pA=="],
 
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
@@ -5853,11 +5956,17 @@
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-router": ["react-router@5.3.4", "", { "dependencies": { "@babel/runtime": "^7.12.13", "history": "^4.9.0", "hoist-non-react-statics": "^3.1.0", "loose-envify": "^1.3.1", "path-to-regexp": "^1.7.0", "prop-types": "^15.6.2", "react-is": "^16.6.0", "tiny-invariant": "^1.0.2", "tiny-warning": "^1.0.0" }, "peerDependencies": { "react": ">=15" } }, "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA=="],
 
     "react-router-config": ["react-router-config@5.1.1", "", { "dependencies": { "@babel/runtime": "^7.1.2" }, "peerDependencies": { "react": ">=15", "react-router": ">=5" } }, "sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg=="],
 
     "react-router-dom": ["react-router-dom@7.13.1", "", { "dependencies": { "react-router": "7.13.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
@@ -5937,8 +6046,6 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
-
     "require-like": ["require-like@0.1.2", "", {}, "sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A=="],
 
     "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
@@ -5977,8 +6084,6 @@
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
-    "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
-
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
     "rolldown": ["rolldown@1.0.0-rc.10", "", { "dependencies": { "@oxc-project/types": "=0.120.0", "@rolldown/pluginutils": "1.0.0-rc.10" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-arm64": "1.0.0-rc.10", "@rolldown/binding-darwin-x64": "1.0.0-rc.10", "@rolldown/binding-freebsd-x64": "1.0.0-rc.10", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA=="],
@@ -5988,6 +6093,8 @@
     "rollup-plugin-dts": ["rollup-plugin-dts@6.3.0", "", { "dependencies": { "magic-string": "^0.30.21" }, "optionalDependencies": { "@babel/code-frame": "^7.27.1" }, "peerDependencies": { "rollup": "^3.29.4 || ^4", "typescript": "^4.5 || ^5.0" } }, "sha512-d0UrqxYd8KyZ6i3M2Nx7WOMy708qsV/7fTHMHxCMCBOAe3V/U7OMPu5GkX8hC+cmkHhzGnfeYongl1IgiooddA=="],
 
     "rpc-websockets": ["rpc-websockets@9.3.5", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/uuid": "^10.0.0", "@types/ws": "^8.2.2", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "uuid": "^11.0.0", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^6.0.0" } }, "sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "rtlcss": ["rtlcss@4.3.0", "", { "dependencies": { "escalade": "^3.1.1", "picocolors": "^1.0.0", "postcss": "^8.4.21", "strip-json-comments": "^3.1.1" }, "bin": { "rtlcss": "bin/rtlcss.js" } }, "sha512-FI+pHEn7Wc4NqKXMXFM+VAYKEj/mRIcW4h24YVwVtyjI+EqGrLc2Hx/Ny0lrZ21cBWU2goLy36eqMcNj3AQJig=="],
 
@@ -6070,6 +6177,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -6263,7 +6372,7 @@
 
     "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
 
-    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
@@ -6423,6 +6532,8 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
     "ts-case-convert": ["ts-case-convert@2.1.0", "", {}, "sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w=="],
@@ -6499,7 +6610,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.57.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.0", "@typescript-eslint/parser": "8.57.0", "@typescript-eslint/typescript-estree": "8.57.0", "@typescript-eslint/utils": "8.57.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA=="],
 
-    "uWebSockets.js": ["uWebSockets.js@github:uNetworking/uWebSockets.js#a80dda2", {}, "uNetworking-uWebSockets.js-a80dda2"],
+    "uWebSockets.js": ["uWebSockets.js@github:uNetworking/uWebSockets.js#a80dda2", {}, "uNetworking-uWebSockets.js-a80dda2", "sha512-6uNfO7n5+UZGySX6Ap4AwOQdIN8C6Ovfn9F2n5RlsjCbrpMkifc6eGtcYwwE32AJaNlcZ3+CxTdC2xA4PX/CPw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
@@ -6518,6 +6629,8 @@
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
     "undici": ["undici@7.24.3", "", {}, "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA=="],
 
@@ -6555,7 +6668,13 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "universal-github-app-jwt": ["universal-github-app-jwt@1.2.0", "", { "dependencies": { "@types/jsonwebtoken": "^9.0.0", "jsonwebtoken": "^9.0.2" } }, "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g=="],
+
+    "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpdf": ["unpdf@1.6.0", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -6576,6 +6695,10 @@
     "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
     "url-loader": ["url-loader@4.1.1", "", { "dependencies": { "loader-utils": "^2.0.0", "mime-types": "^2.1.27", "schema-utils": "^3.0.0" }, "peerDependencies": { "file-loader": "*", "webpack": "^4.0.0 || ^5.0.0" }, "optionalPeers": ["file-loader"] }, "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA=="],
+
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
@@ -6675,13 +6798,13 @@
 
     "websocket-extensions": ["websocket-extensions@0.1.4", "", {}, "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="],
 
-    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
-
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
-    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -6765,7 +6888,7 @@
 
     "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
-    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
@@ -6803,15 +6926,11 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
 
-    "@anthropic-ai/sdk/form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "@anthropic-ai/sdk/formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
-
-    "@anthropic-ai/sdk/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+    "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -6870,6 +6989,8 @@
     "@csstools/cascade-layer-name-parser/@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
 
     "@csstools/cascade-layer-name-parser/@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
     "@csstools/media-query-list-parser/@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
 
@@ -7001,8 +7122,6 @@
 
     "@csstools/postcss-system-ui-font-family/@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
 
-    "@csstools/postcss-text-decoration-shorthand/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-trigonometric-functions/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
     "@csstools/postcss-trigonometric-functions/@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
@@ -7042,6 +7161,8 @@
     "@donmccurdy/caporal/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "@donmccurdy/caporal/table": ["table@5.4.6", "", { "dependencies": { "ajv": "^6.10.2", "lodash": "^4.17.14", "slice-ansi": "^2.1.0", "string-width": "^3.0.0" } }, "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug=="],
+
+    "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@elizaos/core/@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
@@ -7353,9 +7474,9 @@
 
     "@nomicfoundation/ignition-core/immer": ["immer@10.0.2", "", {}, "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA=="],
 
-    "@npmcli/agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "@npmcli/agent/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "@npmcli/agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "@octokit/auth-app/lru-cache": ["@wolfy1339/lru-cache@11.0.2-patch.1", "", {}, "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -7380,6 +7501,16 @@
     "@privy-io/react-auth/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@privy-io/server-auth/type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
+    "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@react-native/codegen/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
@@ -7617,6 +7748,8 @@
 
     "@walletconnect/time/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
     "@walletconnect/window-getters/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -7653,7 +7786,7 @@
 
     "boxen/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
-    "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+    "cacache/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
@@ -7705,8 +7838,6 @@
 
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "cssstyle/@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.2", "", { "dependencies": { "@csstools/css-calc": "^3.0.0", "@csstools/css-color-parser": "^4.0.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.5" } }, "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg=="],
-
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
     "css-blank-pseudo/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -7719,9 +7850,13 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "cssstyle/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
     "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "depcheck/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -7732,6 +7867,8 @@
     "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "elementtree/sax": ["sax@1.1.4", "", {}, "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg=="],
 
@@ -7795,6 +7932,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "ffmpeg-static/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "file-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -7834,24 +7973,6 @@
     "html-webpack-plugin/html-minifier-terser": ["html-minifier-terser@6.1.0", "", { "dependencies": { "camel-case": "^4.1.2", "clean-css": "^5.2.2", "commander": "^8.3.0", "he": "^1.2.0", "param-case": "^3.0.4", "relateurl": "^0.2.7", "terser": "^5.10.0" }, "bin": { "html-minifier-terser": "cli.js" } }, "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw=="],
 
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.8.1", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.6" } }, "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ=="],
-
-    "jsdom/data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
-
-    "jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
-
-    "jsdom/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
-
-    "jsdom/whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
-
-    "jsdom/data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
-
-    "jsdom/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
 
@@ -7955,6 +8076,8 @@
 
     "json-rpc-engine/@metamask/safe-event-emitter": ["@metamask/safe-event-emitter@2.0.0", "", {}, "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="],
 
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
     "keccak/node-addon-api": ["node-addon-api@2.0.2", "", {}, "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="],
 
     "keccak/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -8030,8 +8153,6 @@
     "metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.33.3", "", { "dependencies": { "hermes-estree": "0.33.3" } }, "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA=="],
-
-    "metro-cache/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "metro-config/jest-validate": ["jest-validate@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "camelcase": "^6.2.0", "chalk": "^4.0.0", "jest-get-type": "^29.6.3", "leven": "^3.1.0", "pretty-format": "^29.7.0" } }, "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw=="],
 
@@ -8197,12 +8318,6 @@
 
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "parse-asn1/asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
-
     "parse-bmfont-xml/xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -8215,8 +8330,6 @@
 
     "peek-stream/duplexify": ["duplexify@3.7.1", "", { "dependencies": { "end-of-stream": "^1.0.0", "inherits": "^2.0.1", "readable-stream": "^2.0.0", "stream-shift": "^1.0.0" } }, "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g=="],
 
-    "pg-mem/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
     "pg-mem/object-hash": ["object-hash@2.2.0", "", {}, "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
@@ -8226,6 +8339,8 @@
     "pkijs/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "porto/idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 
@@ -8293,10 +8408,6 @@
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
-    "proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "qrcode/pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
@@ -8333,8 +8444,6 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
-
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.10", "", {}, "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg=="],
 
     "rpc-websockets/@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
@@ -8364,8 +8473,6 @@
     "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "sockjs/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
-
-    "socks-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "solhint/@solidity-parser/parser": ["@solidity-parser/parser@0.20.2", "", {}, "sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA=="],
 
@@ -8527,12 +8634,6 @@
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "@anthropic-ai/sdk/formdata-node/web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
-
-    "@anthropic-ai/sdk/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
@@ -8587,47 +8688,25 @@
 
     "@coinbase/cdp-sdk/@solana/kit/@solana/transactions": ["@solana/transactions@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA=="],
 
-    "@csstools/postcss-alpha-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-alpha-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/postcss-color-function-display-p3-linear/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/postcss-color-function-display-p3-linear/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/postcss-color-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-color-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/postcss-color-mix-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/postcss-color-mix-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/postcss-color-mix-variadic-function-arguments/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-color-mix-variadic-function-arguments/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/postcss-contrast-color-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/postcss-contrast-color-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/postcss-gamut-mapping/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-gamut-mapping/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/postcss-gradients-interpolation-method/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/postcss-gradients-interpolation-method/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/postcss-hwb-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-hwb-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
-    "@csstools/postcss-oklab-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "@csstools/postcss-oklab-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "@csstools/postcss-relative-color-syntax/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/postcss-relative-color-syntax/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
@@ -9017,8 +9096,6 @@
 
     "@metamask/sdk/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
-    "@microsoft/api-extractor/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
     "@neondatabase/serverless/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -9082,8 +9159,6 @@
     "@rollup/plugin-replace/@rollup/pluginutils/estree-walker": ["estree-walker@1.0.1", "", {}, "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="],
 
     "@rollup/plugin-replace/@rollup/pluginutils/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "@rushstack/node-core-library/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
@@ -9403,12 +9478,6 @@
 
     "borsh/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
-    "browserify-sign/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
-
-    "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
-
     "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -9466,6 +9535,8 @@
     "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "ffmpeg-static/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "file-loader/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -9531,6 +9602,12 @@
 
     "jest-util/@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
+    "jszip/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "knex/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "langsmith/p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -9564,8 +9641,6 @@
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
-
-    "metro-cache/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "metro-config/jest-validate/@jest/types": ["@jest/types@29.6.3", "", { "dependencies": { "@jest/schemas": "^29.6.3", "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^17.0.8", "chalk": "^4.0.0" } }, "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw=="],
 
@@ -9683,15 +9758,13 @@
 
     "porto/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "porto/ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "porto/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "porto/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
-    "postcss-color-functional-notation/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
-
     "postcss-color-functional-notation/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
-
-    "postcss-lab-function/@csstools/css-color-parser/@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "postcss-lab-function/@csstools/css-color-parser/@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
 
@@ -9724,8 +9797,6 @@
     "renderkid/htmlparser2/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
 
     "renderkid/htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
-
-    "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -9774,6 +9845,8 @@
     "url-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
 
     "viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "viem/ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "viem/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
@@ -9862,10 +9935,6 @@
     "x402/@solana/transaction-confirmation/@solana/transactions": ["@solana/transactions@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "@anthropic-ai/sdk/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "@anthropic-ai/sdk/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
@@ -10039,6 +10108,8 @@
 
     "@latticexyz/cli/viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "@latticexyz/cli/viem/ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@latticexyz/cli/viem/ox/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@latticexyz/cli/viem/ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
@@ -10060,6 +10131,8 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
+
+    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
@@ -10089,6 +10162,8 @@
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
 
+    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
     "@reown/appkit-wallet/@walletconnect/logger/pino/on-exit-leak-free": ["on-exit-leak-free@0.2.0", "", {}, "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="],
@@ -10108,6 +10183,8 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core": ["@walletconnect/core@2.21.9", "", { "dependencies": { "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/jsonrpc-ws-connection": "1.0.16", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "@walletconnect/window-getters": "1.0.1", "es-toolkit": "1.39.3", "events": "3.3.0", "uint8arrays": "3.1.1" } }, "sha512-SlSknLvbO4i9Y4y8zU0zeCuJv1klQIUX3HRSBs1BaYvQKVVkrdiWPgRj4jcrL2wEOINa9NXw6HXp6x5XCXOolA=="],
+
+    "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
 
@@ -10768,12 +10845,6 @@
     "react-native/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
 
     "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
-
-    "ripemd160/hash-base/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
-
-    "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
-    "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "url-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,11 +88,12 @@
     "moment": "^2.30.1",
     "msgpackr": "^1.11.5",
     "pg": "^8.13.1",
+    "rate-limiter-flexible": "^11.0.1",
     "socket.io-client": "^4.8.1",
     "source-map-support": "^0.5.21",
+    "uWebSockets.js": "uNetworking/uWebSockets.js#v20.60.0",
     "uuid": "^13.0.0",
     "viem": "^2.46.2",
-    "uWebSockets.js": "uNetworking/uWebSockets.js#v20.60.0",
     "ws": "^8.18.0",
     "zod": "^4.1.11"
   },

--- a/packages/server/src/database/migrations/0055_add_duel_oracle_proof_to_history.sql
+++ b/packages/server/src/database/migrations/0055_add_duel_oracle_proof_to_history.sql
@@ -1,0 +1,18 @@
+-- Persist oracle proof fields (duelKeyHex, duelEndTime, seed, replayHash)
+-- on streaming_duel_history so the hyperbet keeper can catch up a missed
+-- onDuelEnd event by querying a per-duel result endpoint.
+--
+-- Nullable: legacy rows from before this migration will not have these
+-- fields populated, and cannot be used for synthetic onDuelEnd replay.
+-- New rows from MatchmakingManager.recordRecentDuel will always populate
+-- them from the currentCycle's buildOracleProof() output.
+
+ALTER TABLE "streaming_duel_history" ADD COLUMN IF NOT EXISTS "duelKeyHex" text;
+--> statement-breakpoint
+ALTER TABLE "streaming_duel_history" ADD COLUMN IF NOT EXISTS "duelEndTime" bigint;
+--> statement-breakpoint
+ALTER TABLE "streaming_duel_history" ADD COLUMN IF NOT EXISTS "seed" text;
+--> statement-breakpoint
+ALTER TABLE "streaming_duel_history" ADD COLUMN IF NOT EXISTS "replayHash" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_streaming_duel_history_duelid" ON "streaming_duel_history" USING btree ("duelId");

--- a/packages/server/src/database/migrations/0056_add_streaming_duel_oracle_proof_integrity_check.sql
+++ b/packages/server/src/database/migrations/0056_add_streaming_duel_oracle_proof_integrity_check.sql
@@ -1,0 +1,28 @@
+-- Enforce oracle-proof row integrity for streaming duel history.
+--
+-- Legacy rows may have no proof material at all. Fresh catch-up rows must have
+-- the full tuple required for synthetic onDuelEnd replay. Mixed rows are
+-- invalid because they look present to operators but cannot settle safely.
+
+DO $$
+BEGIN
+  ALTER TABLE "streaming_duel_history"
+    ADD CONSTRAINT "streaming_duel_history_oracle_proof_all_or_none"
+    CHECK (
+      (
+        "duelKeyHex" IS NULL AND
+        "duelEndTime" IS NULL AND
+        "seed" IS NULL AND
+        "replayHash" IS NULL
+      )
+      OR
+      (
+        "duelKeyHex" IS NOT NULL AND
+        "duelEndTime" IS NOT NULL AND
+        "seed" IS NOT NULL AND
+        "replayHash" IS NOT NULL
+      )
+    );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/packages/server/src/database/migrations/meta/_journal.json
+++ b/packages/server/src/database/migrations/meta/_journal.json
@@ -379,6 +379,20 @@
       "when": 1772300000000,
       "tag": "0054_add_agent_thoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1776397800000,
+      "tag": "0055_add_duel_oracle_proof_to_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1776400000000,
+      "tag": "0056_add_streaming_duel_oracle_proof_integrity_check",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/database/schema.ts
+++ b/packages/server/src/database/schema.ts
@@ -2562,6 +2562,15 @@ export const streamingDuelHistory = pgTable(
     winReason: text("winReason").notNull(),
     damageWinner: integer("damageWinner").notNull().default(0),
     damageLoser: integer("damageLoser").notNull().default(0),
+    // Oracle proof columns, populated at resolution time from buildOracleProof().
+    // Nullable for backwards-compatibility with rows created before this
+    // schema bump. The keeper catch-up endpoint requires these for any
+    // duel whose onDuelEnd was missed — without them, synthetic replay
+    // cannot propose a Solana result.
+    duelKeyHex: text("duelKeyHex"),
+    duelEndTime: bigint("duelEndTime", { mode: "number" }),
+    seed: text("seed"),
+    replayHash: text("replayHash"),
   },
   (table) => ({
     finishedAtIdx: index("idx_streaming_duel_history_finished").on(
@@ -2569,6 +2578,7 @@ export const streamingDuelHistory = pgTable(
     ),
     winnerIdx: index("idx_streaming_duel_history_winner").on(table.winnerId),
     loserIdx: index("idx_streaming_duel_history_loser").on(table.loserId),
+    duelIdIdx: index("idx_streaming_duel_history_duelid").on(table.duelId),
   }),
 );
 

--- a/packages/server/src/duel/DuelCombatAI.ts
+++ b/packages/server/src/duel/DuelCombatAI.ts
@@ -59,6 +59,9 @@ const TRASH_TALK_THRESHOLDS = [90, 80, 70, 60, 50, 40, 30, 20, 10] as const;
 /** Minimum milliseconds between trash talk LLM calls. */
 const TRASH_TALK_COOLDOWN_MS = 4_000;
 
+/** Hard timeout for a single trash talk LLM call — abandon after this. */
+const TRASH_TALK_TIMEOUT_MS = 4_000;
+
 /** Ambient trash talk fires randomly every 5-12 ticks. */
 const AMBIENT_TAUNT_MIN_TICKS = 5;
 const AMBIENT_TAUNT_MAX_TICKS = 12;
@@ -1111,7 +1114,10 @@ export class DuelCombatAI {
       return;
     }
 
-    // LLM path — fire in background, using agent character for personality
+    // LLM path — fire in background, using agent character for personality.
+    // Dedup guard: skip if a call is already in-flight.
+    if (this._trashTalkInFlight) return;
+
     const oppPctStr =
       opponentData && opponentData.maxHealth > 0
         ? `${((opponentData.health / opponentData.maxHealth) * 100).toFixed(0)}%`
@@ -1146,7 +1152,9 @@ export class DuelCombatAI {
     this._trashTalkInFlight = true;
     this.lastTrashTalkTime = Date.now();
 
-    (async () => {
+    // Fire-and-forget — intentionally NOT awaited so the combat tick is never blocked.
+    void (async () => {
+      let timerId: ReturnType<typeof setTimeout> | undefined;
       try {
         const llmPromise = this.runtime!.useModel(ModelType.TEXT_SMALL, {
           prompt,
@@ -1154,16 +1162,14 @@ export class DuelCombatAI {
           temperature: 0.9,
         });
 
-        let timerId: ReturnType<typeof setTimeout>;
         const timeoutPromise = new Promise<never>((_, reject) => {
           timerId = setTimeout(
             () => reject(new Error("Trash talk LLM timeout")),
-            LLM_TIMEOUT_MS,
+            TRASH_TALK_TIMEOUT_MS,
           );
         });
 
         const response = await Promise.race([llmPromise, timeoutPromise]);
-        clearTimeout(timerId!);
 
         const text = (typeof response === "string" ? response : "")
           .trim()
@@ -1172,11 +1178,11 @@ export class DuelCombatAI {
           try {
             sendChatAction(text);
           } catch {
-            // Swallow
+            // Swallow — chat failure must not break combat
           }
         }
       } catch (err) {
-        // On failure, use a scripted fallback
+        // On failure / timeout, use a scripted fallback
         const pool =
           kind === "own_low"
             ? FALLBACK_TAUNTS_OWN_LOW
@@ -1192,6 +1198,7 @@ export class DuelCombatAI {
           // Swallow
         }
       } finally {
+        if (timerId !== undefined) clearTimeout(timerId);
         this._trashTalkInFlight = false;
       }
     })();
@@ -1317,7 +1324,11 @@ export class DuelCombatAI {
     }
 
     try {
-      void this.service.executeMove([targetX, ownPos[1], targetZ], run);
+      void this.service
+        .executeMove([targetX, ownPos[1], targetZ], run)
+        .catch((err) =>
+          duelLogDebug("DuelCombatAI", "Move failed:", errMsg(err)),
+        );
       this.lastMoveTime = now;
       this.strafeMoveCount++;
       // Flip orbit direction every 5 moves — creates longer, more readable arcs

--- a/packages/server/src/eliza/AgentManager.ts
+++ b/packages/server/src/eliza/AgentManager.ts
@@ -23,8 +23,6 @@ import {
   stringToUuid,
   type Character,
   type Plugin,
-  // @ts-ignore - exported at runtime but missing from .d.ts
-  InMemoryDatabaseAdapter,
 } from "@elizaos/core";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
@@ -40,6 +38,10 @@ import {
   ejectAgentFromCombatArena,
   recoverAgentFromDeathLoop,
 } from "./agentRecovery.js";
+import {
+  CharacterWithModelProvider,
+  InMemoryDatabaseAdapter,
+} from "./elizaCoreCompat.js";
 
 /**
  * Dynamically import the Hyperscape plugin to avoid hard dependency in dev.
@@ -1184,7 +1186,7 @@ export class AgentManager {
       instance.config.characterConfig?.system ||
       `You are ${instance.config.name}, an embedded Hyperscape agent. Respond as yourself, stay grounded in the current game world, and keep replies concise and useful.`;
 
-    return {
+    const character = {
       id: stringToUuid(`embedded-chat-${instance.config.characterId}`),
       name: instance.config.name,
       username:
@@ -1225,9 +1227,9 @@ export class AgentManager {
         },
       },
       plugins: [],
-      // @ts-ignore - runtime supports modelProvider even if core type lags.
       modelProvider: provider.provider,
-    } as unknown as Character;
+    } as unknown as CharacterWithModelProvider;
+    return character as Character;
   }
 
   private buildDashboardChatPrompt(
@@ -1420,12 +1422,18 @@ export class AgentManager {
       }
 
       const adapter = new InMemoryDatabaseAdapter();
+      const adapterWithLog = adapter as unknown as {
+        log?: (params: unknown) => Promise<void>;
+        logs?: unknown[];
+      };
       // Eliza 2.0 alpha.76+ InMemoryDatabaseAdapter may omit `log`; only wrap when present.
-      if (typeof adapter.log === "function") {
-        const originalLog = adapter.log.bind(adapter);
-        adapter.log = async (params: Parameters<typeof originalLog>[0]) => {
+      if (typeof adapterWithLog.log === "function") {
+        const originalLog = adapterWithLog.log.bind(adapterWithLog);
+        adapterWithLog.log = async (
+          params: Parameters<typeof originalLog>[0],
+        ) => {
           await originalLog(params);
-          const logs = (adapter as unknown as { logs?: unknown[] }).logs;
+          const logs = adapterWithLog.logs;
           if (logs && logs.length > 50) {
             logs.splice(0, logs.length - 50);
           }
@@ -1519,7 +1527,16 @@ export class AgentManager {
         return;
       }
       const mod = await import("./ModelAgentSpawner.js");
-      mod.startEmbeddedAgentLlmPlanningLoop(
+      (
+        mod as typeof mod & {
+          startEmbeddedAgentLlmPlanningLoop?: (
+            characterId: string,
+            runtime: AgentRuntime,
+            service: EmbeddedHyperscapeService,
+            name: string,
+          ) => void;
+        }
+      ).startEmbeddedAgentLlmPlanningLoop?.(
         characterId,
         runtime,
         instance.service,
@@ -1536,7 +1553,11 @@ export class AgentManager {
     this.stopCharacterVisionRefresh(characterId);
     try {
       const mod = await import("./ModelAgentSpawner.js");
-      mod.stopEmbeddedAgentLlmPlanningLoop(characterId);
+      (
+        mod as typeof mod & {
+          stopEmbeddedAgentLlmPlanningLoop?: (characterId: string) => void;
+        }
+      ).stopEmbeddedAgentLlmPlanningLoop?.(characterId);
     } catch {
       /* ignore */
     }

--- a/packages/server/src/eliza/ElizaDuelBot.ts
+++ b/packages/server/src/eliza/ElizaDuelBot.ts
@@ -10,18 +10,14 @@
  * initiates challenges between bots.
  */
 
-import {
-  AgentRuntime,
-  type Plugin,
-  // @ts-ignore — InMemoryDatabaseAdapter is exported at runtime but not in .d.ts
-  InMemoryDatabaseAdapter,
-} from "@elizaos/core";
+import { AgentRuntime, type Plugin } from "@elizaos/core";
 import { EventEmitter } from "events";
 import { hyperscapePlugin } from "@hyperscape/plugin-hyperscape";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
 import type { ModelProviderConfig } from "./ModelAgentSpawner.js";
 import { loadModelPlugin, createAgentCharacter } from "./agentHelpers.js";
+import { InMemoryDatabaseAdapter } from "./elizaCoreCompat.js";
 import { duelLogError, duelLogInfo, duelLogWarn } from "./logging.js";
 
 // Re-export for convenience

--- a/packages/server/src/eliza/EmbeddedHyperscapeService.ts
+++ b/packages/server/src/eliza/EmbeddedHyperscapeService.ts
@@ -42,6 +42,13 @@ interface EmbeddedWorldMapData {
     position: { x: number; y: number; z: number };
     biome: string;
   }>;
+  pointsOfInterest?: Array<{
+    id: string;
+    name: string;
+    category: string;
+    position: { x: number; y: number; z: number };
+    biome: string;
+  }>;
   resources: Array<{
     type: string;
     resourceId: string;
@@ -106,7 +113,7 @@ function getSharedEntitySnapshot(
     now - cached.time < SHARED_SNAPSHOT_TTL_MS &&
     cached.snapshot.length > 0
   ) {
-    return cached.snapshot;
+    return cached.snapshot.slice();
   }
   const snapshot: EntitySnapshot[] = [];
   for (const [id, entity] of world.entities.items.entries()) {
@@ -117,7 +124,7 @@ function getSharedEntitySnapshot(
     snapshot.push({ id, position: pos, data, entity });
   }
   _snapshotCache.set(world, { snapshot, time: now });
-  return snapshot;
+  return snapshot.slice();
 }
 
 // Event handler type
@@ -225,6 +232,10 @@ export class EmbeddedHyperscapeService implements IEmbeddedHyperscapeService {
     this.world = world;
     this.characterId = characterId;
     this.accountId = accountId;
+    this.name = name;
+  }
+
+  setDisplayName(name: string): void {
     this.name = name;
   }
 

--- a/packages/server/src/eliza/ModelAgentSpawner.ts
+++ b/packages/server/src/eliza/ModelAgentSpawner.ts
@@ -19,20 +19,20 @@ import {
   type Character,
   type Memory,
   type UUID,
-  // @ts-ignore — InMemoryDatabaseAdapter is exported at runtime but not in .d.ts
-  InMemoryDatabaseAdapter,
 } from "@elizaos/core";
 import { EventType, getDuelArenaConfig, type World } from "@hyperscape/shared";
 import { createJWT } from "../shared/utils.js";
 import { errMsg } from "../shared/errMsg.js";
 import { hyperscapePlugin } from "@hyperscape/plugin-hyperscape";
 import type { EmbeddedHyperscapeService } from "./EmbeddedHyperscapeService.js";
+import type { DatabaseSystem } from "../systems/DatabaseSystem/index.js";
 import {
   ejectAgentFromCombatArena,
   recoverAgentFromDeathLoop,
 } from "./agentRecovery.js";
 import { getAgentManager } from "./AgentManager.js";
 import { loadModelPlugin, createAgentCharacter } from "./agentHelpers.js";
+import { InMemoryDatabaseAdapter } from "./elizaCoreCompat.js";
 
 type BunRuntime = {
   gc?: (force?: boolean) => void;
@@ -273,8 +273,7 @@ export async function spawnModelAgents(
   // both cause unbounded memory growth (WASM heap + in-memory log accumulation).
 
   // Get database system for character creation
-  // @ts-ignore - Dynamic import to avoid circular dependency
-  const databaseSystem = world.getSystem("database");
+  const databaseSystem = world.getSystem<DatabaseSystem>("database");
   const db = databaseSystem?.getDb?.();
 
   if (!db) {

--- a/packages/server/src/eliza/__tests__/AgentManager.autonomy.test.ts
+++ b/packages/server/src/eliza/__tests__/AgentManager.autonomy.test.ts
@@ -5,6 +5,8 @@ import {
   isPositionInsideCombatArena,
 } from "@hyperscape/shared";
 import { AgentManager } from "../AgentManager";
+import { AgentBehaviorBridge } from "../managers/AgentBehaviorBridge";
+import { ejectAgentFromCombatArena } from "../agentRecovery";
 
 type Skill = { level: number; xp: number };
 
@@ -230,6 +232,14 @@ describe("AgentManager autonomous loop", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    vi.spyOn(AgentBehaviorBridge.prototype, "start").mockResolvedValue();
+    vi.spyOn(AgentBehaviorBridge.prototype, "stop").mockImplementation(() => {});
+    vi.spyOn(AgentBehaviorBridge.prototype, "startAgent").mockImplementation(
+      () => {},
+    );
+    vi.spyOn(AgentBehaviorBridge.prototype, "stopAgent").mockImplementation(
+      () => {},
+    );
   });
 
   afterEach(() => {
@@ -243,8 +253,6 @@ describe("AgentManager autonomous loop", () => {
     ctx.addResource("resource-tree", [2, terrainHeight + 0.1, 0], "tree");
 
     const manager = new AgentManager(ctx.world as never);
-    const lobby = getDuelArenaConfig().lobbySpawnPoint;
-
     try {
       await manager.createAgent({
         characterId: "agent-loop",
@@ -277,9 +285,17 @@ describe("AgentManager autonomous loop", () => {
       expect(agent!.data.preventRespawn).toBe(false);
       expect(agent!.data.inCombat).toBe(false);
       expect(agent!.data.combatTarget).toBeNull();
-      expect(agent!.data.position[0]).toBeCloseTo(lobby.x, 5);
+      expect(
+        isPositionInsideCombatArena(
+          agent!.data.position[0],
+          agent!.data.position[2],
+        ),
+      ).toBe(false);
+      expect(
+        Math.hypot(agent!.data.position[0], agent!.data.position[2]),
+      ).toBeLessThanOrEqual(8);
       expect(agent!.data.position[1]).toBeCloseTo(terrainHeight + 0.1, 5);
-      expect(agent!.data.position[2]).toBeCloseTo(lobby.z, 5);
+      expect(agent!.data._teleport).toBe(true);
     } finally {
       await manager.shutdown();
     }
@@ -288,51 +304,47 @@ describe("AgentManager autonomous loop", () => {
   it("teleports non-dueling agents out of combat arena tiles", async () => {
     const terrainHeight = 9;
     const ctx = createMockWorld(terrainHeight);
-    ctx.registerCharacter("acct-5", "agent-out", "Outside Agent");
+    const arena = getDuelArenaConfig();
+    const arenaCenter = [
+      arena.baseX + Math.max(1, Math.floor(arena.arenaWidth / 2)),
+      terrainHeight + 0.1,
+      arena.baseZ + Math.max(1, Math.floor(arena.arenaLength / 2)),
+    ] as const;
+    ctx.world.entities.add({
+      id: "agent-out",
+      type: "player",
+      isAgent: true,
+      position: [...arenaCenter],
+      health: 20,
+      maxHealth: 20,
+      inStreamingDuel: false,
+      preventRespawn: false,
+    });
 
-    const manager = new AgentManager(ctx.world as never);
-    const lobby = getDuelArenaConfig().lobbySpawnPoint;
+    const agent = ctx.entities.get("agent-out");
+    expect(agent).toBeDefined();
 
-    try {
-      await manager.createAgent({
-        characterId: "agent-out",
-        accountId: "acct-5",
-        name: "Outside Agent",
-        scriptedRole: "combat",
-        autoStart: true,
-      });
+    const ejected = ejectAgentFromCombatArena(
+      ctx.world as never,
+      "agent-out",
+      "test",
+    );
 
-      await Promise.resolve();
-      await Promise.resolve();
-
-      const agent = ctx.entities.get("agent-out");
-      expect(agent).toBeDefined();
-
-      // Place agent inside arena 1 while not in a duel.
-      agent!.data.position = [70, terrainHeight + 0.1, 90];
-      agent!.data.inStreamingDuel = false;
-      agent!.data.preventRespawn = false;
-
-      await manager.executeBehaviorTick("agent-out");
-
-      expect(
-        isPositionInsideCombatArena(
-          agent!.data.position[0],
-          agent!.data.position[2],
-        ),
-      ).toBe(false);
-      expect(agent!.data._teleport).toBe(true);
-      expect(agent!.data.inStreamingDuel).toBe(false);
-      expect(agent!.data.preventRespawn).toBe(false);
-
-      // Ejected agents should remain near the lobby area.
-      const distFromLobby = Math.hypot(
-        agent!.data.position[0] - lobby.x,
-        agent!.data.position[2] - lobby.z,
-      );
-      expect(distFromLobby).toBeLessThanOrEqual(40);
-    } finally {
-      await manager.shutdown();
-    }
+    expect(isPositionInsideCombatArena(arenaCenter[0], arenaCenter[2])).toBe(
+      true,
+    );
+    expect(ejected).toBe(true);
+    expect(
+      isPositionInsideCombatArena(
+        agent!.data.position[0],
+        agent!.data.position[2],
+      ),
+    ).toBe(false);
+    expect(agent!.data._teleport).toBe(true);
+    expect(agent!.data.inStreamingDuel).toBe(false);
+    expect(agent!.data.preventRespawn).toBe(false);
+    expect(
+      Math.hypot(agent!.data.position[0], agent!.data.position[2]),
+    ).toBeLessThanOrEqual(8);
   });
 });

--- a/packages/server/src/eliza/__tests__/EmbeddedHyperscapeService.rpgMethods.test.ts
+++ b/packages/server/src/eliza/__tests__/EmbeddedHyperscapeService.rpgMethods.test.ts
@@ -9,7 +9,7 @@ function createMockWorld() {
     entities: {
       get: (id: string) => entities.get(id),
       add: vi.fn().mockReturnValue("new-entity-id"),
-      items: () => entities.entries(),
+      items: entities,
       [Symbol.iterator]: () => entities.entries(),
     },
     getSystem: (name: string) => systems.get(name) ?? null,
@@ -75,7 +75,15 @@ describe("EmbeddedHyperscapeService RPG methods", () => {
     });
 
     it("executeBankDepositAll emits BANK_DEPOSIT_ALL event", async () => {
-      const { service, world } = createActiveService();
+      const { service, world, entities } = createActiveService();
+      entities.get("agent-1").data.position = [0, 0, 0];
+      entities.set("bank-lumbridge", {
+        data: {
+          type: "bank",
+          name: "Bank Chest",
+          position: [2, 0, 2],
+        },
+      });
       const result = await service.executeBankDepositAll();
       expect(result).toBe(true);
       expect(world.emit).toHaveBeenCalledWith(
@@ -112,7 +120,27 @@ describe("EmbeddedHyperscapeService RPG methods", () => {
 
   describe("crafting", () => {
     it("executeCook emits cooking event", async () => {
-      const { service, world } = createActiveService();
+      const { service, world, entities, systems } = createActiveService();
+      entities.get("agent-1").data.position = [0, 0, 0];
+      entities.set("station-range", {
+        data: {
+          type: "object",
+          name: "Cooking Range",
+          position: [2, 0, 2],
+        },
+      });
+      systems.set("inventory", {
+        getInventory: () => ({
+          items: [
+            {
+              slot: 0,
+              itemId: "raw_shrimp",
+              quantity: 1,
+              item: { id: "raw_shrimp", name: "Raw Shrimp", type: "food" },
+            },
+          ],
+        }),
+      });
       const result = await service.executeCook("raw_shrimp");
       expect(result).toBe(true);
       expect(world.emit).toHaveBeenCalled();

--- a/packages/server/src/eliza/agentHelpers.ts
+++ b/packages/server/src/eliza/agentHelpers.ts
@@ -13,6 +13,7 @@ import {
 import path from "path";
 import fs from "fs";
 import { errMsg } from "../shared/errMsg.js";
+import { CharacterWithModelProvider } from "./elizaCoreCompat.js";
 
 import type { ModelProviderConfig } from "./ModelAgentSpawner.js";
 
@@ -251,7 +252,7 @@ export function createAgentCharacter(
 
   const modelSecrets = buildModelSecrets(config, overrides.smallModel);
 
-  const character: Character = {
+  const character = {
     id: stringToUuid(agentId),
     name: overrides.name || config.displayName,
     username: agentId,
@@ -262,7 +263,6 @@ export function createAgentCharacter(
     ],
     topics: ["combat strategy", "PvP tactics", "duel techniques"],
     adjectives: ["competitive", "ruthless", "strategic", "adaptive"],
-    // @ts-ignore - modelProvider not in core Character type yet
     modelProvider: config.provider,
     settings: {
       model: config.model,
@@ -283,7 +283,7 @@ export function createAgentCharacter(
       chat: ["Challenge strong players", "Accept all duels"],
     },
     plugins: [],
-  } as unknown as Character;
+  } as unknown as CharacterWithModelProvider;
 
-  return { character, agentId, characterId };
+  return { character: character as Character, agentId, characterId };
 }

--- a/packages/server/src/eliza/dashboardInterop.ts
+++ b/packages/server/src/eliza/dashboardInterop.ts
@@ -34,6 +34,36 @@ let thoughtFlushTimer: ReturnType<typeof setInterval> | null = null;
 // DB handle — set once via setThoughtDb() from server startup
 let _thoughtDb: Database | null = null;
 
+function normalizeDashboardThoughtType(
+  value: string,
+): DashboardThought["type"] {
+  switch (value) {
+    case "situation":
+    case "evaluation":
+    case "thinking":
+    case "decision":
+    case "action":
+      return value;
+    default:
+      return "thinking";
+  }
+}
+
+function normalizeDashboardDecisionPath(
+  value: string | null | undefined,
+): DashboardThought["decisionPath"] {
+  switch (value) {
+    case "short-circuit":
+    case "llm":
+    case "scripted":
+    case "planner":
+    case "curiosity":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
 /** Set the Drizzle DB instance for thought persistence. Call once at startup. */
 export function setThoughtDb(db: Database): void {
   _thoughtDb = db;
@@ -109,10 +139,10 @@ export async function hydrateThoughtsFromDb(
       if (!existingIds.has(id)) {
         existing.push({
           id,
-          type: r.type,
+          type: normalizeDashboardThoughtType(r.type),
           content: r.content,
           timestamp: r.timestamp,
-          decisionPath: r.decisionPath ?? undefined,
+          decisionPath: normalizeDashboardDecisionPath(r.decisionPath),
         });
       }
     }
@@ -141,6 +171,10 @@ type CommandData = {
   message?: string;
   npcId?: string;
   interaction?: string;
+  questId?: string;
+  recipe?: string;
+  slot?: string;
+  description?: string;
 };
 
 type DistancePreference = "nearest" | "furthest";
@@ -241,13 +275,23 @@ export function recordAgentThought(
 
 /** Snapshot of embedded AgentBehaviorTicker.goal (avoid circular import of AgentInstance). */
 export type EmbeddedTickerGoalSnapshot = {
-  type: "questing" | "combat" | "gathering" | "idle";
+  type:
+    | "questing"
+    | "combat"
+    | "gathering"
+    | "banking"
+    | "cooking"
+    | "smelting"
+    | "smithing"
+    | "exploring"
+    | "idle";
   description: string;
   questId?: string;
   questName?: string;
   questStageType?: string;
   questStageTarget?: string;
   questStageCount?: number;
+  questStartNpc?: string;
 };
 
 const MAX_EMBEDDED_DASHBOARD_ACTIVITY = 100;
@@ -1162,7 +1206,7 @@ function findGlobalResourceTarget(
     getWorld?: () => { entities?: { items?: Map<string, WorldEntity> } };
   };
   const world = (service as ServiceWithWorld).getWorld?.();
-  const items = world?.entities?.items;
+  const items = world?.entities?.items as Map<string, WorldEntity> | undefined;
   if (!items) return null;
   const kws = typeKeywords.map((k) => k.toLowerCase());
   let bestId: string | null = null;
@@ -1236,7 +1280,7 @@ function findGlobalMobTarget(
     getWorld?: () => { entities?: { items?: Map<string, WorldEntity> } };
   };
   const world = (service as ServiceWithWorld).getWorld?.();
-  const items = world?.entities?.items;
+  const items = world?.entities?.items as Map<string, WorldEntity> | undefined;
   if (!items) return null;
   const tokens = tokenizeTarget(targetPhrase);
   let bestId: string | null = null;
@@ -1639,13 +1683,11 @@ export function resolveDashboardIntent(
       };
     }
     // No specific item found, try any raw food
-    const anyRaw = inventoryEntries.find((e) =>
-      e.item?.itemId?.startsWith("raw_"),
-    );
+    const anyRaw = inventoryEntries.find((e) => e.itemId.startsWith("raw_"));
     if (anyRaw) {
       return {
         command: "cook",
-        data: { itemId: anyRaw.item!.itemId! },
+        data: { itemId: anyRaw.itemId },
         text: `Cooking ${anyRaw.name}.`,
         thought: `Operator requested cooking. Found ${anyRaw.name} in inventory.`,
         targetName: anyRaw.name,
@@ -1820,7 +1862,7 @@ export function resolveDashboardIntent(
       if (bestQuest && bestScore > 0) {
         return {
           command: "questAccept",
-          data: { questId: bestQuest.id },
+          data: { questId: bestQuest.questId },
           text: `Accepting quest "${bestQuest.name}".`,
           thought: `Operator asked to begin quest. Matched "${bestQuest.name}" from available quests.`,
           targetName: bestQuest.name,
@@ -1833,7 +1875,7 @@ export function resolveDashboardIntent(
       const first = startable[0];
       return {
         command: "questAccept",
-        data: { questId: first.id },
+        data: { questId: first.questId },
         text: `Accepting quest "${first.name}".`,
         thought: `Operator asked to begin a quest. No specific match — picking first available: "${first.name}".`,
         targetName: first.name,

--- a/packages/server/src/eliza/elizaCoreCompat.ts
+++ b/packages/server/src/eliza/elizaCoreCompat.ts
@@ -1,0 +1,21 @@
+import * as ElizaCore from "@elizaos/core";
+import type { Character, IDatabaseAdapter } from "@elizaos/core";
+
+export type InMemoryDatabaseAdapterLike = IDatabaseAdapter<
+  Record<string, never>
+> & {
+  log?: (params: unknown) => Promise<void>;
+  logs?: unknown[];
+};
+
+type InMemoryDatabaseAdapterCtor = new () => InMemoryDatabaseAdapterLike;
+
+export const InMemoryDatabaseAdapter = (
+  ElizaCore as typeof ElizaCore & {
+    InMemoryDatabaseAdapter: InMemoryDatabaseAdapterCtor;
+  }
+).InMemoryDatabaseAdapter;
+
+export type CharacterWithModelProvider = Character & {
+  modelProvider?: string;
+};

--- a/packages/server/src/eliza/llmBehaviorDecision.ts
+++ b/packages/server/src/eliza/llmBehaviorDecision.ts
@@ -647,12 +647,12 @@ export function buildBehaviorDecisionPrompt(
             (q.stageType === "gather" || q.stageType === "interact") &&
             q.stageTarget
           ) {
+            const stageTarget = q.stageTarget;
             const hasItem = fullInv.some(
-              (s) =>
-                s.itemId === q.stageTarget || s.itemId.includes(q.stageTarget),
+              (s) => s.itemId === stageTarget || s.itemId.includes(stageTarget),
             );
             if (!hasItem && q.stageCount && progress < q.stageCount) {
-              line += ` ⚠️ You do NOT have ${q.stageTarget} in inventory — gather/obtain it first!`;
+              line += ` ⚠️ You do NOT have ${stageTarget} in inventory — gather/obtain it first!`;
             }
           }
           return line;

--- a/packages/server/src/eliza/managers/AgentBehaviorBridge.ts
+++ b/packages/server/src/eliza/managers/AgentBehaviorBridge.ts
@@ -583,6 +583,7 @@ export class AgentBehaviorBridge {
         resourceSystemAvailable,
         spawnAnchors: [],
         worldResources: [],
+        stationPositions: [],
         agentState: {
           goal: instance.goal,
           questsAccepted: Array.from(instance.questsAccepted),

--- a/packages/server/src/eliza/managers/AgentBehaviorTicker.ts
+++ b/packages/server/src/eliza/managers/AgentBehaviorTicker.ts
@@ -311,11 +311,18 @@ export class AgentBehaviorTicker {
     // QuestSystem can load the player's quest state from the database.
     // Additional stagger offset prevents simultaneous first ticks.
     instance.behaviorStartTimeout = setTimeout(() => {
-      instance.behaviorStartTimeout = null;
+      const current = this.getAgent(characterId);
+      if (!current || current.state !== "running") {
+        return;
+      }
+      current.behaviorStartTimeout = null;
+      if (!current.service.isAutonomousEnabled()) {
+        return;
+      }
       void runTick();
 
       // Start the recurring interval AFTER the first tick completes its stagger
-      instance.behaviorInterval = setInterval(() => {
+      current.behaviorInterval = setInterval(() => {
         if (tickInProgress) return;
         tickInProgress = true;
         void runTick();
@@ -2298,6 +2305,41 @@ export class AgentBehaviorTicker {
       return [p.x, p.y ?? 0, p.z];
     }
     return null;
+  }
+
+  private getRequiredWoodcuttingLevel(entity: NearbyEntityData): number {
+    return this.getRequiredWoodcuttingLevelFromText(
+      `${entity.name || ""} ${entity.resourceType || ""} ${entity.resourceId || ""}`,
+    );
+  }
+
+  private getRequiredWoodcuttingLevelFromData(
+    data: Record<string, unknown>,
+  ): number {
+    return this.getRequiredWoodcuttingLevelFromText(
+      `${String(data.name || "")} ${String(data.resourceType || "")} ${String(data.type || "")}`,
+    );
+  }
+
+  private getRequiredWoodcuttingLevelFromText(text: string): number {
+    const normalized = text.toLowerCase();
+    if (normalized.includes("magic")) return 75;
+    if (normalized.includes("yew")) return 60;
+    if (normalized.includes("maple")) return 45;
+    if (normalized.includes("teak")) return 35;
+    if (normalized.includes("willow")) return 30;
+    if (normalized.includes("oak")) return 15;
+    return 1;
+  }
+
+  private isActivelyGatheringResource(
+    instance: AgentInstance,
+    resourceId: string,
+  ): boolean {
+    return (
+      instance.lastGatherTargetId === resourceId &&
+      Date.now() - instance.lastGatherQueuedAt < 30_000
+    );
   }
 
   /**

--- a/packages/server/src/eliza/types.ts
+++ b/packages/server/src/eliza/types.ts
@@ -36,6 +36,7 @@ export interface AgentCharacterConfig {
   username?: string;
   system?: string;
   bio?: string[];
+  lore?: string[];
   topics?: string[];
   adjectives?: string[];
   plugins?: string[];
@@ -122,6 +123,7 @@ export interface NearbyEntityData {
   level?: number;
   mobType?: string;
   itemId?: string;
+  resourceId?: string;
   resourceType?: string;
   equippedWeapon?: string;
 }
@@ -205,6 +207,7 @@ export interface AgentQuestProgress {
  */
 export interface AgentQuestInfo {
   questId: string;
+  id?: string;
   name: string;
   description: string;
   difficulty: string;
@@ -226,6 +229,9 @@ export interface AgentQuestInfo {
  * Provides direct world access instead of WebSocket
  */
 export interface IEmbeddedHyperscapeService {
+  /** Update the agent display name used by dashboard/chat surfaces. */
+  setDisplayName(name: string): void;
+
   /** Get the world instance */
   getWorld(): World;
 
@@ -270,6 +276,12 @@ export interface IEmbeddedHyperscapeService {
 
   /** Execute a prayer toggle command. Returns false if the prayer system was unavailable. */
   executePrayer(prayerId: string): Promise<boolean>;
+
+  /** Execute a prayer toggle command against the embedded client action API. */
+  executePrayerToggle(prayerId: string): Promise<boolean>;
+
+  /** Execute a combat style change against the embedded client action API. */
+  executeChangeStyle(newStyle: string): Promise<boolean>;
 
   /** Execute a chat message command. Returns false if the chat system was unavailable. */
   executeChat(message: string): Promise<boolean>;
@@ -324,4 +336,13 @@ export interface IEmbeddedHyperscapeService {
 
   /** Remove the arena movement constraint set by setArenaBounds(). */
   clearArenaBounds(): void;
+
+  /** Enable or disable autonomous overworld behavior while an external controller owns the agent. */
+  setAutonomousBehaviorEnabled(enabled: boolean): void;
+
+  /** Whether autonomous overworld behavior is currently enabled. */
+  isAutonomousEnabled(): boolean;
+
+  /** Send an overhead chat message through the embedded client bridge. */
+  sendChatMessage(text: string): Promise<string>;
 }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -207,7 +207,11 @@ async function startServer() {
       | { db?: unknown; getDb?: () => unknown }
       | undefined;
     const db = dbSystem?.db ?? dbSystem?.getDb?.();
-    if (db) setThoughtDb(db);
+    if (db) {
+      setThoughtDb(
+        db as Parameters<typeof setThoughtDb>[0],
+      );
+    }
   } catch {
     // Non-critical — thoughts will stay in-memory only
   }

--- a/packages/server/src/middleware/csrf.ts
+++ b/packages/server/src/middleware/csrf.ts
@@ -57,16 +57,35 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
  */
 const KNOWN_CROSS_ORIGIN_PATTERNS = [
   /^https?:\/\/(localhost|127\.0\.0\.1|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+)(:\d+)?$/,
-  /^https?:\/\/(www\.)?hyperscape\.gg$/,
-  /^https?:\/\/(www\.)?hyperbet\.win$/,
-  /^https?:\/\/(www\.)?bsc\.hyperbet\.win$/,
-  /^https?:\/\/(www\.)?hyperscape-betting\.pages\.dev$/,
-  /^https?:\/\/.+\.hyperscape-betting\.pages\.dev$/,
-  /^https?:\/\/.+\.hyperbet\.pages\.dev$/,
-  /^https?:\/\/.+\.hyperbet-solana\.pages\.dev$/,
-  /^https?:\/\/.+\.hyperbet-bsc\.pages\.dev$/,
-  /^https?:\/\/.+\.hyperscape\.pages\.dev$/,
+  /^https:\/\/(www\.)?hyperscape\.gg$/,
+  /^https:\/\/(www\.)?hyperbet\.win$/,
+  /^https:\/\/(www\.)?bsc\.hyperbet\.win$/,
+  /^https:\/\/(www\.)?hyperscape-betting\.pages\.dev$/,
+  /^https:\/\/.+\.hyperscape-betting\.pages\.dev$/,
+  /^https:\/\/.+\.hyperbet\.pages\.dev$/,
+  /^https:\/\/.+\.hyperscape\.pages\.dev$/,
 ];
+
+function hasRequestCookie(request: FastifyRequest): boolean {
+  return (
+    typeof request.headers.cookie === "string" &&
+    request.headers.cookie.trim().length > 0
+  );
+}
+
+function hasStructuredAuthorizationHeader(request: FastifyRequest): boolean {
+  const authorization = request.headers.authorization;
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  return (
+    typeof value === "string" && /^(?:Bearer|Basic)\s+\S+$/i.test(value.trim())
+  );
+}
+
+function hasStructuredAdminCodeHeader(request: FastifyRequest): boolean {
+  const adminCode = request.headers["x-admin-code"];
+  const value = Array.isArray(adminCode) ? adminCode[0] : adminCode;
+  return typeof value === "string" && value.trim().length > 0;
+}
 
 /**
  * Generate a cryptographically secure CSRF token
@@ -78,7 +97,7 @@ function generateCsrfToken(): string {
 /**
  * Check if a request should skip CSRF validation
  */
-function shouldSkipCsrf(request: FastifyRequest): boolean {
+export function shouldSkipCsrf(request: FastifyRequest): boolean {
   // Safe methods don't need CSRF protection
   if (SAFE_METHODS.has(request.method)) {
     return true;
@@ -94,14 +113,19 @@ function shouldSkipCsrf(request: FastifyRequest): boolean {
     return true;
   }
 
-  // API clients with Authorization header (Bearer token, API key, etc.)
-  // These are already authenticated via a different mechanism
-  if (request.headers.authorization) {
+  const requestHasCookies = hasRequestCookie(request);
+
+  // API clients with Authorization header are authenticated via a different
+  // mechanism only when the request is not also carrying ambient cookies.
+  // Otherwise a forged Authorization header could bypass CSRF while session
+  // cookies still authenticate the route.
+  if (hasStructuredAuthorizationHeader(request) && !requestHasCookies) {
     return true;
   }
 
-  // Admin requests with X-Admin-Code are already authenticated
-  if (request.headers["x-admin-code"]) {
+  // Same rule for admin-code clients: the header must be structurally present,
+  // and cookie-bearing browser requests still need the CSRF token.
+  if (hasStructuredAdminCodeHeader(request) && !requestHasCookies) {
     return true;
   }
 

--- a/packages/server/src/routes/streaming-betting-auth.ts
+++ b/packages/server/src/routes/streaming-betting-auth.ts
@@ -9,6 +9,11 @@ export type BettingFeedAccessTokenResolution = {
   source: "betting-feed" | null;
 };
 
+export type OracleProofAccessTokenResolution = {
+  token: string | null;
+  source: "oracle-proof" | null;
+};
+
 export function shouldSkipBettingFeedAuth(
   env: Record<string, string | undefined>,
 ): boolean {
@@ -16,6 +21,19 @@ export function shouldSkipBettingFeedAuth(
     env.NODE_ENV === "development" &&
     (env.BETTING_FEED_SKIP_AUTH || "").trim().toLowerCase() === "true"
   );
+}
+
+export function assertSafeBettingFeedAuthConfig(
+  env: Record<string, string | undefined>,
+): void {
+  if (
+    env.NODE_ENV === "production" &&
+    (env.BETTING_FEED_SKIP_AUTH || "").trim().toLowerCase() === "true"
+  ) {
+    throw new Error(
+      "BETTING_FEED_SKIP_AUTH=true is forbidden when NODE_ENV=production",
+    );
+  }
 }
 
 function digestToken(token: string): Buffer {
@@ -28,12 +46,9 @@ export function extractBettingFeedToken(
   const authHeader = Array.isArray(params.authorizationHeader)
     ? params.authorizationHeader[0]
     : params.authorizationHeader;
-  const headerToken =
-    authHeader && /^Bearer\s+/i.test(authHeader)
-      ? authHeader.replace(/^Bearer\s+/i, "").trim()
-      : null;
-  if (headerToken) {
-    return headerToken;
+  const match = authHeader?.match(/^Bearer\s+(\S+)\s*$/i);
+  if (match) {
+    return match[1];
   }
   return null;
 }
@@ -69,4 +84,19 @@ export function resolveBettingFeedAccessToken(
     token: null,
     source: null,
   };
+}
+
+// Oracle-proof retrieval (`/api/streaming/results/:duelId`) exposes
+// `duelKeyHex` + `seed` + `replayHash` — the material needed to submit a
+// Solana resolution. It intentionally has one dedicated secret boundary and
+// never falls back to the general betting feed token.
+export function resolveOracleProofAccessToken(
+  env: Record<string, string | undefined>,
+): OracleProofAccessTokenResolution {
+  const keeperAlignedToken =
+    env.HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN?.trim() || null;
+  if (keeperAlignedToken) {
+    return { token: keeperAlignedToken, source: "oracle-proof" };
+  }
+  return { token: null, source: null };
 }

--- a/packages/server/src/routes/streaming-betting-feed.ts
+++ b/packages/server/src/routes/streaming-betting-feed.ts
@@ -1,9 +1,17 @@
 import type {
   StreamingDuelCycle,
   StreamingPhase,
+  StreamingSourceTimeline,
 } from "../systems/StreamingDuelScheduler/types.js";
+import type {
+  StreamChannelState,
+  StreamDestinationState,
+  StreamManifestStatus,
+  StreamPublicReadiness,
+} from "../streaming/delivery-config.js";
+import type { StreamSourceRuntime } from "../streaming/source-runtime.js";
 
-export const BETTING_FEED_SCHEMA_VERSION = 1;
+export const BETTING_FEED_SCHEMA_VERSION = 3;
 export const BETTING_SOURCE_EPOCH_STORAGE_KEY =
   "streaming:betting-source-epoch";
 
@@ -29,15 +37,84 @@ export type BettingFeedRendererHealth = {
   updatedAt: number | null;
 };
 
+export type BettingFeedDeliveryHealth = BettingFeedRendererHealth;
+
+export type BettingFeedHlsManifest = {
+  updatedAt: number | null;
+  mediaSequence: number | null;
+};
+
+export type BettingFeedRendererMetrics = {
+  captureFps: number | null;
+  encodeFps: number | null;
+  droppedFrames: number | null;
+  renderTick: number | null;
+  duelStateTick: number | null;
+  latestFrameAt: number | null;
+  latestRenderTickAt: number | null;
+  latestDuelStateTickAt: number | null;
+  latestVisualChangeAt: number | null;
+  visualChangeAgeMs: number | null;
+  hlsManifest: BettingFeedHlsManifest | null;
+};
+
+export type BettingFeedDelivery = {
+  mode: "self_hls" | "external_hls";
+  provider: string | null;
+  playbackUrl: string | null;
+  hlsUrl: string | null;
+  llhlsUrl: string | null;
+  ingestUrl: string | null;
+};
+
+export type BettingFeedDestinationState = StreamDestinationState;
+export type BettingFeedPublicReadiness = StreamPublicReadiness;
+export type BettingFeedChannel = StreamChannelState;
+export type BettingFeedSourceRuntime = StreamSourceRuntime;
+
+export type BettingFeedCanonicalAuthority = {
+  providerLive: boolean;
+  playbackProbeReady: boolean;
+  decision: string | null;
+  reason: string | null;
+  revision: number | null;
+  updatedAt: number | null;
+  liveInputId: string | null;
+  videoUid: string | null;
+  lifecycleStatus: string | null;
+  playbackUrl: string | null;
+  playbackProbeStatusCode: number | null;
+  playbackManifestStatus: StreamManifestStatus | null;
+};
+
+export type BettingFeedBroadcastTimeline = {
+  phase: StreamingPhase | null;
+  betOpenTime: number | null;
+  betCloseTime: number | null;
+  fightStartTime: number | null;
+  duelEndTime: number | null;
+  presentationDelayMs: number;
+  updatedAt: number;
+};
+
+export type BettingFeedSourceTimeline = StreamingSourceTimeline;
+
+export type BettingFeedCycle = StreamingDuelCycle & {
+  sourceTimeline?: BettingFeedSourceTimeline;
+};
+
 export type BettingFeedPayload = {
   schemaVersion: number;
   sourceEpoch: number;
   seq: number;
   emittedAt: number;
+  cycle: BettingFeedCycle | null;
   duelId: string | null;
   duelKey: string | null;
   phase: StreamingPhase | null;
   phaseVersion: number;
+  broadcastTimeline: BettingFeedBroadcastTimeline;
+  sourceTimeline: BettingFeedSourceTimeline | null;
   betOpenTime: number | null;
   betCloseTime: number | null;
   fightStartTime: number | null;
@@ -49,6 +126,30 @@ export type BettingFeedPayload = {
   agent2: BettingFeedAgent | null;
   arenaPositions: StreamingDuelCycle["arenaPositions"];
   rendererHealth: BettingFeedRendererHealth | null;
+  deliveryHealth: BettingFeedDeliveryHealth | null;
+  channel: BettingFeedChannel | null;
+  publicReadiness: BettingFeedPublicReadiness | null;
+  canonicalDestination: BettingFeedDestinationState | null;
+  fallbackDestination: BettingFeedDestinationState | null;
+  canonicalAuthority: BettingFeedCanonicalAuthority | null;
+  sourceRuntime: BettingFeedSourceRuntime | null;
+  rendererMetrics: BettingFeedRendererMetrics | null;
+  captureFps: number | null;
+  encodeFps: number | null;
+  droppedFrames: number | null;
+  renderTick: number | null;
+  duelStateTick: number | null;
+  latestFrameAt: number | null;
+  latestRenderTickAt: number | null;
+  latestDuelStateTickAt: number | null;
+  latestVisualChangeAt: number | null;
+  visualChangeAgeMs: number | null;
+  hlsManifestUpdatedAt: number | null;
+  hlsMediaSequence: number | null;
+  delivery: BettingFeedDelivery | null;
+  deliveryMode: BettingFeedDelivery["mode"] | null;
+  deliveryProvider: string | null;
+  playbackUrl: string | null;
 };
 
 export type BettingFeedFrame = {
@@ -94,6 +195,75 @@ function resolveWinnerName(cycle: StreamingDuelCycle): string | null {
   return null;
 }
 
+function isRawSourceTimeEmissionEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    (env.STREAMING_EMIT_RAW_SOURCE_TIME ?? "").trim().toLowerCase() === "true"
+  );
+}
+
+function buildSourceTimeline(
+  cycle: StreamingDuelCycle,
+  updatedAt: number,
+): BettingFeedSourceTimeline {
+  return {
+    phase: cycle.phase,
+    betOpenTime: cycle.betOpenTime ?? null,
+    betCloseTime: cycle.betCloseTime ?? null,
+    fightStartTime: cycle.fightStartTime ?? null,
+    duelEndTime: cycle.duelEndTime ?? null,
+    updatedAt,
+  };
+}
+
+function redactOracleProofFromCycle(
+  cycle: StreamingDuelCycle | null,
+  exposeResolutionOutcome: boolean,
+): BettingFeedCycle | null {
+  if (!cycle) {
+    return null;
+  }
+
+  return {
+    ...cycle,
+    duelKeyHex: null,
+    duelEndTime: null,
+    seed: null,
+    replayHash: null,
+    winnerId: exposeResolutionOutcome ? (cycle.winnerId ?? null) : null,
+    winReason: exposeResolutionOutcome ? (cycle.winReason ?? null) : null,
+  };
+}
+
+function redactIngestUrlFromDestination(
+  destination: StreamDestinationState | null,
+): StreamDestinationState | null {
+  if (!destination) {
+    return null;
+  }
+  return {
+    ...destination,
+    ingestUrl: null,
+  };
+}
+
+function redactIngestUrlFromChannel(
+  channel: StreamChannelState | null,
+): StreamChannelState | null {
+  if (!channel) {
+    return null;
+  }
+
+  return {
+    ...channel,
+    destinations: channel.destinations.map((destination) => ({
+      ...destination,
+      ingestUrl: null,
+    })),
+  };
+}
+
 function toAgentSnapshot(
   agent: StreamingDuelCycle["agent1"],
 ): BettingFeedAgent | null {
@@ -116,34 +286,246 @@ function toAgentSnapshot(
   };
 }
 
+function projectBroadcastTimestamp(
+  timestamp: number | null | undefined,
+  presentationDelayMs: number,
+): number | null {
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? Math.max(0, timestamp + presentationDelayMs)
+    : null;
+}
+
+function resolveBroadcastTimelinePhase(params: {
+  cycle: StreamingDuelCycle | null;
+  emittedAt: number;
+  betOpenTime: number | null;
+  betCloseTime: number | null;
+  fightStartTime: number | null;
+  duelEndTime: number | null;
+}): StreamingPhase | null {
+  const {
+    cycle,
+    emittedAt,
+    betOpenTime,
+    betCloseTime,
+    fightStartTime,
+    duelEndTime,
+  } = params;
+  if (!cycle) {
+    return null;
+  }
+
+  if (cycle.phase === "IDLE") {
+    return "IDLE";
+  }
+  const projectedCycleStart =
+    betOpenTime ?? betCloseTime ?? fightStartTime ?? duelEndTime;
+  if (projectedCycleStart != null && emittedAt < projectedCycleStart) {
+    return "IDLE";
+  }
+
+  if (duelEndTime != null && emittedAt >= duelEndTime) {
+    return "RESOLUTION";
+  }
+
+  if (fightStartTime != null && emittedAt >= fightStartTime) {
+    return "FIGHTING";
+  }
+
+  if (betCloseTime != null && emittedAt >= betCloseTime) {
+    return "COUNTDOWN";
+  }
+
+  if (betOpenTime != null && emittedAt >= betOpenTime) {
+    return "ANNOUNCEMENT";
+  }
+
+  return cycle.phase;
+}
+
+function buildBroadcastTimeline(params: {
+  cycle: StreamingDuelCycle | null;
+  emittedAt: number;
+  presentationDelayMs: number;
+}): BettingFeedBroadcastTimeline {
+  const betOpenTime = projectBroadcastTimestamp(
+    params.cycle?.betOpenTime ?? null,
+    params.presentationDelayMs,
+  );
+  const betCloseTime = projectBroadcastTimestamp(
+    params.cycle?.betCloseTime ?? null,
+    params.presentationDelayMs,
+  );
+  const fightStartTime = projectBroadcastTimestamp(
+    params.cycle?.fightStartTime ?? null,
+    params.presentationDelayMs,
+  );
+  const duelEndTime = projectBroadcastTimestamp(
+    params.cycle?.duelEndTime ?? null,
+    params.presentationDelayMs,
+  );
+
+  return {
+    phase: resolveBroadcastTimelinePhase({
+      cycle: params.cycle,
+      emittedAt: params.emittedAt,
+      betOpenTime,
+      betCloseTime,
+      fightStartTime,
+      duelEndTime,
+    }),
+    betOpenTime,
+    betCloseTime,
+    fightStartTime,
+    duelEndTime,
+    presentationDelayMs: params.presentationDelayMs,
+    updatedAt: params.emittedAt,
+  };
+}
+
 export function buildBettingFeedPayload(params: {
   sourceEpoch: number;
   seq: number;
   emittedAt: number;
   cycle: StreamingDuelCycle | null;
   rendererHealth?: BettingFeedRendererHealth | null;
+  deliveryHealth?: BettingFeedDeliveryHealth | null;
+  channel?: BettingFeedChannel | null;
+  canonicalAuthority?: BettingFeedCanonicalAuthority | null;
+  sourceRuntime?: BettingFeedSourceRuntime | null;
+  rendererMetrics?: BettingFeedRendererMetrics | null;
+  delivery?: BettingFeedDelivery | null;
 }): BettingFeedPayload {
   const cycle = params.cycle;
+  const rendererMetrics = params.rendererMetrics ?? null;
+  const hlsManifest = rendererMetrics?.hlsManifest ?? null;
+  const channel = params.channel ?? null;
+  const presentationDelayMs = Math.max(0, channel?.presentationDelayMs ?? 0);
+  const canonicalDestination =
+    channel?.destinations.find(
+      (destination) => destination.id === channel.canonicalDestinationId,
+    ) ?? null;
+  const fallbackDestination =
+    channel?.fallbackDestinationId != null
+      ? (channel.destinations.find(
+          (destination) => destination.id === channel.fallbackDestinationId,
+        ) ?? null)
+      : null;
+  const delivery =
+    params.delivery ??
+    (canonicalDestination
+      ? {
+          mode:
+            canonicalDestination.provider === "self_hls"
+              ? "self_hls"
+              : "external_hls",
+          provider: canonicalDestination.provider,
+          playbackUrl: canonicalDestination.playbackUrl,
+          hlsUrl:
+            canonicalDestination.transport === "hls" &&
+            canonicalDestination.provider !== "self_hls"
+              ? canonicalDestination.playbackUrl
+              : null,
+          llhlsUrl:
+            canonicalDestination.transport === "llhls"
+              ? canonicalDestination.playbackUrl
+              : null,
+          ingestUrl: canonicalDestination.ingestUrl,
+        }
+      : null);
+  const deliveryHealth =
+    params.deliveryHealth ??
+    (channel?.publicReadiness
+      ? {
+          ready: channel.publicReadiness.ready,
+          degradedReason: channel.publicReadiness.reason,
+          updatedAt: channel.publicReadiness.updatedAt,
+        }
+      : null);
+  const broadcastTimeline = buildBroadcastTimeline({
+    cycle,
+    emittedAt: params.emittedAt,
+    presentationDelayMs,
+  });
+  const sourceTimeline =
+    isRawSourceTimeEmissionEnabled() && cycle
+      ? buildSourceTimeline(cycle, params.emittedAt)
+      : null;
+  const publicPhase = broadcastTimeline.phase ?? cycle?.phase ?? null;
+  // Public RESOLUTION disclosure is bettor display state only. Settlement and
+  // oracle proof material stay on the authenticated result/keeper path; this
+  // feed never exposes duelKeyHex, seed, replayHash, or ingest credentials.
+  const exposeResolutionOutcome = publicPhase === "RESOLUTION";
+  const publicCycleBase = redactOracleProofFromCycle(
+    cycle,
+    exposeResolutionOutcome,
+  );
+  const publicCycle =
+    publicCycleBase && sourceTimeline
+      ? {
+          ...publicCycleBase,
+          sourceTimeline,
+        }
+      : publicCycleBase;
+  const publicChannel = redactIngestUrlFromChannel(channel);
+  const publicCanonicalDestination =
+    redactIngestUrlFromDestination(canonicalDestination);
+  const publicFallbackDestination =
+    redactIngestUrlFromDestination(fallbackDestination);
+  const publicDelivery = delivery
+    ? {
+        ...delivery,
+        ingestUrl: null,
+      }
+    : null;
   return {
     schemaVersion: BETTING_FEED_SCHEMA_VERSION,
     sourceEpoch: params.sourceEpoch,
     seq: params.seq,
     emittedAt: params.emittedAt,
+    cycle: publicCycle,
     duelId: cycle?.duelId ?? null,
-    duelKey: cycle?.duelKeyHex ?? null,
-    phase: cycle?.phase ?? null,
+    duelKey: null,
+    phase: publicPhase,
     phaseVersion: cycle?.phaseVersion ?? 0,
-    betOpenTime: cycle?.betOpenTime ?? null,
-    betCloseTime: cycle?.betCloseTime ?? null,
-    fightStartTime: cycle?.fightStartTime ?? null,
-    duelEndTime: cycle?.duelEndTime ?? null,
-    winnerId: cycle?.winnerId ?? null,
-    winnerName: cycle ? resolveWinnerName(cycle) : null,
-    winReason: cycle?.winReason ?? null,
+    broadcastTimeline,
+    sourceTimeline,
+    betOpenTime: broadcastTimeline.betOpenTime,
+    betCloseTime: broadcastTimeline.betCloseTime,
+    fightStartTime: broadcastTimeline.fightStartTime,
+    duelEndTime: broadcastTimeline.duelEndTime,
+    winnerId: exposeResolutionOutcome ? (cycle?.winnerId ?? null) : null,
+    winnerName:
+      exposeResolutionOutcome && cycle ? resolveWinnerName(cycle) : null,
+    winReason: exposeResolutionOutcome ? (cycle?.winReason ?? null) : null,
     agent1: toAgentSnapshot(cycle?.agent1 ?? null),
     agent2: toAgentSnapshot(cycle?.agent2 ?? null),
     arenaPositions: cycle?.arenaPositions ?? null,
     rendererHealth: params.rendererHealth ?? null,
+    deliveryHealth,
+    channel: publicChannel,
+    publicReadiness: publicChannel?.publicReadiness ?? null,
+    canonicalDestination: publicCanonicalDestination,
+    fallbackDestination: publicFallbackDestination,
+    canonicalAuthority: params.canonicalAuthority ?? null,
+    sourceRuntime: params.sourceRuntime ?? null,
+    rendererMetrics,
+    captureFps: rendererMetrics?.captureFps ?? null,
+    encodeFps: rendererMetrics?.encodeFps ?? null,
+    droppedFrames: rendererMetrics?.droppedFrames ?? null,
+    renderTick: rendererMetrics?.renderTick ?? null,
+    duelStateTick: rendererMetrics?.duelStateTick ?? null,
+    latestFrameAt: rendererMetrics?.latestFrameAt ?? null,
+    latestRenderTickAt: rendererMetrics?.latestRenderTickAt ?? null,
+    latestDuelStateTickAt: rendererMetrics?.latestDuelStateTickAt ?? null,
+    latestVisualChangeAt: rendererMetrics?.latestVisualChangeAt ?? null,
+    visualChangeAgeMs: rendererMetrics?.visualChangeAgeMs ?? null,
+    hlsManifestUpdatedAt: hlsManifest?.updatedAt ?? null,
+    hlsMediaSequence: hlsManifest?.mediaSequence ?? null,
+    delivery: publicDelivery,
+    deliveryMode: publicDelivery?.mode ?? null,
+    deliveryProvider: publicDelivery?.provider ?? null,
+    playbackUrl: publicDelivery?.playbackUrl ?? null,
   };
 }
 
@@ -151,10 +533,104 @@ export function buildBettingFeedDedupKey(payload: BettingFeedPayload): string {
   return JSON.stringify({
     ...payload,
     emittedAt: 0,
+    cycle: payload.cycle
+      ? {
+          ...payload.cycle,
+          sourceTimeline: payload.cycle.sourceTimeline
+            ? {
+                ...payload.cycle.sourceTimeline,
+                updatedAt: 0,
+              }
+            : undefined,
+        }
+      : null,
+    broadcastTimeline: {
+      ...payload.broadcastTimeline,
+      updatedAt: 0,
+    },
+    sourceTimeline: payload.sourceTimeline
+      ? {
+          ...payload.sourceTimeline,
+          updatedAt: 0,
+        }
+      : null,
+    latestFrameAt: 0,
+    latestRenderTickAt: 0,
+    latestDuelStateTickAt: 0,
+    latestVisualChangeAt: 0,
+    hlsManifestUpdatedAt: 0,
     rendererHealth: payload.rendererHealth
       ? {
           ...payload.rendererHealth,
           updatedAt: 0,
+        }
+      : null,
+    deliveryHealth: payload.deliveryHealth
+      ? {
+          ...payload.deliveryHealth,
+          updatedAt: 0,
+        }
+      : null,
+    channel: payload.channel
+      ? {
+          ...payload.channel,
+          publicReadiness: {
+            ...payload.channel.publicReadiness,
+            updatedAt: 0,
+          },
+          destinations: payload.channel.destinations.map((destination) => ({
+            ...destination,
+            updatedAt: 0,
+          })),
+        }
+      : null,
+    publicReadiness: payload.publicReadiness
+      ? {
+          ...payload.publicReadiness,
+          updatedAt: 0,
+        }
+      : null,
+    canonicalDestination: payload.canonicalDestination
+      ? {
+          ...payload.canonicalDestination,
+          updatedAt: 0,
+        }
+      : null,
+    fallbackDestination: payload.fallbackDestination
+      ? {
+          ...payload.fallbackDestination,
+          updatedAt: 0,
+        }
+      : null,
+    canonicalAuthority: payload.canonicalAuthority
+      ? {
+          ...payload.canonicalAuthority,
+          updatedAt: 0,
+        }
+      : null,
+    sourceRuntime: payload.sourceRuntime
+      ? {
+          ...payload.sourceRuntime,
+          lastFrameAt: 0,
+          lastRenderTickAt: 0,
+          lastVisualChangeAt: 0,
+          lastRecoveryAt: 0,
+          workerHeartbeatAt: 0,
+        }
+      : null,
+    rendererMetrics: payload.rendererMetrics
+      ? {
+          ...payload.rendererMetrics,
+          latestFrameAt: 0,
+          latestRenderTickAt: 0,
+          latestDuelStateTickAt: 0,
+          latestVisualChangeAt: 0,
+          hlsManifest: payload.rendererMetrics.hlsManifest
+            ? {
+                ...payload.rendererMetrics.hlsManifest,
+                updatedAt: 0,
+              }
+            : null,
         }
       : null,
   });

--- a/packages/server/src/routes/streaming-betting-health.ts
+++ b/packages/server/src/routes/streaming-betting-health.ts
@@ -5,8 +5,35 @@ import {
 } from "@hyperscape/shared";
 import type { StreamingDuelCycle } from "../systems/StreamingDuelScheduler/types.js";
 import { getStreamCapture } from "../streaming/stream-capture.js";
+import type { HlsManifestSnapshot } from "../streaming/stream-status-artifacts.js";
 import type { BettingFeedRendererHealth } from "./streaming-betting-feed.js";
-import type { ExternalRtmpStatusSnapshot } from "./streaming-external-status.js";
+import type {
+  ExternalHlsManifestBlob,
+  ExternalRendererMetricsBlob,
+  ExternalRtmpStatusSnapshot,
+} from "./streaming-external-status.js";
+
+// External CDP capture status is sampled out-of-process and can legitimately
+// arrive several seconds behind the HLS edge. Keep this above segment cadence
+// plus polling jitter so healthy self-HLS playback is not blanked prematurely.
+const RENDER_TICK_STALE_MS = 10_000;
+const VISUAL_CHANGE_STALE_MS = 5_000;
+const VISUAL_CHANGE_GRACE_MS = 8_000;
+const DEFAULT_MIN_ENCODE_FPS = 24;
+const MIN_ENCODE_FPS_TARGET_RATIO = 0.8;
+
+type NormalizedRendererMetrics = {
+  captureFps: number | null;
+  encodeFps: number | null;
+  latestRenderTickAt: number | null;
+  latestVisualChangeAt: number | null;
+  visualChangeAgeMs: number | null;
+};
+
+type NormalizedHlsManifest = {
+  updatedAt: number | null;
+  mediaSequence: number | null;
+};
 
 function asFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -28,6 +55,66 @@ function normalizeRendererHealthSnapshot(
     degradedReason: asString(candidate.degradedReason),
     updatedAt: asFiniteNumber(candidate.updatedAt),
   };
+}
+
+function normalizeRendererMetrics(
+  value: ExternalRendererMetricsBlob | undefined,
+): NormalizedRendererMetrics | null {
+  if (!value || typeof value !== "object") return null;
+  return {
+    captureFps: asFiniteNumber(value.captureFps),
+    encodeFps: asFiniteNumber(value.encodeFps),
+    latestRenderTickAt: asFiniteNumber(value.latestRenderTickAt),
+    latestVisualChangeAt: asFiniteNumber(value.latestVisualChangeAt),
+    visualChangeAgeMs: asFiniteNumber(value.visualChangeAgeMs),
+  };
+}
+
+function normalizeHlsManifest(
+  value: ExternalHlsManifestBlob | HlsManifestSnapshot | undefined | null,
+): NormalizedHlsManifest | null {
+  if (!value || typeof value !== "object") return null;
+  return {
+    updatedAt: asFiniteNumber(value.updatedAt),
+    mediaSequence: asFiniteNumber(value.mediaSequence),
+  };
+}
+
+function resolveTargetEncodeFps(
+  externalSnapshot: ExternalRtmpStatusSnapshot | null,
+): number | null {
+  return (
+    asFiniteNumber(externalSnapshot?.ingest?.targetFps) ??
+    asFiniteNumber(externalSnapshot?.smoke?.ingest?.targetFps) ??
+    null
+  );
+}
+
+function resolveMinEncodeFps(targetEncodeFps: number | null): number {
+  const explicit = Number.parseInt(process.env.STREAM_MIN_ENCODE_FPS || "", 10);
+  if (Number.isFinite(explicit) && explicit > 0) {
+    return explicit;
+  }
+  if (targetEncodeFps != null && targetEncodeFps > 0) {
+    return Math.max(
+      1,
+      Math.floor(targetEncodeFps * MIN_ENCODE_FPS_TARGET_RATIO),
+    );
+  }
+  return DEFAULT_MIN_ENCODE_FPS;
+}
+
+function isFreshHlsManifest(params: {
+  hlsManifest: NormalizedHlsManifest | null;
+  nowMs: number;
+  freshnessMs: number;
+}): boolean {
+  const { hlsManifest, nowMs, freshnessMs } = params;
+  if (!hlsManifest) return false;
+  if (hlsManifest.mediaSequence == null || hlsManifest.updatedAt == null) {
+    return false;
+  }
+  return Math.max(0, nowMs - hlsManifest.updatedAt) <= freshnessMs;
 }
 
 function deriveCycleGuardrailReason(
@@ -58,12 +145,104 @@ function deriveCycleGuardrailReason(
   });
 }
 
+function phaseNeedsLiveRender(cycle: StreamingDuelCycle | null): boolean {
+  return cycle?.phase != null && cycle.phase !== "IDLE";
+}
+
+function phaseNeedsVisualChange(cycle: StreamingDuelCycle | null): boolean {
+  return (
+    cycle?.phase === "COUNTDOWN" ||
+    cycle?.phase === "FIGHTING" ||
+    cycle?.phase === "RESOLUTION"
+  );
+}
+
+function isWithinVisualChangeGraceWindow(
+  cycle: StreamingDuelCycle | null,
+  nowMs: number,
+): boolean {
+  if (!cycle || !phaseNeedsVisualChange(cycle)) {
+    return false;
+  }
+
+  return Math.max(0, nowMs - cycle.phaseStartTime) < VISUAL_CHANGE_GRACE_MS;
+}
+
+function deriveMetricsDegradedReason(params: {
+  cycle: StreamingDuelCycle | null;
+  metrics: NormalizedRendererMetrics | null;
+  hlsManifest: NormalizedHlsManifest | null;
+  nowMs: number;
+  externalStatusMaxAgeMs: number;
+  minEncodeFps: number;
+}): string | null {
+  const {
+    cycle,
+    metrics,
+    hlsManifest,
+    nowMs,
+    externalStatusMaxAgeMs,
+    minEncodeFps,
+  } = params;
+  if (!phaseNeedsLiveRender(cycle)) {
+    return null;
+  }
+  if (!metrics && !hlsManifest) {
+    return null;
+  }
+  if (metrics != null) {
+    const renderTickAgeMs =
+      metrics.latestRenderTickAt != null
+        ? Math.max(0, nowMs - metrics.latestRenderTickAt)
+        : null;
+    if (renderTickAgeMs == null || renderTickAgeMs > RENDER_TICK_STALE_MS) {
+      return "render_tick_stale";
+    }
+
+    if (!phaseNeedsVisualChange(cycle)) {
+      return null;
+    }
+
+    const withinVisualChangeGraceWindow = isWithinVisualChangeGraceWindow(
+      cycle,
+      nowMs,
+    );
+    if (
+      !withinVisualChangeGraceWindow &&
+      (metrics.visualChangeAgeMs == null ||
+        metrics.visualChangeAgeMs >= VISUAL_CHANGE_STALE_MS)
+    ) {
+      return "visual_change_stale";
+    }
+    // captureFps is raw browser compositor ingress. In CDP mode we intentionally
+    // throttle source frames and repeat the latest valid frame to keep encoder
+    // cadence stable, so content freshness and encodeFps are the hard gates.
+    if (metrics.encodeFps != null && metrics.encodeFps < minEncodeFps) {
+      return "encoder_fps_low";
+    }
+
+    return null;
+  }
+
+  const manifestFresh = isFreshHlsManifest({
+    hlsManifest,
+    nowMs,
+    freshnessMs: externalStatusMaxAgeMs,
+  });
+  if (!manifestFresh) {
+    return "manifest_stale";
+  }
+
+  return null;
+}
+
 export function deriveBettingRendererHealth(
   cycle: StreamingDuelCycle | null,
   options?: {
     externalStatusSnapshot?: ExternalRtmpStatusSnapshot | null;
     externalStatusMaxAgeMs?: number;
     nowMs?: number;
+    localHlsManifest?: HlsManifestSnapshot | null;
     captureStats?: {
       clientConnected: boolean;
       ffmpegRunning: boolean;
@@ -71,6 +250,7 @@ export function deriveBettingRendererHealth(
   },
 ): BettingFeedRendererHealth {
   const updatedAt = options?.nowMs ?? Date.now();
+  const externalStatusMaxAgeMs = options?.externalStatusMaxAgeMs ?? 15_000;
   const guardrailReason = deriveCycleGuardrailReason(cycle);
   if (guardrailReason) {
     return {
@@ -84,15 +264,36 @@ export function deriveBettingRendererHealth(
   const externalRendererHealth = normalizeRendererHealthSnapshot(
     externalSnapshot?.rendererHealth,
   );
+  const externalRendererMetrics = normalizeRendererMetrics(
+    externalSnapshot?.metrics,
+  );
+  const externalHlsManifest =
+    normalizeHlsManifest(externalSnapshot?.hlsManifest) ??
+    normalizeHlsManifest(options?.localHlsManifest);
+  const minEncodeFps = resolveMinEncodeFps(
+    resolveTargetEncodeFps(externalSnapshot),
+  );
+  const metricsReason = deriveMetricsDegradedReason({
+    cycle,
+    metrics: externalRendererMetrics,
+    hlsManifest: externalHlsManifest,
+    nowMs: updatedAt,
+    externalStatusMaxAgeMs,
+    minEncodeFps,
+  });
+
   if (externalRendererHealth) {
+    const healthSnapshotUpdatedAt =
+      asFiniteNumber(externalSnapshot?.updatedAt) ??
+      externalRendererHealth.updatedAt;
     const ageMs =
-      externalRendererHealth.updatedAt != null
-        ? Math.max(0, updatedAt - externalRendererHealth.updatedAt)
+      healthSnapshotUpdatedAt != null
+        ? Math.max(0, updatedAt - healthSnapshotUpdatedAt)
         : null;
     if (
-      externalRendererHealth.updatedAt != null &&
+      healthSnapshotUpdatedAt != null &&
       ageMs != null &&
-      ageMs > (options?.externalStatusMaxAgeMs ?? 15_000)
+      ageMs > externalStatusMaxAgeMs
     ) {
       return {
         ready: false,
@@ -100,7 +301,63 @@ export function deriveBettingRendererHealth(
         updatedAt,
       };
     }
-    return externalRendererHealth;
+
+    if (metricsReason) {
+      return {
+        ready: false,
+        degradedReason: metricsReason,
+        updatedAt,
+      };
+    }
+
+    if (
+      !externalRendererHealth.ready &&
+      externalRendererHealth.degradedReason &&
+      externalRendererHealth.degradedReason !== "renderer_health_stale"
+    ) {
+      return {
+        ...externalRendererHealth,
+        updatedAt: healthSnapshotUpdatedAt,
+      };
+    }
+
+    if (externalRendererHealth.ready || !phaseNeedsVisualChange(cycle)) {
+      return {
+        ...externalRendererHealth,
+        updatedAt: healthSnapshotUpdatedAt,
+      };
+    }
+
+    if (externalRendererMetrics || externalHlsManifest) {
+      return {
+        ready: true,
+        degradedReason: null,
+        updatedAt:
+          externalRendererHealth.updatedAt ??
+          externalHlsManifest?.updatedAt ??
+          updatedAt,
+      };
+    }
+  } else if (metricsReason) {
+    return {
+      ready: false,
+      degradedReason: metricsReason,
+      updatedAt,
+    };
+  }
+
+  if (
+    isFreshHlsManifest({
+      hlsManifest: externalHlsManifest,
+      nowMs: updatedAt,
+      freshnessMs: externalStatusMaxAgeMs,
+    })
+  ) {
+    return {
+      ready: true,
+      degradedReason: null,
+      updatedAt: externalHlsManifest?.updatedAt ?? updatedAt,
+    };
   }
 
   const captureStats = options?.captureStats ?? getStreamCapture().getStats();

--- a/packages/server/src/routes/streaming-betting-routes.ts
+++ b/packages/server/src/routes/streaming-betting-routes.ts
@@ -13,9 +13,11 @@ import {
   buildBettingFeedPayload,
   selectReplayDelivery,
   type BettingFeedFrame,
+  type BettingFeedRendererMetrics,
   type BettingFeedRendererHealth,
 } from "./streaming-betting-feed.js";
 import {
+  assertSafeBettingFeedAuthConfig,
   extractBettingFeedToken,
   hasValidBettingFeedToken,
   resolveBettingFeedAccessToken,
@@ -23,7 +25,48 @@ import {
 } from "./streaming-betting-auth.js";
 import { trimReplayFrames } from "./streaming-sse-buffer.js";
 import { deriveBettingRendererHealth } from "./streaming-betting-health.js";
-import { acquireExternalStatusPoller } from "./streaming-external-status.js";
+import {
+  acquireExternalStatusPoller,
+  type ExternalRtmpDestination,
+  type ExternalRtmpStatusSnapshot,
+} from "./streaming-external-status.js";
+import { deriveStreamSourceRuntime } from "./streaming-source-runtime.js";
+import { acquirePlaybackProbePoller } from "../streaming/destination-probe.js";
+import {
+  buildStreamDestinationId,
+  inferStreamDeliveryTransport,
+  normalizeStreamDestinationProvider,
+  resolveExternalStreamDeliveryInfo,
+  resolveSelfHostedStreamPlaybackUrl,
+  resolveStreamCanonicalProviderPriority,
+  resolveStreamDeliveryInfo,
+  resolveStreamFailbackSoakMs,
+  resolveStreamPresentationDelayMs,
+  type StreamCanonicalProvider,
+  type StreamChannelState,
+  type StreamDestinationState,
+  type StreamManifestStatus,
+  type StreamPublicReadiness,
+} from "../streaming/delivery-config.js";
+import type { StreamSourceRuntime } from "../streaming/source-runtime.js";
+import { readLocalHlsManifestSnapshot } from "../streaming/stream-status-artifacts.js";
+import {
+  loadPersistedStreamingAuthorityState,
+  persistCloudflareLifecyclePollState,
+  persistCloudflarePlaybackProbeState,
+  persistCloudflareReconciliationState,
+  persistCanonicalProviderState,
+  persistCloudflareLifecycleState,
+  persistCloudflareWebhookState,
+  reconcileCloudflareAuthority,
+  summarizeCloudflareLiveWebhook,
+  verifyCloudflareWebhookSecret,
+  type PersistedCanonicalProviderState,
+  type PersistedCloudflareLifecyclePollState,
+  type PersistedCloudflarePlaybackProbeState,
+  type PersistedCloudflareReconciliationState,
+  type PersistedStreamingAuthorityState,
+} from "../streaming/cloudflare-authority.js";
 
 // Re-exports so existing consumers (streaming.ts, tests) don't need import changes.
 export { deriveBettingRendererHealth } from "./streaming-betting-health.js";
@@ -68,7 +111,34 @@ type BettingRouteMetrics = {
   };
 };
 
+type CanonicalCandidateState = {
+  provider: StreamCanonicalProvider;
+  destination: StreamDestinationState;
+  publicReadiness: StreamPublicReadiness;
+  ready: boolean;
+};
+
+type CurrentChannelSnapshot = {
+  channel: StreamChannelState;
+  canonicalAuthority: PersistedCloudflareReconciliationState | null;
+};
+
+type CanonicalProviderSelectionState = {
+  activeProvider: StreamCanonicalProvider | null;
+  primaryHealthySince: number | null;
+};
+
+const REQUIRE_EXTERNAL_SOURCE_RUNTIME =
+  process.env.STREAM_SOURCE_RUNTIME_REQUIRE_EXTERNAL === "true" ||
+  process.env.NODE_ENV === "production";
+const CLOUDFLARE_WEBHOOK_RATE_LIMIT: RateLimitOptions = {
+  max: 180,
+  timeWindow: "1 minute",
+};
 type SseSendStatus = "ok" | "closed" | "slow" | "error";
+type RateLimitedFastify = FastifyInstance & {
+  rateLimit: NonNullable<FastifyInstance["rateLimit"]>;
+};
 
 type DatabaseSystemLike = Pick<DatabaseSystem, "getDb">;
 
@@ -81,6 +151,21 @@ function formatSseEvent(event: string, data: string, id?: number): string {
   const normalizedData = data.replace(/\n/g, "\ndata: ");
   const idLine = typeof id === "number" ? `id: ${id}\n` : "";
   return `${idLine}event: ${event}\ndata: ${normalizedData}\n\n`;
+}
+
+function automaticFailoverEnabled(): boolean {
+  return process.env.STREAM_ENABLE_AUTOMATIC_FAILOVER === "true";
+}
+
+function ensureRateLimitDecorator(
+  fastify: FastifyInstance,
+): asserts fastify is RateLimitedFastify {
+  if (typeof fastify.rateLimit === "function") {
+    return;
+  }
+  throw new Error(
+    "Streaming betting routes require @fastify/rate-limit to be registered before route setup",
+  );
 }
 
 export function normalizeInternalAllowedOrigin(
@@ -134,10 +219,21 @@ export function allocateNextBettingClientId(
 ): BettingClientIdAllocation {
   const activeIds = new Set(activeClientIds);
   const maxClientId = Number.MAX_SAFE_INTEGER - 1;
-  let clientId = nextCursor;
+  let clientId =
+    Number.isSafeInteger(nextCursor) &&
+    nextCursor >= 1 &&
+    nextCursor <= maxClientId
+      ? nextCursor
+      : 1;
   let wrapped = false;
+  let attempts = 0;
+  const maxAttempts = activeIds.size + 1;
 
   while (activeIds.has(clientId)) {
+    attempts += 1;
+    if (attempts > maxAttempts) {
+      throw new Error("No betting SSE client ids available");
+    }
     clientId += 1;
     if (clientId > maxClientId) {
       clientId = 1;
@@ -178,6 +274,8 @@ export function registerStreamingBettingRoutes(
     getStreamingDuelScheduler: getStreamingDuelSchedulerOverride,
     getStreamCaptureStats,
   } = options;
+  ensureRateLimitDecorator(fastify);
+  assertSafeBettingFeedAuthConfig(process.env);
 
   const tokenResolution = resolveBettingFeedAccessToken(process.env);
   const skipAuth = shouldSkipBettingFeedAuth(process.env);
@@ -185,19 +283,54 @@ export function registerStreamingBettingRoutes(
   const viewerTokenConfigured = Boolean(
     process.env.STREAMING_VIEWER_ACCESS_TOKEN?.trim(),
   );
+  const cloudflareLiveInputId =
+    process.env.STREAM_CLOUDFLARE_LIVE_INPUT_ID?.trim() || null;
   const getScheduler =
     getStreamingDuelSchedulerOverride ?? getStreamingDuelScheduler;
   const externalStatusPoller = acquireExternalStatusPoller(
     externalStatusFile,
     externalStatusMaxAgeMs,
   );
+  const configuredDelivery = resolveStreamDeliveryInfo(process.env);
+  const configuredProviderPriority = resolveStreamCanonicalProviderPriority(
+    process.env,
+  );
+  const configuredFailbackSoakMs = resolveStreamFailbackSoakMs(process.env);
+  const configuredPresentationDelayMs = resolveStreamPresentationDelayMs(
+    process.env,
+    configuredDelivery.mode,
+  );
+  const configuredSelfHostedPlaybackUrl = resolveSelfHostedStreamPlaybackUrl(
+    process.env,
+  );
+  const configuredCanonicalProvider = normalizeStreamDestinationProvider(
+    configuredDelivery.provider,
+    "Cloudflare",
+  );
+  const configuredCanonicalDestinationId = buildStreamDestinationId({
+    role: "canonical",
+    provider: configuredCanonicalProvider,
+    name: "External Delivery",
+  });
+  const configuredExternalPlaybackUrl = resolveExternalStreamDeliveryInfo(
+    process.env,
+  ).playbackUrl;
+  const externalPlaybackProbePoller = acquirePlaybackProbePoller(
+    configuredExternalPlaybackUrl,
+    {
+      intervalMs: Math.max(2_000, Math.min(externalStatusMaxAgeMs, 5_000)),
+      timeoutMs: Math.min(externalStatusMaxAgeMs, 4_000),
+    },
+  );
   if (!tokenResolution.token && process.env.NODE_ENV === "production") {
     fastify.log.warn(
       "BETTING_FEED_ACCESS_TOKEN is unset in production; internal betting feed will fail closed",
     );
   } else if (!tokenResolution.token && skipAuth) {
-    fastify.log.warn(
-      "BETTING_FEED_SKIP_AUTH=true with no betting-feed token configured; internal betting feed auth bypass is enabled for development use only",
+    // Log at error severity so the auth-bypass state is impossible to miss
+    // even during normal startup log volume.
+    fastify.log.error(
+      "BETTING_FEED_SKIP_AUTH=true AND NODE_ENV=development — internal betting feed is serving UNAUTHENTICATED. This must never land in production.",
     );
   } else if (!tokenResolution.token && viewerTokenConfigured) {
     fastify.log.warn(
@@ -212,6 +345,25 @@ export function registerStreamingBettingRoutes(
       "STREAMING_VIEWER_ACCESS_TOKEN remains separate from internal betting feed auth; BETTING_FEED_ACCESS_TOKEN is the canonical betting secret",
     );
   }
+  const canonicalProviderSelectionState: CanonicalProviderSelectionState = {
+    activeProvider: null,
+    primaryHealthySince: null,
+  };
+  let canonicalProviderSelectionHydrated = false;
+  let canonicalProviderSelectionHydration: Promise<void> | null = null;
+  // Exponential backoff for failed hydration attempts. Without this, a failing
+  // DB causes every betting-feed tick to retry immediately, hammering the
+  // backend. Start at 1s and double up to 60s; reset on success.
+  let canonicalProviderHydrationFailures = 0;
+  let canonicalProviderHydrationNextAttemptAt = 0;
+  const HYDRATION_MIN_BACKOFF_MS = 1_000;
+  const HYDRATION_MAX_BACKOFF_MS = 60_000;
+  let persistedAuthorityStateCache: PersistedStreamingAuthorityState | null =
+    null;
+  let lastPersistedCanonicalProviderStateJson: string | null = null;
+  let lastPersistedCloudflareLifecyclePollJson: string | null = null;
+  let lastPersistedCloudflarePlaybackProbeJson: string | null = null;
+  let lastPersistedCloudflareReconciliationJson: string | null = null;
   if (internalAllowedOrigin && !allowedOrigin) {
     fastify.log.warn(
       {
@@ -279,6 +431,7 @@ export function registerStreamingBettingRoutes(
     }
     closed = true;
     clearBettingLoops();
+    externalPlaybackProbePoller?.release();
     externalStatusPoller?.release();
     for (const clientId of [...bettingClients.keys()]) {
       removeBettingClient(clientId);
@@ -305,6 +458,197 @@ export function registerStreamingBettingRoutes(
 
   const getDatabaseSystem = (): DatabaseSystemLike | null =>
     (world.getSystem("database") ?? null) as DatabaseSystemLike | null;
+
+  const getStorageDb = () => getDatabaseSystem()?.getDb?.();
+
+  const persistCanonicalProviderSelection = (): void => {
+    if (!canonicalProviderSelectionHydrated) {
+      return;
+    }
+    const activeProvider =
+      canonicalProviderSelectionState.activeProvider === "cloudflare_stream" ||
+      canonicalProviderSelectionState.activeProvider === "self_hls"
+        ? canonicalProviderSelectionState.activeProvider
+        : null;
+    const comparisonPayload = JSON.stringify({
+      activeProvider,
+      primaryHealthySince: canonicalProviderSelectionState.primaryHealthySince,
+    });
+    if (comparisonPayload === lastPersistedCanonicalProviderStateJson) {
+      return;
+    }
+    lastPersistedCanonicalProviderStateJson = comparisonPayload;
+    const state: PersistedCanonicalProviderState = {
+      activeProvider,
+      primaryHealthySince: canonicalProviderSelectionState.primaryHealthySince,
+      updatedAt: Date.now(),
+    };
+    getPersistedAuthorityState().canonicalProviderState = state;
+    void persistCanonicalProviderState(getStorageDb(), state).catch((error) => {
+      lastPersistedCanonicalProviderStateJson = null;
+      fastify.log.warn(
+        {
+          err: error,
+          activeProvider: state.activeProvider,
+        },
+        "[streaming-betting] Failed to persist canonical provider state",
+      );
+    });
+  };
+
+  const ensureCanonicalProviderSelectionHydrated = async (): Promise<void> => {
+    if (canonicalProviderSelectionHydrated) {
+      return;
+    }
+    if (canonicalProviderSelectionHydration) {
+      return canonicalProviderSelectionHydration;
+    }
+    if (Date.now() < canonicalProviderHydrationNextAttemptAt) {
+      // Backoff window from a prior failure is still active; callers see
+      // unhydrated state and will retry on their next tick.
+      return;
+    }
+
+    canonicalProviderSelectionHydration = (async () => {
+      try {
+        const persisted =
+          await loadPersistedStreamingAuthorityState(getStorageDb());
+        persistedAuthorityStateCache = persisted;
+        const state = persisted.canonicalProviderState;
+        if (state) {
+          canonicalProviderSelectionState.activeProvider =
+            state.activeProvider === "cloudflare_stream" ||
+            state.activeProvider === "self_hls"
+              ? state.activeProvider
+              : null;
+          canonicalProviderSelectionState.primaryHealthySince =
+            typeof state.primaryHealthySince === "number" &&
+            Number.isFinite(state.primaryHealthySince)
+              ? state.primaryHealthySince
+              : null;
+          lastPersistedCanonicalProviderStateJson = JSON.stringify({
+            activeProvider: canonicalProviderSelectionState.activeProvider,
+            primaryHealthySince:
+              canonicalProviderSelectionState.primaryHealthySince,
+          });
+        }
+        lastPersistedCloudflareLifecyclePollJson =
+          persisted.cloudflareLifecyclePoll
+            ? JSON.stringify(persisted.cloudflareLifecyclePoll)
+            : null;
+        lastPersistedCloudflarePlaybackProbeJson =
+          persisted.cloudflarePlaybackProbe
+            ? JSON.stringify(persisted.cloudflarePlaybackProbe)
+            : null;
+        lastPersistedCloudflareReconciliationJson =
+          persisted.cloudflareReconciliation
+            ? JSON.stringify(persisted.cloudflareReconciliation)
+            : null;
+        canonicalProviderSelectionHydrated = true;
+        canonicalProviderHydrationFailures = 0;
+        canonicalProviderHydrationNextAttemptAt = 0;
+      } catch (error) {
+        canonicalProviderHydrationFailures += 1;
+        const backoff = Math.min(
+          HYDRATION_MAX_BACKOFF_MS,
+          HYDRATION_MIN_BACKOFF_MS *
+            2 ** (canonicalProviderHydrationFailures - 1),
+        );
+        canonicalProviderHydrationNextAttemptAt = Date.now() + backoff;
+        console.warn(
+          `[streaming-betting] Failed to hydrate canonical provider selection; retrying in ${backoff}ms (failures=${canonicalProviderHydrationFailures})`,
+          error,
+        );
+      } finally {
+        canonicalProviderSelectionHydration = null;
+      }
+    })();
+
+    return canonicalProviderSelectionHydration;
+  };
+
+  void ensureCanonicalProviderSelectionHydrated();
+
+  const getPersistedAuthorityState = (): PersistedStreamingAuthorityState => {
+    if (persistedAuthorityStateCache) {
+      return persistedAuthorityStateCache;
+    }
+    persistedAuthorityStateCache = {
+      canonicalProviderState: null,
+      cloudflareLifecycle: null,
+      cloudflareLastWebhook: null,
+      cloudflareLifecyclePoll: null,
+      cloudflarePlaybackProbe: null,
+      cloudflareReconciliation: null,
+    };
+    return persistedAuthorityStateCache;
+  };
+
+  const persistCloudflareLifecyclePollSnapshot = (
+    state: PersistedCloudflareLifecyclePollState | null,
+  ): void => {
+    if (!state) {
+      return;
+    }
+    const comparisonPayload = JSON.stringify(state);
+    if (comparisonPayload === lastPersistedCloudflareLifecyclePollJson) {
+      return;
+    }
+    lastPersistedCloudflareLifecyclePollJson = comparisonPayload;
+    getPersistedAuthorityState().cloudflareLifecyclePoll = state;
+    void persistCloudflareLifecyclePollState(getStorageDb(), state).catch(
+      (error) => {
+        lastPersistedCloudflareLifecyclePollJson = null;
+        fastify.log.warn(
+          { err: error },
+          "[streaming-betting] Failed to persist Cloudflare lifecycle poll state",
+        );
+      },
+    );
+  };
+
+  const persistCloudflarePlaybackProbeSnapshot = (
+    state: PersistedCloudflarePlaybackProbeState | null,
+  ): void => {
+    if (!state) {
+      return;
+    }
+    const comparisonPayload = JSON.stringify(state);
+    if (comparisonPayload === lastPersistedCloudflarePlaybackProbeJson) {
+      return;
+    }
+    lastPersistedCloudflarePlaybackProbeJson = comparisonPayload;
+    getPersistedAuthorityState().cloudflarePlaybackProbe = state;
+    void persistCloudflarePlaybackProbeState(getStorageDb(), state).catch(
+      (error) => {
+        lastPersistedCloudflarePlaybackProbeJson = null;
+        fastify.log.warn(
+          { err: error },
+          "[streaming-betting] Failed to persist Cloudflare playback probe state",
+        );
+      },
+    );
+  };
+
+  const persistCloudflareReconciliationSnapshot = (
+    state: PersistedCloudflareReconciliationState,
+  ): void => {
+    const comparisonPayload = JSON.stringify(state);
+    if (comparisonPayload === lastPersistedCloudflareReconciliationJson) {
+      return;
+    }
+    lastPersistedCloudflareReconciliationJson = comparisonPayload;
+    getPersistedAuthorityState().cloudflareReconciliation = state;
+    void persistCloudflareReconciliationState(getStorageDb(), state).catch(
+      (error) => {
+        lastPersistedCloudflareReconciliationJson = null;
+        fastify.log.warn(
+          { err: error },
+          "[streaming-betting] Failed to persist Cloudflare reconciliation state",
+        );
+      },
+    );
+  };
 
   const persistBettingSourceEpoch = async (epoch: number): Promise<void> => {
     const db = getDatabaseSystem()?.getDb?.();
@@ -383,29 +727,967 @@ export function registerStreamingBettingRoutes(
   const currentRendererHealthSnapshot = (
     cycle: StreamingDuelCycle | null,
     nowMs?: number,
-  ): BettingFeedRendererHealth =>
-    deriveBettingRendererHealth(cycle, {
+  ): BettingFeedRendererHealth => {
+    const localHlsManifest = readLocalHlsManifestSnapshot(process.env);
+    return deriveBettingRendererHealth(cycle, {
       externalStatusSnapshot: externalStatusPoller?.getSnapshot() ?? null,
       externalStatusMaxAgeMs,
       nowMs,
+      localHlsManifest,
       captureStats: getStreamCaptureStats?.() ?? undefined,
     });
+  };
+
+  const currentRendererMetricsSnapshot =
+    (): BettingFeedRendererMetrics | null => {
+      const metrics = externalStatusPoller?.getSnapshot()?.metrics;
+      const hlsManifest =
+        externalStatusPoller?.getSnapshot()?.hlsManifest ??
+        readLocalHlsManifestSnapshot(process.env);
+      const hasHlsManifest =
+        typeof hlsManifest?.updatedAt === "number" ||
+        typeof hlsManifest?.mediaSequence === "number";
+      if (!metrics && !hasHlsManifest) {
+        return null;
+      }
+      return {
+        captureFps:
+          typeof metrics?.captureFps === "number" ? metrics.captureFps : null,
+        encodeFps:
+          typeof metrics?.encodeFps === "number" ? metrics.encodeFps : null,
+        droppedFrames:
+          typeof metrics?.droppedFrames === "number"
+            ? metrics.droppedFrames
+            : null,
+        renderTick:
+          typeof metrics?.renderTick === "number" ? metrics.renderTick : null,
+        duelStateTick:
+          typeof metrics?.duelStateTick === "number"
+            ? metrics.duelStateTick
+            : null,
+        latestFrameAt:
+          typeof metrics?.latestFrameAt === "number"
+            ? metrics.latestFrameAt
+            : null,
+        latestRenderTickAt:
+          typeof metrics?.latestRenderTickAt === "number"
+            ? metrics.latestRenderTickAt
+            : null,
+        latestDuelStateTickAt:
+          typeof metrics?.latestDuelStateTickAt === "number"
+            ? metrics.latestDuelStateTickAt
+            : null,
+        latestVisualChangeAt:
+          typeof metrics?.latestVisualChangeAt === "number"
+            ? metrics.latestVisualChangeAt
+            : null,
+        visualChangeAgeMs:
+          typeof metrics?.visualChangeAgeMs === "number"
+            ? metrics.visualChangeAgeMs
+            : null,
+        hlsManifest: hasHlsManifest
+          ? {
+              updatedAt:
+                typeof hlsManifest.updatedAt === "number"
+                  ? hlsManifest.updatedAt
+                  : null,
+              mediaSequence:
+                typeof hlsManifest.mediaSequence === "number"
+                  ? hlsManifest.mediaSequence
+                  : null,
+            }
+          : null,
+      };
+    };
+
+  const currentSourceRuntimeSnapshot = (
+    cycle: StreamingDuelCycle | null,
+    nowMs?: number,
+    rendererHealth?: BettingFeedRendererHealth | null,
+  ): StreamSourceRuntime => {
+    const localHlsManifest = readLocalHlsManifestSnapshot(process.env);
+    return deriveStreamSourceRuntime({
+      externalStatusSnapshot: externalStatusPoller?.getSnapshot() ?? null,
+      externalStatusMaxAgeMs,
+      rendererHealth:
+        rendererHealth ?? currentRendererHealthSnapshot(cycle, nowMs),
+      localHlsManifest,
+      captureStats: getStreamCaptureStats?.() ?? undefined,
+      nowMs,
+      requireExternalWorker: REQUIRE_EXTERNAL_SOURCE_RUNTIME,
+    });
+  };
+
+  const resolveSnapshotUpdatedAt = (
+    value: number | null | undefined,
+    fallbackUpdatedAt: number,
+  ): number => {
+    return typeof value === "number" && Number.isFinite(value)
+      ? value
+      : fallbackUpdatedAt;
+  };
+
+  const isSnapshotFresh = (
+    updatedAt: number | null | undefined,
+    nowMs: number,
+  ): boolean => {
+    return (
+      typeof updatedAt === "number" &&
+      Number.isFinite(updatedAt) &&
+      Math.max(0, nowMs - updatedAt) <= externalStatusMaxAgeMs
+    );
+  };
+
+  const resolveManifestStatusFromUpdatedAt = (
+    updatedAt: number | null | undefined,
+    nowMs: number,
+  ): StreamManifestStatus => {
+    if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) {
+      return "missing";
+    }
+    return isSnapshotFresh(updatedAt, nowMs) ? "ok" : "stale";
+  };
+
+  const resolveExternalDeliveryReason = (params: {
+    nowMs: number;
+    externalSnapshot: ExternalRtmpStatusSnapshot | null;
+    destination: ExternalRtmpDestination | null;
+    playbackUrl: string | null;
+  }): string | null => {
+    const probeSnapshot = externalPlaybackProbePoller?.getSnapshot() ?? null;
+
+    if (!params.playbackUrl) {
+      return "playback_unconfigured";
+    }
+    if (!params.externalSnapshot) {
+      return "delivery_status_unavailable";
+    }
+
+    const snapshotUpdatedAt = resolveSnapshotUpdatedAt(
+      params.externalSnapshot.updatedAt,
+      params.nowMs,
+    );
+    if (!isSnapshotFresh(snapshotUpdatedAt, params.nowMs)) {
+      return "delivery_status_stale";
+    }
+    if (
+      params.externalSnapshot.active !== true ||
+      params.externalSnapshot.ffmpegRunning !== true
+    ) {
+      return "delivery_pipeline_inactive";
+    }
+    if (!params.destination) {
+      return "delivery_destination_missing";
+    }
+    if (probeSnapshot?.ready === true) {
+      return null;
+    }
+    if (params.destination.connected !== true) {
+      return "delivery_disconnected";
+    }
+    if (
+      params.externalSnapshot.stats?.healthy === false ||
+      (typeof params.destination.error === "string" &&
+        params.destination.error.trim().length > 0)
+    ) {
+      return "delivery_unhealthy";
+    }
+    if (!probeSnapshot) {
+      return "delivery_status_unavailable";
+    }
+    if (probeSnapshot.ready) {
+      return null;
+    }
+    if (probeSnapshot.manifestStatus === "missing") {
+      return "manifest_not_ready";
+    }
+    if (probeSnapshot.manifestStatus === "stale") {
+      return "manifest_stale";
+    }
+    return "delivery_unhealthy";
+  };
+
+  const findCanonicalExternalDestination = (
+    externalSnapshot: ExternalRtmpStatusSnapshot | null,
+  ): ExternalRtmpDestination | null => {
+    if (!externalSnapshot) {
+      return null;
+    }
+
+    const destinations = Array.isArray(externalSnapshot.destinations)
+      ? externalSnapshot.destinations
+      : [];
+    return (
+      destinations.find((destination) => destination.role === "canonical") ??
+      destinations.find(
+        (destination) => destination.id === configuredCanonicalDestinationId,
+      ) ??
+      destinations.find(
+        (destination) =>
+          normalizeStreamDestinationProvider(
+            destination.provider ?? null,
+            destination.name ?? null,
+          ) === configuredCanonicalProvider,
+      ) ??
+      destinations.find((destination) =>
+        (destination.name ?? "")
+          .trim()
+          .toLowerCase()
+          .includes("external delivery"),
+      ) ??
+      null
+    );
+  };
+
+  const buildSelfHostedDestination = (params: {
+    role: "canonical" | "fallback";
+    nowMs: number;
+  }): StreamDestinationState => {
+    const localManifest =
+      externalStatusPoller?.getSnapshot()?.hlsManifest ??
+      readLocalHlsManifestSnapshot(process.env);
+    const manifestUpdatedAt =
+      typeof localManifest?.updatedAt === "number" &&
+      Number.isFinite(localManifest.updatedAt)
+        ? localManifest.updatedAt
+        : null;
+    const manifestStatus = resolveManifestStatusFromUpdatedAt(
+      manifestUpdatedAt,
+      params.nowMs,
+    );
+    const playbackReady = manifestStatus === "ok";
+
+    return {
+      id: buildStreamDestinationId({
+        role: params.role,
+        provider: "self_hls",
+        name: "Self-HLS",
+      }),
+      name: "Self-HLS",
+      role: params.role,
+      provider: "self_hls",
+      transport: "hls",
+      playbackUrl: configuredSelfHostedPlaybackUrl,
+      ingestUrl: null,
+      connected: playbackReady,
+      transportHealthy: playbackReady,
+      playbackReady,
+      manifestStatus,
+      lastError: playbackReady
+        ? null
+        : manifestStatus === "stale"
+          ? "manifest_stale"
+          : "manifest_not_ready",
+      updatedAt: manifestUpdatedAt,
+    };
+  };
+
+  const buildExternalDeliveryCandidate = (params: {
+    role: "canonical" | "fallback";
+    nowMs: number;
+    sourceRuntime: StreamSourceRuntime;
+  }): CanonicalCandidateState | null => {
+    if (
+      !configuredExternalPlaybackUrl &&
+      configuredDelivery.mode !== "external_hls"
+    ) {
+      return null;
+    }
+    const externalSnapshot = externalStatusPoller?.getSnapshot() ?? null;
+    const externalDestination =
+      findCanonicalExternalDestination(externalSnapshot);
+    const probeSnapshot = externalPlaybackProbePoller?.getSnapshot() ?? null;
+    const playbackUrl =
+      externalDestination?.playbackUrl ??
+      configuredDelivery.playbackUrl ??
+      configuredDelivery.llhlsUrl ??
+      configuredDelivery.hlsUrl ??
+      null;
+    const ingestUrl =
+      externalDestination?.ingestUrl ?? configuredDelivery.ingestUrl ?? null;
+    const snapshotUpdatedAt = externalSnapshot
+      ? resolveSnapshotUpdatedAt(externalSnapshot.updatedAt, params.nowMs)
+      : params.nowMs;
+    const probeReady = probeSnapshot?.ready === true;
+    const destinationConnected =
+      externalDestination?.connected === true || probeReady;
+    const destinationError =
+      typeof externalDestination?.error === "string"
+        ? externalDestination.error.trim()
+        : null;
+    const updatedAt = resolveSnapshotUpdatedAt(
+      probeSnapshot?.updatedAt ??
+        externalDestination?.startedAt ??
+        externalSnapshot?.updatedAt,
+      params.nowMs,
+    );
+    const lastFatalWriteAt =
+      typeof externalSnapshot?.captureDiagnostics?.lastFatalWriteError?.at ===
+        "number" &&
+      Number.isFinite(
+        externalSnapshot.captureDiagnostics.lastFatalWriteError.at,
+      )
+        ? externalSnapshot.captureDiagnostics.lastFatalWriteError.at
+        : null;
+    const freshestSourceIncidentAt = Math.max(
+      lastFatalWriteAt ?? Number.NEGATIVE_INFINITY,
+      params.sourceRuntime.workerHeartbeatAt ?? Number.NEGATIVE_INFINITY,
+    );
+    const contradictorySourceError =
+      probeReady &&
+      params.sourceRuntime.ready !== true &&
+      (!Number.isFinite(freshestSourceIncidentAt) ||
+        freshestSourceIncidentAt >= updatedAt);
+    const transportHealthy =
+      params.sourceRuntime.ready === true &&
+      externalSnapshot != null &&
+      isSnapshotFresh(snapshotUpdatedAt, params.nowMs) &&
+      externalSnapshot.active === true &&
+      externalSnapshot.ffmpegRunning === true &&
+      externalSnapshot.stats?.healthy !== false &&
+      destinationConnected &&
+      probeReady &&
+      !contradictorySourceError;
+    const reason = resolveExternalDeliveryReason({
+      nowMs: params.nowMs,
+      externalSnapshot,
+      destination: externalDestination,
+      playbackUrl,
+    });
+
+    const publicReadiness: StreamPublicReadiness = {
+      ready: reason == null,
+      reason,
+      updatedAt,
+    };
+
+    return {
+      provider: "cloudflare_stream",
+      destination: {
+        id: buildStreamDestinationId({
+          role: params.role,
+          provider: "cloudflare_stream",
+          name: externalDestination?.name ?? "Cloudflare Stream",
+        }),
+        name: externalDestination?.name ?? "Cloudflare Stream",
+        role: params.role,
+        provider: externalDestination
+          ? normalizeStreamDestinationProvider(
+              externalDestination.provider ?? configuredDelivery.provider,
+              externalDestination.name ?? "External Delivery",
+            )
+          : configuredCanonicalProvider,
+        transport:
+          externalDestination?.transport ??
+          inferStreamDeliveryTransport({
+            playbackUrl,
+            ingestUrl,
+          }),
+        playbackUrl,
+        ingestUrl,
+        connected: destinationConnected,
+        transportHealthy,
+        playbackReady: probeReady,
+        manifestStatus:
+          probeSnapshot?.manifestStatus ??
+          (playbackUrl ? "unknown" : "missing"),
+        lastError: probeReady
+          ? contradictorySourceError
+            ? (params.sourceRuntime.degradedReason ??
+              destinationError ??
+              reason)
+            : null
+          : (destinationError ?? probeSnapshot?.lastError ?? reason),
+        updatedAt,
+      },
+      publicReadiness,
+      ready: publicReadiness.ready === true,
+    };
+  };
+
+  const buildSelfHostedCandidate = (params: {
+    role: "canonical" | "fallback";
+    nowMs: number;
+    sourceRuntime: StreamSourceRuntime;
+  }): CanonicalCandidateState => {
+    const destination = buildSelfHostedDestination({
+      role: params.role,
+      nowMs: params.nowMs,
+    });
+    const publicReadiness =
+      params.sourceRuntime.ready === true
+        ? {
+            ready: destination.playbackReady,
+            reason: destination.lastError,
+            updatedAt: destination.updatedAt,
+          }
+        : {
+            ready: false,
+            reason: params.sourceRuntime.degradedReason,
+            updatedAt:
+              params.sourceRuntime.workerHeartbeatAt ?? destination.updatedAt,
+          };
+
+    return {
+      provider: "self_hls",
+      destination,
+      publicReadiness,
+      ready: publicReadiness.ready === true,
+    };
+  };
+
+  const buildCloudflareLifecyclePollSnapshot = (params: {
+    nowMs: number;
+    externalSnapshot: ExternalRtmpStatusSnapshot | null;
+    destination: ExternalRtmpDestination | null;
+    playbackUrl: string | null;
+  }): PersistedCloudflareLifecyclePollState | null => {
+    const persistedAuthority = getPersistedAuthorityState();
+    const snapshotUpdatedAt = params.externalSnapshot
+      ? resolveSnapshotUpdatedAt(
+          params.externalSnapshot.updatedAt,
+          params.nowMs,
+        )
+      : null;
+    const probeSnapshot = externalPlaybackProbePoller?.getSnapshot() ?? null;
+    const probeUpdatedAt =
+      probeSnapshot != null
+        ? resolveSnapshotUpdatedAt(probeSnapshot.updatedAt, params.nowMs)
+        : null;
+    const playbackProbeFresh =
+      probeUpdatedAt != null && isSnapshotFresh(probeUpdatedAt, params.nowMs);
+    const localIngestHealthy =
+      params.externalSnapshot != null &&
+      snapshotUpdatedAt != null &&
+      isSnapshotFresh(snapshotUpdatedAt, params.nowMs) &&
+      params.externalSnapshot.active === true &&
+      params.externalSnapshot.ffmpegRunning === true &&
+      params.externalSnapshot.stats?.healthy !== false;
+    const providerLive = playbackProbeFresh && probeSnapshot?.ready === true;
+    let status: PersistedCloudflareLifecyclePollState["status"] = "unknown";
+    if (providerLive) {
+      status = "connected";
+    } else if (playbackProbeFresh && probeSnapshot?.ready === false) {
+      status = "disconnected";
+    } else if (
+      params.externalSnapshot?.stats?.healthy === false ||
+      (typeof params.destination?.error === "string" &&
+        params.destination.error.trim().length > 0)
+    ) {
+      status = "errored";
+    } else if (params.destination?.connected === false) {
+      status = "disconnected";
+    } else if (localIngestHealthy) {
+      status = "unknown";
+    }
+    const receivedAt = Math.max(snapshotUpdatedAt ?? 0, probeUpdatedAt ?? 0, 0);
+    const normalizedReceivedAt = receivedAt > 0 ? receivedAt : params.nowMs;
+    const liveInputId =
+      cloudflareLiveInputId ??
+      persistedAuthority.cloudflareLifecycle?.liveInputId ??
+      persistedAuthority.cloudflareLastWebhook?.liveInputId ??
+      null;
+    const videoUid =
+      persistedAuthority.cloudflareLifecycle?.videoId ??
+      persistedAuthority.cloudflareLastWebhook?.videoId ??
+      null;
+
+    if (!liveInputId && !params.playbackUrl) {
+      return null;
+    }
+
+    return {
+      liveInputId,
+      videoUid,
+      status,
+      providerLive,
+      statusSummary:
+        status === "connected"
+          ? "connected"
+          : playbackProbeFresh && probeSnapshot?.ready === false
+            ? (probeSnapshot.lastError ?? probeSnapshot.manifestStatus)
+            : typeof params.destination?.error === "string" &&
+                params.destination.error.trim().length > 0
+              ? params.destination.error.trim()
+              : params.externalSnapshot == null
+                ? "delivery_status_unavailable"
+                : !isSnapshotFresh(normalizedReceivedAt, params.nowMs)
+                  ? "delivery_status_stale"
+                  : status,
+      playbackUrl: params.playbackUrl,
+      occurredAt: normalizedReceivedAt,
+      receivedAt: normalizedReceivedAt,
+    };
+  };
+
+  const currentCanonicalAuthoritySnapshot = (params: {
+    nowMs: number;
+    sourceRuntime: StreamSourceRuntime;
+    externalSnapshot: ExternalRtmpStatusSnapshot | null;
+    destination: ExternalRtmpDestination | null;
+    playbackUrl: string | null;
+  }): PersistedCloudflareReconciliationState | null => {
+    const lifecyclePollSnapshot = buildCloudflareLifecyclePollSnapshot(params);
+    const probeSnapshot = externalPlaybackProbePoller?.getSnapshot() ?? null;
+    const playbackProbeSnapshot: PersistedCloudflarePlaybackProbeState | null =
+      probeSnapshot
+        ? {
+            playbackUrl: probeSnapshot.playbackUrl,
+            ready: probeSnapshot.ready,
+            manifestStatus: probeSnapshot.manifestStatus,
+            statusCode: probeSnapshot.statusCode,
+            lastError: probeSnapshot.lastError,
+            updatedAt: probeSnapshot.updatedAt,
+          }
+        : null;
+
+    persistCloudflareLifecyclePollSnapshot(lifecyclePollSnapshot);
+    persistCloudflarePlaybackProbeSnapshot(playbackProbeSnapshot);
+
+    const persistedAuthority = getPersistedAuthorityState();
+    if (
+      lifecyclePollSnapshot == null &&
+      playbackProbeSnapshot == null &&
+      persistedAuthority.cloudflareLifecycle == null &&
+      persistedAuthority.cloudflareLifecyclePoll == null &&
+      persistedAuthority.cloudflarePlaybackProbe == null
+    ) {
+      return null;
+    }
+
+    const reconciliation = reconcileCloudflareAuthority({
+      sourceRuntimeReady: params.sourceRuntime.ready === true,
+      lifecycle: persistedAuthority.cloudflareLifecycle,
+      lifecyclePoll:
+        lifecyclePollSnapshot ?? persistedAuthority.cloudflareLifecyclePoll,
+      playbackProbe:
+        playbackProbeSnapshot ?? persistedAuthority.cloudflarePlaybackProbe,
+      previous: persistedAuthority.cloudflareReconciliation,
+      nowMs: params.nowMs,
+      freshnessMs: externalStatusMaxAgeMs,
+      playbackUrl: params.playbackUrl,
+    });
+    persistCloudflareReconciliationSnapshot(reconciliation);
+    return reconciliation;
+  };
+
+  const selectCanonicalCandidate = (params: {
+    nowMs: number;
+    candidates: CanonicalCandidateState[];
+  }): {
+    canonical: CanonicalCandidateState;
+    fallback: CanonicalCandidateState | null;
+  } => {
+    if (params.candidates.length === 0) {
+      const provider: StreamCanonicalProvider =
+        configuredCanonicalProvider === "self_hls"
+          ? "self_hls"
+          : "cloudflare_stream";
+      return {
+        canonical: {
+          provider,
+          destination: {
+            id: buildStreamDestinationId({
+              role: "canonical",
+              provider,
+              name: provider === "self_hls" ? "Self-HLS" : "Cloudflare Stream",
+            }),
+            name: provider === "self_hls" ? "Self-HLS" : "Cloudflare Stream",
+            role: "canonical",
+            provider,
+            transport: inferStreamDeliveryTransport({
+              playbackUrl: null,
+              ingestUrl: null,
+            }),
+            playbackUrl: null,
+            ingestUrl: null,
+            connected: false,
+            transportHealthy: false,
+            playbackReady: false,
+            manifestStatus: "missing",
+            lastError: "no_delivery_candidate",
+            updatedAt: params.nowMs,
+          },
+          publicReadiness: {
+            ready: false,
+            reason: "no_delivery_candidate",
+            updatedAt: params.nowMs,
+          },
+          ready: false,
+        },
+        fallback: null,
+      };
+    }
+
+    const candidatesByProvider = new Map(
+      params.candidates.map((candidate) => [candidate.provider, candidate]),
+    );
+    const priority = configuredProviderPriority.filter((provider) =>
+      candidatesByProvider.has(provider),
+    );
+    const primaryProvider = priority[0] ?? null;
+    const primaryCandidate =
+      primaryProvider != null
+        ? (candidatesByProvider.get(primaryProvider) ?? null)
+        : null;
+    const activeCandidate =
+      canonicalProviderSelectionState.activeProvider != null
+        ? (candidatesByProvider.get(
+            canonicalProviderSelectionState.activeProvider,
+          ) ?? null)
+        : null;
+    const firstReadyCandidate =
+      priority
+        .map((provider) => candidatesByProvider.get(provider) ?? null)
+        .find((candidate) => candidate?.ready === true) ?? null;
+
+    if (!automaticFailoverEnabled()) {
+      const cloudflareCandidate =
+        candidatesByProvider.get("cloudflare_stream") ?? null;
+      const nextCanonical =
+        cloudflareCandidate ?? primaryCandidate ?? params.candidates[0];
+      canonicalProviderSelectionState.activeProvider = nextCanonical.provider;
+      canonicalProviderSelectionState.primaryHealthySince =
+        nextCanonical.provider === primaryProvider &&
+        nextCanonical.ready === true
+          ? params.nowMs
+          : null;
+      persistCanonicalProviderSelection();
+
+      const fallback =
+        priority
+          .map((provider) => candidatesByProvider.get(provider) ?? null)
+          .find(
+            (candidate) =>
+              candidate && candidate.provider !== nextCanonical.provider,
+          ) ?? null;
+
+      return {
+        canonical: nextCanonical,
+        fallback,
+      };
+    }
+
+    let nextCanonical =
+      activeCandidate ??
+      firstReadyCandidate ??
+      primaryCandidate ??
+      params.candidates[0];
+
+    if (primaryCandidate?.ready === true) {
+      canonicalProviderSelectionState.primaryHealthySince ??= params.nowMs;
+    } else {
+      canonicalProviderSelectionState.primaryHealthySince = null;
+    }
+
+    if (nextCanonical.provider === primaryProvider) {
+      if (nextCanonical.ready !== true && firstReadyCandidate) {
+        nextCanonical = firstReadyCandidate;
+      }
+    } else {
+      const primaryHealthyForMs =
+        canonicalProviderSelectionState.primaryHealthySince == null
+          ? 0
+          : Math.max(
+              0,
+              params.nowMs -
+                canonicalProviderSelectionState.primaryHealthySince,
+            );
+      if (
+        primaryCandidate?.ready === true &&
+        primaryHealthyForMs >= configuredFailbackSoakMs
+      ) {
+        nextCanonical = primaryCandidate;
+      } else if (nextCanonical.ready !== true && firstReadyCandidate) {
+        nextCanonical = firstReadyCandidate;
+      }
+    }
+
+    canonicalProviderSelectionState.activeProvider = nextCanonical.provider;
+    persistCanonicalProviderSelection();
+
+    const fallback =
+      priority
+        .map((provider) => candidatesByProvider.get(provider) ?? null)
+        .find(
+          (candidate) =>
+            candidate && candidate.provider !== nextCanonical.provider,
+        ) ?? null;
+
+    return {
+      canonical: nextCanonical,
+      fallback,
+    };
+  };
+
+  const buildMirrorDestinations = (params: {
+    nowMs: number;
+    canonicalDestinationId: string | null;
+  }): StreamDestinationState[] => {
+    const externalSnapshot = externalStatusPoller?.getSnapshot() ?? null;
+    if (!externalSnapshot) {
+      return [];
+    }
+
+    const snapshotUpdatedAt = resolveSnapshotUpdatedAt(
+      externalSnapshot.updatedAt,
+      params.nowMs,
+    );
+    const snapshotFresh = isSnapshotFresh(snapshotUpdatedAt, params.nowMs);
+    const baseTransportHealthy =
+      snapshotFresh &&
+      externalSnapshot.active === true &&
+      externalSnapshot.ffmpegRunning === true &&
+      externalSnapshot.stats?.healthy !== false;
+    const seen = new Set<string>();
+
+    return externalSnapshot.destinations.flatMap((destination) => {
+      const provider = normalizeStreamDestinationProvider(
+        destination.provider ?? null,
+        destination.name ?? null,
+      );
+      if (
+        destination.id === params.canonicalDestinationId ||
+        destination.role === "canonical" ||
+        (params.canonicalDestinationId != null &&
+          provider === configuredCanonicalProvider &&
+          ((destination.name ?? "")
+            .trim()
+            .toLowerCase()
+            .includes("external delivery") ||
+            destination.id == null))
+      ) {
+        return [];
+      }
+      if (destination.role === "fallback" || provider === "self_hls") {
+        return [];
+      }
+
+      const id =
+        destination.id ??
+        buildStreamDestinationId({
+          role: "mirror",
+          provider,
+          name: destination.name ?? provider,
+        });
+      if (seen.has(id)) {
+        return [];
+      }
+      seen.add(id);
+
+      const transportHealthy =
+        baseTransportHealthy &&
+        destination.connected === true &&
+        !(
+          typeof destination.error === "string" &&
+          destination.error.trim().length > 0
+        );
+      return [
+        {
+          id,
+          name: destination.name ?? provider,
+          role: "mirror",
+          provider,
+          transport:
+            destination.transport ??
+            inferStreamDeliveryTransport({
+              playbackUrl: destination.playbackUrl ?? null,
+              ingestUrl: destination.ingestUrl ?? destination.url ?? null,
+            }),
+          playbackUrl: destination.playbackUrl ?? null,
+          ingestUrl: destination.ingestUrl ?? destination.url ?? null,
+          connected: destination.connected === true,
+          transportHealthy,
+          playbackReady: transportHealthy,
+          manifestStatus: "unknown",
+          lastError:
+            typeof destination.error === "string" &&
+            destination.error.trim().length > 0
+              ? destination.error.trim()
+              : snapshotFresh
+                ? null
+                : "delivery_status_stale",
+          updatedAt: resolveSnapshotUpdatedAt(
+            destination.startedAt ?? externalSnapshot.updatedAt,
+            params.nowMs,
+          ),
+        } satisfies StreamDestinationState,
+      ];
+    });
+  };
+
+  const currentChannelSnapshot = (
+    cycle: StreamingDuelCycle | null,
+    nowMs?: number,
+    sourceRuntime?: StreamSourceRuntime,
+  ): CurrentChannelSnapshot => {
+    const updatedAt = nowMs ?? Date.now();
+    const resolvedSourceRuntime =
+      sourceRuntime ?? currentSourceRuntimeSnapshot(cycle, updatedAt);
+    const externalSnapshot = externalStatusPoller?.getSnapshot() ?? null;
+    const externalDestination =
+      findCanonicalExternalDestination(externalSnapshot);
+    const candidatePool: CanonicalCandidateState[] = [];
+    const selfHostedPublicCandidateEnabled =
+      configuredDelivery.mode !== "external_hls" ||
+      process.env.STREAM_PUBLIC_SELF_HLS_FALLBACK_ENABLED === "true";
+    if (selfHostedPublicCandidateEnabled) {
+      candidatePool.push(
+        buildSelfHostedCandidate({
+          role: "canonical",
+          nowMs: updatedAt,
+          sourceRuntime: resolvedSourceRuntime,
+        }),
+      );
+    }
+    const externalCandidate = buildExternalDeliveryCandidate({
+      role: "canonical",
+      nowMs: updatedAt,
+      sourceRuntime: resolvedSourceRuntime,
+    });
+    if (externalCandidate) {
+      candidatePool.push(externalCandidate);
+    }
+    const { canonical, fallback } = selectCanonicalCandidate({
+      nowMs: updatedAt,
+      candidates: candidatePool,
+    });
+    const canonicalAuthority =
+      canonical.provider === "cloudflare_stream"
+        ? currentCanonicalAuthoritySnapshot({
+            nowMs: updatedAt,
+            sourceRuntime: resolvedSourceRuntime,
+            externalSnapshot,
+            destination: externalDestination,
+            playbackUrl:
+              externalCandidate?.destination.playbackUrl ??
+              configuredExternalPlaybackUrl,
+          })
+        : null;
+    const canonicalDestination = canonical.destination;
+    const fallbackDestination =
+      fallback == null
+        ? null
+        : fallback.provider === "self_hls"
+          ? buildSelfHostedDestination({
+              role: "fallback",
+              nowMs: updatedAt,
+            })
+          : (buildExternalDeliveryCandidate({
+              role: "fallback",
+              nowMs: updatedAt,
+              sourceRuntime: resolvedSourceRuntime,
+            })?.destination ?? {
+              ...fallback.destination,
+              id: buildStreamDestinationId({
+                role: "fallback",
+                provider: "cloudflare_stream",
+                name: "Cloudflare Stream",
+              }),
+              role: "fallback",
+            });
+    const mirrors = buildMirrorDestinations({
+      nowMs: updatedAt,
+      canonicalDestinationId: canonicalDestination.id,
+    });
+    const publicReadiness =
+      canonicalAuthority == null
+        ? canonical.publicReadiness
+        : {
+            ready: canonicalAuthority.decision === "ready",
+            reason: canonicalAuthority.reason,
+            updatedAt: canonicalAuthority.updatedAt,
+          };
+
+    return {
+      channel: {
+        id: "hyperscapes-broadcast-channel",
+        mode: "always_on",
+        presentationDelayMs: configuredPresentationDelayMs,
+        activeDuelId: cycle?.duelId ?? null,
+        activeDuelKey: null,
+        canonicalDestinationId: canonicalDestination.id,
+        fallbackDestinationId: fallbackDestination?.id ?? null,
+        publicPlaybackUrl: canonicalDestination.playbackUrl,
+        publicReadiness,
+        destinations: [
+          canonicalDestination,
+          ...(fallbackDestination ? [fallbackDestination] : []),
+          ...mirrors,
+        ],
+      },
+      canonicalAuthority,
+    };
+  };
+
+  const buildSerializedBettingFrame = (params: {
+    seq: number;
+    emittedAt: number;
+    cycle: StreamingDuelCycle | null;
+  }): BettingFeedFrame => {
+    const rendererHealth = currentRendererHealthSnapshot(
+      params.cycle,
+      params.emittedAt,
+    );
+    const sourceRuntime = currentSourceRuntimeSnapshot(
+      params.cycle,
+      params.emittedAt,
+      rendererHealth,
+    );
+    const channelSnapshot = currentChannelSnapshot(
+      params.cycle,
+      params.emittedAt,
+      sourceRuntime,
+    );
+    const payload = buildBettingFeedPayload({
+      sourceEpoch: bettingSourceEpoch,
+      seq: params.seq,
+      emittedAt: params.emittedAt,
+      cycle: params.cycle,
+      rendererHealth,
+      channel: channelSnapshot.channel,
+      canonicalAuthority: channelSnapshot.canonicalAuthority,
+      sourceRuntime,
+      rendererMetrics: currentRendererMetricsSnapshot(),
+    });
+    const payloadJson = JSON.stringify(payload);
+
+    return {
+      seq: params.seq,
+      emittedAt: payload.emittedAt,
+      payload,
+      payloadJson,
+      payloadBytes: Buffer.byteLength(payloadJson, "utf8"),
+    };
+  };
+
+  const buildCurrentBettingFrame = (params: {
+    seq: number;
+    emittedAt?: number;
+  }): BettingFeedFrame | null => {
+    const scheduler = getScheduler();
+    if (!scheduler) {
+      return null;
+    }
+    return buildSerializedBettingFrame({
+      seq: params.seq,
+      emittedAt: params.emittedAt ?? Date.now(),
+      cycle: scheduler.getCurrentCycle() ?? null,
+    });
+  };
 
   const captureBettingFrame = (
     forceNewFrame = false,
   ): BettingFeedFrame | null => {
-    const scheduler = getScheduler();
-    const cycle = scheduler?.getCurrentCycle() ?? null;
     const nextSeq = bettingSequence + 1;
-    const emittedAt = Date.now();
-    const rendererHealth = currentRendererHealthSnapshot(cycle, emittedAt);
-    const payload = buildBettingFeedPayload({
-      sourceEpoch: bettingSourceEpoch,
+    const frame = buildCurrentBettingFrame({
       seq: nextSeq,
-      emittedAt,
-      cycle,
-      rendererHealth,
+      emittedAt: Date.now(),
     });
+    if (!frame) {
+      return null;
+    }
+    const payload = frame.payload;
     const dedupKey = buildBettingFeedDedupKey(payload);
 
     if (
@@ -418,15 +1700,6 @@ export function registerStreamingBettingRoutes(
 
     lastSerializedBettingState = dedupKey;
     bettingSequence = nextSeq;
-    const payloadJson = JSON.stringify(payload);
-
-    const frame: BettingFeedFrame = {
-      seq: nextSeq,
-      emittedAt: payload.emittedAt,
-      payload,
-      payloadJson,
-      payloadBytes: Buffer.byteLength(payloadJson, "utf8"),
-    };
 
     bettingReplayFrames.push(frame);
     bettingReplayFramesTotalBytes += frame.payloadBytes;
@@ -511,21 +1784,39 @@ export function registerStreamingBettingRoutes(
   };
 
   const buildBettingBootstrapResponse = (frame: BettingFeedFrame | null) => {
+    const currentFrame =
+      frame ??
+      buildCurrentBettingFrame({
+        seq: Math.max(1, bettingSequence),
+        emittedAt: Date.now(),
+      });
     const fallbackEmittedAt = Date.now();
+    const fallbackRendererHealth = currentRendererHealthSnapshot(
+      null,
+      fallbackEmittedAt,
+    );
+    const fallbackSourceRuntime = currentSourceRuntimeSnapshot(
+      null,
+      fallbackEmittedAt,
+      fallbackRendererHealth,
+    );
     const fallbackPayload = buildBettingFeedPayload({
       sourceEpoch: bettingSourceEpoch,
       seq: bettingSequence,
       emittedAt: fallbackEmittedAt,
       cycle: null,
-      rendererHealth: currentRendererHealthSnapshot(null, fallbackEmittedAt),
+      rendererHealth: fallbackRendererHealth,
+      ...currentChannelSnapshot(null, fallbackEmittedAt, fallbackSourceRuntime),
+      sourceRuntime: fallbackSourceRuntime,
+      rendererMetrics: currentRendererMetricsSnapshot(),
     });
 
     return {
-      ...(frame?.payload ?? fallbackPayload),
+      ...(currentFrame?.payload ?? fallbackPayload),
       schemaVersion: BETTING_FEED_SCHEMA_VERSION,
       sourceEpoch: bettingSourceEpoch,
-      seq: frame?.seq ?? bettingSequence,
-      emittedAt: frame?.emittedAt ?? fallbackEmittedAt,
+      seq: currentFrame?.seq ?? bettingSequence,
+      emittedAt: currentFrame?.emittedAt ?? fallbackEmittedAt,
       replay: {
         sourceEpoch: bettingSourceEpoch,
         latestSeq:
@@ -555,11 +1846,14 @@ export function registerStreamingBettingRoutes(
       return;
     }
   };
-
   const handleBettingBootstrap = async (
-    _request: FastifyRequest,
+    request: FastifyRequest,
     reply: FastifyReply,
   ) => {
+    if (reply.sent || reply.raw.writableEnded || reply.raw.destroyed) {
+      return;
+    }
+
     const scheduler = getScheduler();
     if (!scheduler) {
       return reply.status(503).send({
@@ -568,22 +1862,54 @@ export function registerStreamingBettingRoutes(
       });
     }
 
+    await ensureCanonicalProviderSelectionHydrated();
     await ensureBettingSourceEpoch();
-    if (bettingReplayFrames.length === 0) {
+    await externalStatusPoller?.refresh();
+    await externalPlaybackProbePoller?.refresh();
+    const latestFrame =
+      captureBettingFrame(false) ??
+      buildCurrentBettingFrame({
+        seq: Math.max(1, bettingSequence),
+        emittedAt: Date.now(),
+      }) ??
+      bettingReplayFrames[bettingReplayFrames.length - 1] ??
       captureBettingFrame(true);
+
+    if (!latestFrame) {
+      request.log.warn(
+        {
+          bettingSourceEpoch,
+          replayFrames: bettingReplayFrames.length,
+          bettingSequence,
+        },
+        "null_bootstrap_frame",
+      );
+    } else if (
+      latestFrame.payload.cycle == null &&
+      bettingReplayFrames.length === 0
+    ) {
+      request.log.warn(
+        {
+          bettingSourceEpoch,
+          replayFrames: bettingReplayFrames.length,
+          bettingSequence,
+          phase: latestFrame.payload.phase,
+        },
+        "null_bootstrap_frame",
+      );
     }
 
-    return reply.send(
-      buildBettingBootstrapResponse(
-        bettingReplayFrames[bettingReplayFrames.length - 1] ?? null,
-      ),
-    );
+    return reply.send(buildBettingBootstrapResponse(latestFrame ?? null));
   };
 
   const handleBettingEvents = async (
     request: FastifyRequest<{ Querystring: { since?: string } }>,
     reply: FastifyReply,
   ) => {
+    if (reply.sent || reply.raw.writableEnded || reply.raw.destroyed) {
+      return;
+    }
+
     const scheduler = getScheduler();
     if (!scheduler) {
       return reply.status(503).send({
@@ -592,7 +1918,11 @@ export function registerStreamingBettingRoutes(
       });
     }
 
+    await ensureCanonicalProviderSelectionHydrated();
     await ensureBettingSourceEpoch();
+    await externalStatusPoller?.refresh();
+    await externalPlaybackProbePoller?.refresh();
+    captureBettingFrame(false);
     if (bettingReplayFrames.length === 0) {
       captureBettingFrame(true);
     }
@@ -675,6 +2005,78 @@ export function registerStreamingBettingRoutes(
     startBettingLoopsIfNeeded();
   };
 
+  const handleCloudflareWebhook = async (
+    request: FastifyRequest<{ Body: Record<string, unknown> }>,
+    reply: FastifyReply,
+  ) => {
+    const receivedAt = Date.now();
+    const summary = summarizeCloudflareLiveWebhook({
+      payload: request.body,
+      receivedAt,
+    });
+    if (!summary.webhook.liveInputId) {
+      return reply.status(400).send({
+        error: "Bad Request",
+        message: "Cloudflare webhook payload is missing a live input id",
+      });
+    }
+    if (
+      cloudflareLiveInputId &&
+      summary.webhook.liveInputId !== cloudflareLiveInputId
+    ) {
+      return reply.status(202).send({
+        ok: true,
+        ignored: true,
+        eventType: summary.webhook.eventType,
+        liveInputId: summary.webhook.liveInputId,
+        receivedAt,
+      });
+    }
+
+    try {
+      const authorityState = getPersistedAuthorityState();
+      authorityState.cloudflareLastWebhook = summary.webhook;
+      authorityState.cloudflareLifecycle = summary.lifecycle;
+      await Promise.all([
+        persistCloudflareWebhookState(getStorageDb(), summary.webhook),
+        persistCloudflareLifecycleState(getStorageDb(), summary.lifecycle),
+      ]);
+    } catch {
+      // Best-effort durability only.
+    }
+
+    return reply.status(202).send({
+      ok: true,
+      eventType: summary.webhook.eventType,
+      liveInputId: summary.webhook.liveInputId,
+      receivedAt,
+    });
+  };
+
+  const authorizeCloudflareWebhook = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const webhookSecret =
+      process.env.STREAM_CLOUDFLARE_WEBHOOK_SECRET?.trim() || null;
+    if (!webhookSecret) {
+      return reply.status(503).send({
+        error: "Cloudflare webhook secret not configured",
+        message:
+          "Set STREAM_CLOUDFLARE_WEBHOOK_SECRET before enabling the webhook route",
+      });
+    }
+
+    if (verifyCloudflareWebhookSecret(request.headers, webhookSecret)) {
+      return;
+    }
+
+    return reply.status(401).send({
+      error: "Unauthorized",
+      message: "Missing or invalid Cloudflare webhook secret",
+    });
+  };
+
   // Legacy compatibility alias. Canonical internal betting bootstrap route:
   // /api/internal/bet-sync/state
   fastify.get(
@@ -719,6 +2121,33 @@ export function registerStreamingBettingRoutes(
       preHandler: bettingEventsAuthPreHandler,
     },
     handleBettingEvents,
+  );
+
+  // Cloudflare webhook bodies are small JSON events (live-input lifecycle +
+  // recording metadata). Cap at 32 KiB and require an object-shaped body.
+  // We keep `additionalProperties: true` because Cloudflare evolves the
+  // webhook schema on their side and a closed allowlist would break on
+  // format updates. Defense-in-depth against injection already happens at:
+  //   1. timingSafeEqual shared-secret verification (authorizeCloudflareWebhook)
+  //   2. bodyLimit (here)
+  //   3. summarizeCloudflareLiveWebhook() — field-by-field allowlist parsing,
+  //      so unknown fields never reach downstream persistence
+  fastify.post<{
+    Body: Record<string, unknown>;
+  }>(
+    "/api/streaming/cloudflare/webhook",
+    {
+      bodyLimit: 32 * 1024,
+      config: { rateLimit: CLOUDFLARE_WEBHOOK_RATE_LIMIT },
+      schema: {
+        body: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      preHandler: authorizeCloudflareWebhook,
+    },
+    handleCloudflareWebhook,
   );
 
   fastify.addHook("onClose", async () => {

--- a/packages/server/src/routes/streaming-external-status.ts
+++ b/packages/server/src/routes/streaming-external-status.ts
@@ -1,10 +1,32 @@
 import fs from "node:fs/promises";
+import type {
+  StreamDeliveryInfo,
+  StreamDeliveryMode,
+  StreamManifestStatus,
+  StreamDeliveryTransport,
+  StreamDestinationProvider,
+  StreamDestinationRole,
+} from "../streaming/delivery-config.js";
+import type {
+  StreamSourceCaptureMode,
+  StreamSourceRuntime,
+} from "../streaming/source-runtime.js";
 
 /** A single RTMP destination entry from the external status file. */
 export interface ExternalRtmpDestination {
+  id?: string;
+  name?: string;
+  role?: StreamDestinationRole;
+  provider?: StreamDestinationProvider;
+  transport?: StreamDeliveryTransport;
+  playbackUrl?: string | null;
+  ingestUrl?: string | null;
   url?: string;
   status?: string;
   connected?: boolean;
+  bytesWritten?: number;
+  startedAt?: number;
+  error?: string;
   /** External encoders may include additional fields. */
   [key: string]: unknown;
 }
@@ -29,16 +51,101 @@ export interface ExternalRendererHealthBlob {
   phase?: string | null;
 }
 
+export interface ExternalRendererMetricsBlob {
+  captureFps?: number | null;
+  encodeFps?: number | null;
+  droppedFrames?: number | null;
+  renderTick?: number | null;
+  duelStateTick?: number | null;
+  latestFrameAt?: number | null;
+  latestRenderTickAt?: number | null;
+  latestDuelStateTickAt?: number | null;
+  latestVisualChangeAt?: number | null;
+  visualChangeAgeMs?: number | null;
+}
+
+export interface ExternalHlsManifestBlob {
+  updatedAt?: number | null;
+  mediaSequence?: number | null;
+}
+
+export interface ExternalRendererSmokeBlob {
+  currentSceneUrl?: string | null;
+  activeBundle?: string | null;
+  deliveryMode?: string | null;
+  captureFpsP50?: number | null;
+  captureFpsP95?: number | null;
+  encodeFpsP50?: number | null;
+  encodeFpsP95?: number | null;
+  updatedAt?: number | null;
+  ingest?: ExternalRendererIngestBlob | null;
+}
+
+export interface ExternalRendererIngestBlob {
+  profile?: string | null;
+  transport?: string | null;
+  audioSampleRate?: number | null;
+  gopFrames?: number | null;
+  targetFps?: number | null;
+  probeOnly?: boolean | null;
+}
+
+export interface ExternalCaptureFrameSampleBlob {
+  at?: number | null;
+  size?: number | null;
+  cdpTimestamp?: number | null;
+}
+
+export interface ExternalCaptureBackpressureTransitionBlob {
+  at?: number | null;
+  backpressured?: boolean | null;
+}
+
+export interface ExternalCaptureFatalWriteBlob {
+  at?: number | null;
+  message?: string | null;
+  frameCount?: number | null;
+  droppedFrames?: number | null;
+  bytesReceived?: number | null;
+  backpressured?: boolean | null;
+  cdpDirectMode?: boolean | null;
+  uptimeMs?: number | null;
+}
+
+export interface ExternalCaptureDiagnosticsBlob {
+  recentFrames?: ExternalCaptureFrameSampleBlob[] | null;
+  recentFrameCadenceMs?: Array<number | null> | null;
+  nonMonotonicCdpTimestampCount?: number | null;
+  backpressureTransitions?: ExternalCaptureBackpressureTransitionBlob[] | null;
+  firstFatalWriteError?: ExternalCaptureFatalWriteBlob | null;
+  lastFatalWriteError?: ExternalCaptureFatalWriteBlob | null;
+  pageStallBeforeLastFatalWrite?: boolean | null;
+  lastFrameAgeMs?: number | null;
+  captureSessionGeneration?: string | null;
+  manifestStatus?: StreamManifestStatus | null;
+}
+
 /**
  * Typed snapshot from the external RTMP status file. Only allowlisted fields
  * are preserved after parsing — unknown keys in the source JSON are stripped
  * to prevent arbitrary data from being forwarded to API consumers.
  */
 export interface ExternalRtmpStatusSnapshot {
+  active?: boolean;
+  ffmpegRunning?: boolean;
+  clientConnected?: boolean;
+  captureMode?: StreamSourceCaptureMode;
   destinations: ExternalRtmpDestination[];
   stats: ExternalRtmpStreamStats;
   updatedAt: number;
   rendererHealth?: ExternalRendererHealthBlob;
+  metrics?: ExternalRendererMetricsBlob;
+  hlsManifest?: ExternalHlsManifestBlob;
+  delivery?: StreamDeliveryInfo;
+  smoke?: ExternalRendererSmokeBlob;
+  ingest?: ExternalRendererIngestBlob;
+  sourceRuntime?: StreamSourceRuntime;
+  captureDiagnostics?: ExternalCaptureDiagnosticsBlob;
 }
 
 type ExternalStatusPoller = {
@@ -50,14 +157,522 @@ type ExternalStatusPoller = {
 
 const externalStatusPollers = new Map<string, ExternalStatusPoller>();
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function asFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function parseNullableFiniteNumber(
+  record: Record<string, unknown>,
+  key: string,
+): number | null | undefined {
+  if (!(key in record)) return undefined;
+  if (record[key] === null) return null;
+  return asFiniteNumber(record[key]);
+}
+
+function parseNullableBoolean(
+  record: Record<string, unknown>,
+  key: string,
+): boolean | null | undefined {
+  if (!(key in record)) return undefined;
+  if (record[key] === null) return null;
+  return typeof record[key] === "boolean" ? record[key] : undefined;
+}
+
+function parseNullableString(
+  record: Record<string, unknown>,
+  key: string,
+): string | null | undefined {
+  if (!(key in record)) return undefined;
+  if (record[key] === null) return null;
+  return asNonEmptyString(record[key]);
+}
+
+function hasKeys(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+function parseExternalDestinations(value: unknown): ExternalRtmpDestination[] {
+  if (!Array.isArray(value)) return [];
+  const destinations: ExternalRtmpDestination[] = [];
+  for (const candidate of value) {
+    const record = asRecord(candidate);
+    if (!record) {
+      continue;
+    }
+    destinations.push({
+      id: asNonEmptyString(record.id) ?? undefined,
+      name: asNonEmptyString(record.name) ?? undefined,
+      role:
+        record.role === "canonical" ||
+        record.role === "fallback" ||
+        record.role === "mirror"
+          ? record.role
+          : undefined,
+      provider:
+        record.provider === "cloudflare_stream" ||
+        record.provider === "self_hls" ||
+        record.provider === "twitch" ||
+        record.provider === "kick" ||
+        record.provider === "youtube" ||
+        record.provider === "custom"
+          ? record.provider
+          : undefined,
+      transport:
+        record.transport === "llhls" ||
+        record.transport === "hls" ||
+        record.transport === "rtmps" ||
+        record.transport === "srt" ||
+        record.transport === "unknown"
+          ? record.transport
+          : undefined,
+      playbackUrl: asNonEmptyString(record.playbackUrl),
+      ingestUrl: asNonEmptyString(record.ingestUrl),
+      url: asNonEmptyString(record.url) ?? undefined,
+      status: asNonEmptyString(record.status) ?? undefined,
+      connected:
+        typeof record.connected === "boolean" ? record.connected : undefined,
+      bytesWritten: asFiniteNumber(record.bytesWritten) ?? undefined,
+      startedAt: asFiniteNumber(record.startedAt) ?? undefined,
+      error: asNonEmptyString(record.error) ?? undefined,
+    });
+  }
+  return destinations;
+}
+
+function parseExternalStats(value: unknown): ExternalRtmpStreamStats {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const record = value as Record<string, unknown>;
+  const stats: ExternalRtmpStreamStats = {};
+  const bitrate = asFiniteNumber(record.bitrate);
+  const fps = asFiniteNumber(record.fps);
+  const uptime = asFiniteNumber(record.uptime);
+  const bytesReceived = asFiniteNumber(record.bytesReceived);
+  const droppedFrames = asFiniteNumber(record.droppedFrames);
+
+  if (bitrate !== null) {
+    stats.bitrate = bitrate;
+  }
+  if (fps !== null) {
+    stats.fps = fps;
+  }
+  if (uptime !== null) {
+    stats.uptime = uptime;
+  }
+  if (bytesReceived !== null) {
+    stats.bytesReceived = bytesReceived;
+  }
+  if (droppedFrames !== null) {
+    stats.droppedFrames = droppedFrames;
+  }
+  if (typeof record.healthy === "boolean") {
+    stats.healthy = record.healthy;
+  }
+
+  return stats;
+}
+
+function parseStreamManifestStatus(
+  value: unknown,
+): StreamManifestStatus | null {
+  return value === "ok" ||
+    value === "stale" ||
+    value === "missing" ||
+    value === "unknown"
+    ? value
+    : null;
+}
+
+function parseStreamDeliveryMode(value: unknown): StreamDeliveryMode | null {
+  return value === "self_hls" || value === "external_hls" ? value : null;
+}
+
+function parseExternalRendererIngestBlob(
+  value: unknown,
+): ExternalRendererIngestBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalRendererIngestBlob = {};
+  const profile = parseNullableString(record, "profile");
+  const transport = parseNullableString(record, "transport");
+  const audioSampleRate = parseNullableFiniteNumber(record, "audioSampleRate");
+  const gopFrames = parseNullableFiniteNumber(record, "gopFrames");
+  const targetFps = parseNullableFiniteNumber(record, "targetFps");
+  const probeOnly = parseNullableBoolean(record, "probeOnly");
+
+  if (profile !== undefined) parsed.profile = profile;
+  if (transport !== undefined) parsed.transport = transport;
+  if (audioSampleRate !== undefined) parsed.audioSampleRate = audioSampleRate;
+  if (gopFrames !== undefined) parsed.gopFrames = gopFrames;
+  if (targetFps !== undefined) parsed.targetFps = targetFps;
+  if (probeOnly !== undefined) parsed.probeOnly = probeOnly;
+
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalRendererHealthBlob(
+  value: unknown,
+): ExternalRendererHealthBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalRendererHealthBlob = {};
+  if (typeof record.ready === "boolean") {
+    parsed.ready = record.ready;
+  }
+  const degradedReason = parseNullableString(record, "degradedReason");
+  const updatedAt = parseNullableFiniteNumber(record, "updatedAt");
+  const phase = parseNullableString(record, "phase");
+  if (degradedReason !== undefined) parsed.degradedReason = degradedReason;
+  if (updatedAt !== undefined) parsed.updatedAt = updatedAt;
+  if (phase !== undefined) parsed.phase = phase;
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalRendererMetricsBlob(
+  value: unknown,
+): ExternalRendererMetricsBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalRendererMetricsBlob = {};
+  for (const key of [
+    "captureFps",
+    "encodeFps",
+    "droppedFrames",
+    "renderTick",
+    "duelStateTick",
+    "latestFrameAt",
+    "latestRenderTickAt",
+    "latestDuelStateTickAt",
+    "latestVisualChangeAt",
+    "visualChangeAgeMs",
+  ] as const) {
+    const valueForKey = parseNullableFiniteNumber(record, key);
+    if (valueForKey !== undefined) {
+      parsed[key] = valueForKey;
+    }
+  }
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalHlsManifestBlob(
+  value: unknown,
+): ExternalHlsManifestBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalHlsManifestBlob = {};
+  const updatedAt = parseNullableFiniteNumber(record, "updatedAt");
+  const mediaSequence = parseNullableFiniteNumber(record, "mediaSequence");
+  if (updatedAt !== undefined) parsed.updatedAt = updatedAt;
+  if (mediaSequence !== undefined) parsed.mediaSequence = mediaSequence;
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalDeliveryInfo(
+  value: unknown,
+): StreamDeliveryInfo | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const mode = parseStreamDeliveryMode(record.mode);
+  if (!mode) {
+    return undefined;
+  }
+
+  return {
+    mode,
+    provider: parseNullableString(record, "provider") ?? null,
+    playbackUrl: parseNullableString(record, "playbackUrl") ?? null,
+    hlsUrl: parseNullableString(record, "hlsUrl") ?? null,
+    llhlsUrl: parseNullableString(record, "llhlsUrl") ?? null,
+    ingestUrl: parseNullableString(record, "ingestUrl") ?? null,
+  };
+}
+
+function parseExternalRendererSmokeBlob(
+  value: unknown,
+): ExternalRendererSmokeBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalRendererSmokeBlob = {};
+  const currentSceneUrl = parseNullableString(record, "currentSceneUrl");
+  const activeBundle = parseNullableString(record, "activeBundle");
+  const deliveryMode = parseNullableString(record, "deliveryMode");
+  const updatedAt = parseNullableFiniteNumber(record, "updatedAt");
+  const ingest = parseExternalRendererIngestBlob(record.ingest);
+
+  if (currentSceneUrl !== undefined) parsed.currentSceneUrl = currentSceneUrl;
+  if (activeBundle !== undefined) parsed.activeBundle = activeBundle;
+  if (deliveryMode !== undefined) parsed.deliveryMode = deliveryMode;
+  if (updatedAt !== undefined) parsed.updatedAt = updatedAt;
+  if (ingest) parsed.ingest = ingest;
+  for (const key of [
+    "captureFpsP50",
+    "captureFpsP95",
+    "encodeFpsP50",
+    "encodeFpsP95",
+  ] as const) {
+    const valueForKey = parseNullableFiniteNumber(record, key);
+    if (valueForKey !== undefined) {
+      parsed[key] = valueForKey;
+    }
+  }
+
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalCaptureFrameSample(
+  value: unknown,
+): ExternalCaptureFrameSampleBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalCaptureFrameSampleBlob = {};
+  const at = parseNullableFiniteNumber(record, "at");
+  const size = parseNullableFiniteNumber(record, "size");
+  const cdpTimestamp = parseNullableFiniteNumber(record, "cdpTimestamp");
+  if (at !== undefined) parsed.at = at;
+  if (size !== undefined) parsed.size = size;
+  if (cdpTimestamp !== undefined) parsed.cdpTimestamp = cdpTimestamp;
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalCaptureBackpressureTransition(
+  value: unknown,
+): ExternalCaptureBackpressureTransitionBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalCaptureBackpressureTransitionBlob = {};
+  const at = parseNullableFiniteNumber(record, "at");
+  const backpressured = parseNullableBoolean(record, "backpressured");
+  if (at !== undefined) parsed.at = at;
+  if (backpressured !== undefined) parsed.backpressured = backpressured;
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalCaptureFatalWrite(
+  value: unknown,
+): ExternalCaptureFatalWriteBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalCaptureFatalWriteBlob = {};
+  const message = parseNullableString(record, "message");
+  const backpressured = parseNullableBoolean(record, "backpressured");
+  const cdpDirectMode = parseNullableBoolean(record, "cdpDirectMode");
+  if (message !== undefined) parsed.message = message;
+  if (backpressured !== undefined) parsed.backpressured = backpressured;
+  if (cdpDirectMode !== undefined) parsed.cdpDirectMode = cdpDirectMode;
+  for (const key of [
+    "at",
+    "frameCount",
+    "droppedFrames",
+    "bytesReceived",
+    "uptimeMs",
+  ] as const) {
+    const valueForKey = parseNullableFiniteNumber(record, key);
+    if (valueForKey !== undefined) {
+      parsed[key] = valueForKey;
+    }
+  }
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalCaptureDiagnosticsBlob(
+  value: unknown,
+): ExternalCaptureDiagnosticsBlob | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const parsed: ExternalCaptureDiagnosticsBlob = {};
+  const recentFrames = Array.isArray(record.recentFrames)
+    ? record.recentFrames
+        .map((frame) => parseExternalCaptureFrameSample(frame))
+        .filter(
+          (frame): frame is ExternalCaptureFrameSampleBlob =>
+            frame !== undefined,
+        )
+    : undefined;
+  const recentFrameCadenceMs = Array.isArray(record.recentFrameCadenceMs)
+    ? record.recentFrameCadenceMs
+        .map((sample) =>
+          sample === null ? null : (asFiniteNumber(sample) ?? undefined),
+        )
+        .filter((sample): sample is number | null => sample !== undefined)
+    : undefined;
+  const backpressureTransitions = Array.isArray(record.backpressureTransitions)
+    ? record.backpressureTransitions
+        .map((entry) => parseExternalCaptureBackpressureTransition(entry))
+        .filter(
+          (entry): entry is ExternalCaptureBackpressureTransitionBlob =>
+            entry !== undefined,
+        )
+    : undefined;
+  const firstFatalWriteError = parseExternalCaptureFatalWrite(
+    record.firstFatalWriteError,
+  );
+  const lastFatalWriteError = parseExternalCaptureFatalWrite(
+    record.lastFatalWriteError,
+  );
+  const nonMonotonicCdpTimestampCount = parseNullableFiniteNumber(
+    record,
+    "nonMonotonicCdpTimestampCount",
+  );
+  const pageStallBeforeLastFatalWrite = parseNullableBoolean(
+    record,
+    "pageStallBeforeLastFatalWrite",
+  );
+  const lastFrameAgeMs = parseNullableFiniteNumber(record, "lastFrameAgeMs");
+  const captureSessionGeneration = parseNullableString(
+    record,
+    "captureSessionGeneration",
+  );
+  const manifestStatus =
+    "manifestStatus" in record
+      ? record.manifestStatus === null
+        ? null
+        : parseStreamManifestStatus(record.manifestStatus)
+      : undefined;
+
+  if (recentFrames !== undefined) parsed.recentFrames = recentFrames;
+  if (recentFrameCadenceMs !== undefined) {
+    parsed.recentFrameCadenceMs = recentFrameCadenceMs;
+  }
+  if (backpressureTransitions !== undefined) {
+    parsed.backpressureTransitions = backpressureTransitions;
+  }
+  if (firstFatalWriteError) parsed.firstFatalWriteError = firstFatalWriteError;
+  if (lastFatalWriteError) parsed.lastFatalWriteError = lastFatalWriteError;
+  if (nonMonotonicCdpTimestampCount !== undefined) {
+    parsed.nonMonotonicCdpTimestampCount = nonMonotonicCdpTimestampCount;
+  }
+  if (pageStallBeforeLastFatalWrite !== undefined) {
+    parsed.pageStallBeforeLastFatalWrite = pageStallBeforeLastFatalWrite;
+  }
+  if (lastFrameAgeMs !== undefined) parsed.lastFrameAgeMs = lastFrameAgeMs;
+  if (captureSessionGeneration !== undefined) {
+    parsed.captureSessionGeneration = captureSessionGeneration;
+  }
+  if (manifestStatus !== undefined) parsed.manifestStatus = manifestStatus;
+
+  return hasKeys(parsed) ? parsed : undefined;
+}
+
+function parseExternalSourceRuntime(
+  value: unknown,
+): StreamSourceRuntime | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const ready = typeof record.ready === "boolean" ? record.ready : undefined;
+  const statusSource =
+    record.statusSource === "external_worker" ||
+    record.statusSource === "in_process_bridge" ||
+    record.statusSource === "none"
+      ? record.statusSource
+      : undefined;
+  const captureMode =
+    record.captureMode === "cdp" ||
+    record.captureMode === "webcodecs" ||
+    record.captureMode === "mediarecorder" ||
+    record.captureMode === "x11_nvenc" ||
+    record.captureMode === "none"
+      ? record.captureMode
+      : undefined;
+  const degradedReason =
+    "degradedReason" in record
+      ? record.degradedReason === null
+        ? null
+        : record.degradedReason === "worker_missing" ||
+            record.degradedReason === "browser_missing" ||
+            record.degradedReason === "page_not_ready" ||
+            record.degradedReason === "unexpected_navigation" ||
+            record.degradedReason === "capture_stalled" ||
+            record.degradedReason === "encoder_stalled" ||
+            record.degradedReason === "manifest_stale" ||
+            record.degradedReason === "destination_disconnected" ||
+            record.degradedReason === "status_stale" ||
+            record.degradedReason === "unknown"
+          ? record.degradedReason
+          : undefined
+      : undefined;
+  const currentSceneUrl = parseNullableString(record, "currentSceneUrl");
+  const activeBundle = parseNullableString(record, "activeBundle");
+  const lastFrameAt = parseNullableFiniteNumber(record, "lastFrameAt");
+  const lastRenderTickAt = parseNullableFiniteNumber(
+    record,
+    "lastRenderTickAt",
+  );
+  const lastVisualChangeAt = parseNullableFiniteNumber(
+    record,
+    "lastVisualChangeAt",
+  );
+  const lastRecoveryAt = parseNullableFiniteNumber(record, "lastRecoveryAt");
+  const recoveryCount = parseNullableFiniteNumber(record, "recoveryCount");
+  const workerHeartbeatAt = parseNullableFiniteNumber(
+    record,
+    "workerHeartbeatAt",
+  );
+  const hasRecognizedField =
+    ready !== undefined ||
+    statusSource !== undefined ||
+    captureMode !== undefined ||
+    degradedReason !== undefined ||
+    currentSceneUrl !== undefined ||
+    activeBundle !== undefined ||
+    lastFrameAt !== undefined ||
+    lastRenderTickAt !== undefined ||
+    lastVisualChangeAt !== undefined ||
+    lastRecoveryAt !== undefined ||
+    recoveryCount !== undefined ||
+    workerHeartbeatAt !== undefined;
+  if (!hasRecognizedField) {
+    return undefined;
+  }
+
+  return {
+    ready: ready ?? false,
+    statusSource: statusSource ?? "none",
+    captureMode: captureMode ?? "none",
+    degradedReason: degradedReason ?? null,
+    currentSceneUrl: currentSceneUrl ?? null,
+    activeBundle: activeBundle ?? null,
+    lastFrameAt: lastFrameAt ?? null,
+    lastRenderTickAt: lastRenderTickAt ?? null,
+    lastVisualChangeAt: lastVisualChangeAt ?? null,
+    lastRecoveryAt: lastRecoveryAt ?? null,
+    recoveryCount: Math.max(0, recoveryCount ?? 0),
+    workerHeartbeatAt: workerHeartbeatAt ?? null,
+  };
 }
 
 /**
  * Parse and validate the external RTMP status JSON, stripping unknown keys.
  *
- * Only `destinations`, `stats`, `updatedAt`, and `rendererHealth` are
+ * Only `active`, `ffmpegRunning`, `clientConnected`, `destinations`, `stats`,
+ * `updatedAt`, `rendererHealth`, `metrics`, `hlsManifest`, `delivery`, `smoke`,
+ * and `ingest`
+ * plus additive `sourceRuntime`
+ * are
  * forwarded. Any extra keys in the source file are silently dropped so
  * tampered files cannot inject arbitrary data into API responses.
  */
@@ -69,11 +684,10 @@ export function parseExternalRtmpStatusSnapshot(
   try {
     const normalized = raw.trim();
     if (!normalized) return null;
-    const parsed = JSON.parse(normalized) as Record<string, unknown>;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-      return null;
+    const parsed = asRecord(JSON.parse(normalized));
+    if (!parsed) return null;
     if (!Array.isArray(parsed.destinations)) return null;
-    if (typeof parsed.stats !== "object" || parsed.stats == null) return null;
+    if (!asRecord(parsed.stats)) return null;
 
     const updatedAt = asFiniteNumber(Number(parsed.updatedAt || 0)) ?? 0;
     if (
@@ -86,15 +700,50 @@ export function parseExternalRtmpStatusSnapshot(
 
     // Allowlist: only forward known fields.
     const snapshot: ExternalRtmpStatusSnapshot = {
-      destinations: parsed.destinations as ExternalRtmpDestination[],
-      stats: parsed.stats as ExternalRtmpStreamStats,
+      destinations: parseExternalDestinations(parsed.destinations),
+      stats: parseExternalStats(parsed.stats),
       updatedAt,
     };
-
-    if (parsed.rendererHealth && typeof parsed.rendererHealth === "object") {
-      snapshot.rendererHealth =
-        parsed.rendererHealth as ExternalRendererHealthBlob;
+    if (typeof parsed.active === "boolean") {
+      snapshot.active = parsed.active;
     }
+    if (typeof parsed.ffmpegRunning === "boolean") {
+      snapshot.ffmpegRunning = parsed.ffmpegRunning;
+    }
+    if (typeof parsed.clientConnected === "boolean") {
+      snapshot.clientConnected = parsed.clientConnected;
+    }
+    if (
+      parsed.captureMode === "cdp" ||
+      parsed.captureMode === "webcodecs" ||
+      parsed.captureMode === "mediarecorder" ||
+      parsed.captureMode === "x11_nvenc" ||
+      parsed.captureMode === "none"
+    ) {
+      snapshot.captureMode = parsed.captureMode;
+    }
+
+    const rendererHealth = parseExternalRendererHealthBlob(
+      parsed.rendererHealth,
+    );
+    const metrics = parseExternalRendererMetricsBlob(parsed.metrics);
+    const hlsManifest = parseExternalHlsManifestBlob(parsed.hlsManifest);
+    const delivery = parseExternalDeliveryInfo(parsed.delivery);
+    const smoke = parseExternalRendererSmokeBlob(parsed.smoke);
+    const ingest = parseExternalRendererIngestBlob(parsed.ingest);
+    const sourceRuntime = parseExternalSourceRuntime(parsed.sourceRuntime);
+    const captureDiagnostics = parseExternalCaptureDiagnosticsBlob(
+      parsed.captureDiagnostics,
+    );
+
+    if (rendererHealth) snapshot.rendererHealth = rendererHealth;
+    if (metrics) snapshot.metrics = metrics;
+    if (hlsManifest) snapshot.hlsManifest = hlsManifest;
+    if (delivery) snapshot.delivery = delivery;
+    if (smoke) snapshot.smoke = smoke;
+    if (ingest) snapshot.ingest = ingest;
+    if (sourceRuntime) snapshot.sourceRuntime = sourceRuntime;
+    if (captureDiagnostics) snapshot.captureDiagnostics = captureDiagnostics;
 
     return snapshot;
   } catch {
@@ -188,6 +837,7 @@ export function acquireExternalStatusPoller(
       }, refreshIntervalMs),
       refCount: 0,
     };
+    poller.interval.unref?.();
     externalStatusPollers.set(key, poller);
     void refreshExternalStatusPoller(
       poller,

--- a/packages/server/src/routes/streaming-source-runtime.ts
+++ b/packages/server/src/routes/streaming-source-runtime.ts
@@ -1,0 +1,217 @@
+import type { HlsManifestSnapshot } from "../streaming/stream-status-artifacts.js";
+import {
+  buildUnavailableStreamSourceRuntime,
+  normalizeStreamSourceCaptureMode,
+  normalizeStreamSourceRuntime,
+  type StreamSourceDegradedReason,
+  type StreamSourceRuntime,
+} from "../streaming/source-runtime.js";
+import type { BettingFeedRendererHealth } from "./streaming-betting-feed.js";
+import type { ExternalRtmpStatusSnapshot } from "./streaming-external-status.js";
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isFreshTimestamp(
+  timestampMs: number | null,
+  nowMs: number,
+  maxAgeMs: number,
+): boolean {
+  return (
+    timestampMs != null &&
+    Number.isFinite(timestampMs) &&
+    Math.max(0, nowMs - timestampMs) <= maxAgeMs
+  );
+}
+
+function mapRendererDegradedReasonToSourceReason(
+  degradedReason: string | null | undefined,
+): StreamSourceDegradedReason | null {
+  const normalized = (degradedReason ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "manifest_stale") return "manifest_stale";
+  if (
+    normalized === "capture_pipeline_inactive" ||
+    normalized === "ffmpeg_not_running" ||
+    normalized === "encoder_fps_low"
+  ) {
+    return "encoder_stalled";
+  }
+  if (
+    normalized === "capture_client_disconnected" ||
+    normalized === "bridge_inactive" ||
+    normalized === "render_tick_stale" ||
+    normalized === "visual_change_stale" ||
+    normalized === "capture_fps_low"
+  ) {
+    return "capture_stalled";
+  }
+  if (
+    normalized === "capture_page_missing" ||
+    normalized === "loading_overlay_active" ||
+    normalized === "canvas_missing" ||
+    normalized === "initialization_failed" ||
+    normalized === "asset_origin_incomplete" ||
+    normalized === "socket_disconnected" ||
+    normalized === "stream_state_missing" ||
+    normalized === "waiting_for_duel_data" ||
+    normalized === "world_not_ready" ||
+    normalized === "terrain_not_ready" ||
+    normalized === "camera_target_unresolved" ||
+    normalized === "avatar_not_ready" ||
+    normalized === "initializing" ||
+    normalized === "agents_missing" ||
+    normalized === "invalid_agent_hp" ||
+    normalized === "arena_positions_invalid"
+  ) {
+    return "page_not_ready";
+  }
+  if (normalized.startsWith("probe_failed:")) {
+    return "page_not_ready";
+  }
+  return null;
+}
+
+function resolveFallbackSourceReason(params: {
+  rendererHealth: BettingFeedRendererHealth | null;
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  localHlsManifest?: HlsManifestSnapshot | null;
+  captureStats?:
+    | {
+        clientConnected: boolean;
+        ffmpegRunning: boolean;
+      }
+    | null
+    | undefined;
+  nowMs: number;
+  externalStatusMaxAgeMs: number;
+}): StreamSourceDegradedReason | null {
+  const { rendererHealth, externalSnapshot, localHlsManifest, captureStats } =
+    params;
+  const rendererReason = mapRendererDegradedReasonToSourceReason(
+    rendererHealth?.degradedReason,
+  );
+  if (rendererReason) {
+    return rendererReason;
+  }
+
+  const ffmpegRunning =
+    externalSnapshot?.ffmpegRunning === true ||
+    captureStats?.ffmpegRunning === true;
+  if (!ffmpegRunning) {
+    return "encoder_stalled";
+  }
+
+  const clientConnected =
+    externalSnapshot?.clientConnected === true ||
+    captureStats?.clientConnected === true;
+  if (!clientConnected) {
+    return "capture_stalled";
+  }
+
+  const probeOnly = externalSnapshot?.ingest?.probeOnly === true;
+  const manifestUpdatedAt =
+    asFiniteNumber(externalSnapshot?.hlsManifest?.updatedAt) ??
+    asFiniteNumber(localHlsManifest?.updatedAt);
+  if (
+    !probeOnly &&
+    manifestUpdatedAt != null &&
+    !isFreshTimestamp(
+      manifestUpdatedAt,
+      params.nowMs,
+      params.externalStatusMaxAgeMs,
+    )
+  ) {
+    return "manifest_stale";
+  }
+
+  return null;
+}
+
+export function deriveStreamSourceRuntime(params: {
+  externalStatusSnapshot?: ExternalRtmpStatusSnapshot | null;
+  externalStatusMaxAgeMs: number;
+  rendererHealth?: BettingFeedRendererHealth | null;
+  localHlsManifest?: HlsManifestSnapshot | null;
+  captureStats?:
+    | {
+        clientConnected: boolean;
+        ffmpegRunning: boolean;
+      }
+    | null
+    | undefined;
+  nowMs?: number;
+  requireExternalWorker?: boolean;
+}): StreamSourceRuntime {
+  const nowMs = params.nowMs ?? Date.now();
+  const externalSnapshot = params.externalStatusSnapshot ?? null;
+  const normalizedExternalRuntime = normalizeStreamSourceRuntime(
+    externalSnapshot?.sourceRuntime,
+  );
+  const snapshotHeartbeatAt =
+    normalizedExternalRuntime?.workerHeartbeatAt ??
+    asFiniteNumber(externalSnapshot?.updatedAt);
+  const requireExternalWorker = params.requireExternalWorker === true;
+
+  if (requireExternalWorker && !externalSnapshot) {
+    return buildUnavailableStreamSourceRuntime({
+      statusSource: "external_worker",
+      degradedReason: "worker_missing",
+      workerHeartbeatAt: null,
+    });
+  }
+
+  if (
+    requireExternalWorker &&
+    externalSnapshot &&
+    !isFreshTimestamp(snapshotHeartbeatAt, nowMs, params.externalStatusMaxAgeMs)
+  ) {
+    return buildUnavailableStreamSourceRuntime({
+      statusSource: "external_worker",
+      captureMode: normalizedExternalRuntime?.captureMode ?? "none",
+      degradedReason: "status_stale",
+      currentSceneUrl: normalizedExternalRuntime?.currentSceneUrl ?? null,
+      activeBundle: normalizedExternalRuntime?.activeBundle ?? null,
+      lastFrameAt: normalizedExternalRuntime?.lastFrameAt ?? null,
+      lastRenderTickAt: normalizedExternalRuntime?.lastRenderTickAt ?? null,
+      lastVisualChangeAt: normalizedExternalRuntime?.lastVisualChangeAt ?? null,
+      lastRecoveryAt: normalizedExternalRuntime?.lastRecoveryAt ?? null,
+      recoveryCount: normalizedExternalRuntime?.recoveryCount ?? 0,
+      workerHeartbeatAt: snapshotHeartbeatAt,
+    });
+  }
+
+  if (normalizedExternalRuntime) {
+    return normalizedExternalRuntime;
+  }
+
+  const degradedReason = resolveFallbackSourceReason({
+    rendererHealth: params.rendererHealth ?? null,
+    externalSnapshot,
+    localHlsManifest: params.localHlsManifest,
+    captureStats: params.captureStats,
+    nowMs,
+    externalStatusMaxAgeMs: params.externalStatusMaxAgeMs,
+  });
+
+  return {
+    ready: degradedReason == null,
+    statusSource: externalSnapshot ? "external_worker" : "in_process_bridge",
+    captureMode:
+      normalizeStreamSourceCaptureMode(externalSnapshot?.captureMode) ?? "none",
+    degradedReason,
+    currentSceneUrl: externalSnapshot?.smoke?.currentSceneUrl ?? null,
+    activeBundle: externalSnapshot?.smoke?.activeBundle ?? null,
+    lastFrameAt: asFiniteNumber(externalSnapshot?.metrics?.latestFrameAt),
+    lastRenderTickAt: asFiniteNumber(
+      externalSnapshot?.metrics?.latestRenderTickAt,
+    ),
+    lastVisualChangeAt: asFiniteNumber(
+      externalSnapshot?.metrics?.latestVisualChangeAt,
+    ),
+    lastRecoveryAt: null,
+    recoveryCount: 0,
+    workerHeartbeatAt: snapshotHeartbeatAt,
+  };
+}

--- a/packages/server/src/routes/streaming.ts
+++ b/packages/server/src/routes/streaming.ts
@@ -11,13 +11,45 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type { RateLimitOptions } from "@fastify/rate-limit";
 import type { World } from "@hyperscape/shared";
+import { RateLimiterMemory } from "rate-limiter-flexible";
+import { createHash } from "node:crypto";
+import type { DatabaseSystem } from "../systems/DatabaseSystem/index.js";
 import { getStreamingDuelScheduler } from "../systems/StreamingDuelScheduler/index.js";
 import {
   STREAMING_TIMING,
   type StreamingPhase,
+  type StreamingSourceTimeline,
+  type StreamingStateUpdate,
 } from "../systems/StreamingDuelScheduler/types.js";
 import { peekRTMPBridge } from "../streaming/index.js";
 import { getStreamCapture } from "../streaming/stream-capture.js";
+import {
+  buildStreamDestinationId,
+  normalizeStreamDestinationProvider,
+  resolveStreamDeliveryInfo,
+  type StreamManifestStatus,
+} from "../streaming/delivery-config.js";
+import type { StreamSourceRuntime } from "../streaming/source-runtime.js";
+import { resolveStreamIngestSettings } from "../streaming/ingest-config.js";
+import {
+  acquirePlaybackProbePoller,
+  type StreamPlaybackProbeResult,
+} from "../streaming/destination-probe.js";
+import {
+  loadPersistedStreamingAuthorityState,
+  type PersistedStreamingAuthorityState,
+} from "../streaming/cloudflare-authority.js";
+import {
+  extractBettingFeedToken,
+  hasValidBettingFeedToken,
+  resolveBettingFeedAccessToken,
+  resolveOracleProofAccessToken,
+} from "./streaming-betting-auth.js";
+import {
+  readLocalHlsManifestSnapshot,
+  resolveExternalStatusFile,
+  type HlsManifestSnapshot,
+} from "../streaming/stream-status-artifacts.js";
 import {
   STREAMING_CANONICAL_PLATFORM,
   STREAMING_PUBLIC_DELAY_DEFAULT_MS,
@@ -29,8 +61,13 @@ import {
   loadExternalRtmpStatusSnapshot,
   registerStreamingBettingRoutes,
 } from "./streaming-betting-routes.js";
+import type {
+  ExternalCaptureDiagnosticsBlob,
+  ExternalRtmpDestination,
+  ExternalRtmpStatusSnapshot,
+} from "./streaming-external-status.js";
+import { deriveStreamSourceRuntime } from "./streaming-source-runtime.js";
 import { trimReplayFrames } from "./streaming-sse-buffer.js";
-import { getDefaultPublicWsUrl } from "../shared/public-ws-url.js";
 type InventorySnapshotItem = {
   slot: number;
   itemId: string;
@@ -101,11 +138,14 @@ const STREAMING_SSE_MAX_CLIENTS = Math.max(
     Number.parseInt(process.env.STREAMING_SSE_MAX_CLIENTS || "64", 10),
   ),
 );
-const EXTERNAL_RTMP_STATUS_FILE = (process.env.RTMP_STATUS_FILE || "").trim();
+const EXTERNAL_RTMP_STATUS_FILE = resolveExternalStatusFile(process.env);
 const EXTERNAL_RTMP_STATUS_MAX_AGE_MS = Math.max(
   5000,
   Number.parseInt(process.env.RTMP_STATUS_MAX_AGE_MS || "15000", 10),
 );
+const REQUIRE_EXTERNAL_SOURCE_RUNTIME =
+  process.env.STREAM_SOURCE_RUNTIME_REQUIRE_EXTERNAL === "true" ||
+  process.env.NODE_ENV === "production";
 const BETTING_BOOTSTRAP_RATE_LIMIT: RateLimitOptions = {
   max: 240,
   timeWindow: "1 minute",
@@ -114,6 +154,792 @@ const BETTING_EVENTS_RATE_LIMIT: RateLimitOptions = {
   max: 60,
   timeWindow: "1 minute",
 };
+const AUTHENTICATED_RESULTS_RATE_LIMIT: RateLimitOptions = {
+  max: 120,
+  timeWindow: "1 minute",
+};
+const STREAMING_STATUS_RATE_LIMIT: RateLimitOptions = {
+  max: 120,
+  timeWindow: "1 minute",
+};
+const STREAMING_RESULT_DUEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$/;
+const STREAMING_STATUS_CODEQL_LIMITER = new RateLimiterMemory({
+  points: 120,
+  duration: 60,
+});
+
+/**
+ * Opt-in additive contract for raw source-time fields on the canonical
+ * stream state. When false (default) the wire shape is unchanged and every
+ * existing consumer keeps working. When true the server also emits:
+ *   - `cycle.sourceTimeline` — raw phase + timing fields (unprojected)
+ *   - `emittedAt` on REST responses (SSE frames stamp this independently)
+ * Commit 1 of the viewer-aligned-bet-state rollout; see
+ * `docs/frontier_duel_bet_stream_sync_prd_sow.md` for the cross-rail plan.
+ */
+export function isRawSourceTimeEmissionEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    (env.STREAMING_EMIT_RAW_SOURCE_TIME ?? "").trim().toLowerCase() === "true"
+  );
+}
+
+/**
+ * Build a raw `sourceTimeline` projection of the given cycle. Every field
+ * mirrors the scheduler's underlying wall-clock value without any
+ * presentation-delay or replay-offset shift applied. `updatedAt` is the
+ * source-emission timestamp of the frame the cycle was pulled from —
+ * distinct from any downstream delivery time.
+ */
+export function buildSourceTimeline(
+  cycle: StreamingStateUpdate["cycle"],
+  updatedAt: number,
+): StreamingSourceTimeline {
+  return {
+    phase: cycle.phase,
+    betOpenTime: cycle.betOpenTime ?? null,
+    betCloseTime: cycle.betCloseTime ?? null,
+    fightStartTime: cycle.fightStartTime ?? null,
+    duelEndTime: cycle.duelEndTime ?? null,
+    updatedAt,
+  };
+}
+
+/**
+ * Attach raw source-time metadata to a streaming-state object, subject to
+ * the `STREAMING_EMIT_RAW_SOURCE_TIME` flag (resolved via `enabled`). When
+ * disabled, the wire shape is unchanged and every existing consumer keeps
+ * working. When enabled:
+ *   - `cycle.sourceTimeline` is populated with raw scheduler timings
+ *   - `emittedAt` is attached at the envelope root when `stampEmittedAt`
+ *     is true (REST responses want this; SSE frames already stamp
+ *     `emittedAt` from their own envelope construction upstream).
+ */
+export function attachRawSourceTime<
+  T extends { cycle: StreamingStateUpdate["cycle"] },
+>(
+  state: T,
+  sourceEmittedAt: number,
+  options: {
+    stampEmittedAt: boolean;
+    enabled: boolean;
+    sourceCycle?: StreamingStateUpdate["cycle"] | null;
+  },
+): T {
+  if (!options.enabled) return state;
+  const sourceTimeline =
+    state.cycle.sourceTimeline ??
+    buildSourceTimeline(options.sourceCycle ?? state.cycle, sourceEmittedAt);
+  const withTimeline: T = {
+    ...state,
+    cycle: {
+      ...state.cycle,
+      sourceTimeline,
+    },
+  };
+  if (!options.stampEmittedAt) return withTimeline;
+  return { ...withTimeline, emittedAt: sourceEmittedAt } as T & {
+    emittedAt: number;
+  };
+}
+
+/**
+ * Standalone preHandler implementing the exact pattern CodeQL's
+ * RouteHandlerLimitedByRateLimiterFlexible class recognizes: a function taking
+ * a request parameter that calls `.consume(request.<prop>)` on an instance of
+ * a `RateLimiter*` class from `rate-limiter-flexible`. Extracted to module
+ * scope so the middleware is a separate routing-tree node that guards the
+ * handler, which is what CodeQL's `isGuardedByNode` check requires.
+ *
+ * Using this preHandler satisfies `js/missing-rate-limiting` WITHOUT relying
+ * on the `config.rateLimit` shorthand, which CodeQL's `FastifyPerRouteRateLimit`
+ * class only recognizes when the rate-limiter plugin is imported under the
+ * old unscoped name `fastify-rate-limit` (this repo uses `@fastify/rate-limit`).
+ */
+async function codeqlStatusRateLimitPreHandler(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  try {
+    await STREAMING_STATUS_CODEQL_LIMITER.consume(request.ip);
+  } catch {
+    await reply.code(429).send({ error: "Too Many Requests" });
+  }
+}
+type RateLimitedFastify = FastifyInstance & {
+  rateLimit: NonNullable<FastifyInstance["rateLimit"]>;
+};
+type StreamingStatusMetricsSnapshot = {
+  captureFps: number | null;
+  encodeFps: number | null;
+  droppedFrames: number | null;
+  renderTick: number | null;
+  duelStateTick: number | null;
+  latestFrameAt: number | null;
+  latestRenderTickAt: number | null;
+  latestDuelStateTickAt: number | null;
+  latestVisualChangeAt: number | null;
+  visualChangeAgeMs: number | null;
+};
+
+type StreamingStatusManifestSnapshot = {
+  updatedAt: number | null;
+  mediaSequence: number | null;
+};
+
+type StreamingStatusSmokeSnapshot = {
+  currentSceneUrl: string | null;
+  activeBundle: string | null;
+  deliveryMode: string | null;
+  captureFpsP50: number | null;
+  captureFpsP95: number | null;
+  encodeFpsP50: number | null;
+  encodeFpsP95: number | null;
+  updatedAt: number | null;
+  ingest: StreamingStatusIngestSnapshot;
+};
+
+type StreamingStatusIngestSnapshot = {
+  profile: string | null;
+  transport: string | null;
+  audioSampleRate: number | null;
+  gopFrames: number | null;
+  probeOnly: boolean | null;
+};
+
+type StreamingCanonicalStatusSnapshot = {
+  sourceReady: boolean;
+  canonicalTransportConnected: boolean;
+  canonicalPlaybackReady: boolean;
+  manifestStatus: StreamManifestStatus;
+  lastError: string | null;
+  updatedAt: number | null;
+};
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function hashAuditValue(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return null;
+  }
+  return createHash("sha256").update(normalized, "utf8").digest("hex");
+}
+
+function redactIngestUrlFromDestination<T>(destination: T): T {
+  if (!destination || typeof destination !== "object") {
+    return destination;
+  }
+  return {
+    ...destination,
+    ingestUrl: null,
+  };
+}
+
+function redactIngestUrlsFromDestinations<T>(destinations: readonly T[]): T[] {
+  return destinations.map((destination) =>
+    redactIngestUrlFromDestination(destination),
+  );
+}
+
+function redactIngestUrlFromDelivery<T>(delivery: T): T {
+  if (!delivery || typeof delivery !== "object") {
+    return delivery;
+  }
+  if (!("ingestUrl" in delivery)) {
+    return delivery;
+  }
+  return {
+    ...delivery,
+    ingestUrl: null,
+  };
+}
+
+function ensureRateLimitDecorator(
+  fastify: FastifyInstance,
+): asserts fastify is RateLimitedFastify {
+  if (typeof fastify.rateLimit === "function") {
+    return;
+  }
+  throw new Error(
+    "Streaming routes require @fastify/rate-limit to be registered before route setup",
+  );
+}
+
+export function normalizeStreamingStatusMetrics(params: {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  bridgeStats?:
+    | {
+        encoderFps?: number;
+        droppedFrames?: number;
+      }
+    | null
+    | undefined;
+}): StreamingStatusMetricsSnapshot {
+  const metrics = params.externalSnapshot?.metrics;
+  const bridgeStats = params.bridgeStats;
+
+  return {
+    captureFps: asFiniteNumber(metrics?.captureFps),
+    encodeFps:
+      asFiniteNumber(metrics?.encodeFps) ??
+      asFiniteNumber(bridgeStats?.encoderFps),
+    droppedFrames:
+      asFiniteNumber(metrics?.droppedFrames) ??
+      asFiniteNumber(bridgeStats?.droppedFrames),
+    renderTick: asFiniteNumber(metrics?.renderTick),
+    duelStateTick: asFiniteNumber(metrics?.duelStateTick),
+    latestFrameAt: asFiniteNumber(metrics?.latestFrameAt),
+    latestRenderTickAt: asFiniteNumber(metrics?.latestRenderTickAt),
+    latestDuelStateTickAt: asFiniteNumber(metrics?.latestDuelStateTickAt),
+    latestVisualChangeAt: asFiniteNumber(metrics?.latestVisualChangeAt),
+    visualChangeAgeMs: asFiniteNumber(metrics?.visualChangeAgeMs),
+  };
+}
+
+export function normalizeStreamingStatusManifest(params: {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  localHlsManifest?: HlsManifestSnapshot | null;
+}): StreamingStatusManifestSnapshot {
+  const externalManifest = params.externalSnapshot?.hlsManifest;
+  const localManifest = params.localHlsManifest;
+  return {
+    updatedAt:
+      asFiniteNumber(externalManifest?.updatedAt) ??
+      asFiniteNumber(localManifest?.updatedAt),
+    mediaSequence:
+      asFiniteNumber(externalManifest?.mediaSequence) ??
+      asFiniteNumber(localManifest?.mediaSequence),
+  };
+}
+
+export function normalizeStreamingStatusSmoke(params: {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  deliveryModeFallback: string | null;
+}): StreamingStatusSmokeSnapshot {
+  const smoke = params.externalSnapshot?.smoke;
+  const ingest =
+    smoke?.ingest && typeof smoke.ingest === "object"
+      ? smoke.ingest
+      : params.externalSnapshot?.ingest;
+  const fallbackIngest = resolveStreamIngestSettings(process.env);
+  return {
+    currentSceneUrl:
+      typeof smoke?.currentSceneUrl === "string" &&
+      smoke.currentSceneUrl.trim().length > 0
+        ? smoke.currentSceneUrl.trim()
+        : null,
+    activeBundle:
+      typeof smoke?.activeBundle === "string" &&
+      smoke.activeBundle.trim().length > 0
+        ? smoke.activeBundle.trim()
+        : null,
+    deliveryMode:
+      typeof smoke?.deliveryMode === "string" &&
+      smoke.deliveryMode.trim().length > 0
+        ? smoke.deliveryMode.trim()
+        : params.deliveryModeFallback,
+    captureFpsP50: asFiniteNumber(smoke?.captureFpsP50),
+    captureFpsP95: asFiniteNumber(smoke?.captureFpsP95),
+    encodeFpsP50: asFiniteNumber(smoke?.encodeFpsP50),
+    encodeFpsP95: asFiniteNumber(smoke?.encodeFpsP95),
+    updatedAt: asFiniteNumber(smoke?.updatedAt),
+    ingest: {
+      profile:
+        typeof ingest?.profile === "string" && ingest.profile.trim().length > 0
+          ? ingest.profile.trim()
+          : fallbackIngest.profile,
+      transport:
+        typeof ingest?.transport === "string" &&
+        ingest.transport.trim().length > 0
+          ? ingest.transport.trim()
+          : fallbackIngest.transport,
+      audioSampleRate:
+        asFiniteNumber(ingest?.audioSampleRate) ??
+        fallbackIngest.audioSampleRate,
+      gopFrames: asFiniteNumber(ingest?.gopFrames) ?? fallbackIngest.gopFrames,
+      probeOnly:
+        asBoolean(ingest?.probeOnly) ??
+        (fallbackIngest.probeOnly ? true : false),
+    },
+  };
+}
+
+function findCanonicalStreamingDestination(params: {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  delivery: ReturnType<typeof resolveStreamDeliveryInfo>;
+}): {
+  index: number;
+  destination: ExternalRtmpDestination | null;
+} {
+  const destinations = Array.isArray(params.externalSnapshot?.destinations)
+    ? params.externalSnapshot!.destinations
+    : [];
+  const canonicalProvider = normalizeStreamDestinationProvider(
+    params.delivery.provider,
+    "Cloudflare",
+  );
+  const canonicalDestinationId = buildStreamDestinationId({
+    role: "canonical",
+    provider: canonicalProvider,
+    name: "External Delivery",
+  });
+
+  const index = destinations.findIndex(
+    (destination) => destination.role === "canonical",
+  );
+  if (index >= 0) {
+    return {
+      index,
+      destination: destinations[index] ?? null,
+    };
+  }
+
+  const idIndex = destinations.findIndex(
+    (destination) => destination.id === canonicalDestinationId,
+  );
+  if (idIndex >= 0) {
+    return {
+      index: idIndex,
+      destination: destinations[idIndex] ?? null,
+    };
+  }
+
+  const providerIndex = destinations.findIndex(
+    (destination) =>
+      normalizeStreamDestinationProvider(
+        destination.provider ?? null,
+        destination.name ?? null,
+      ) === canonicalProvider,
+  );
+  if (providerIndex >= 0) {
+    return {
+      index: providerIndex,
+      destination: destinations[providerIndex] ?? null,
+    };
+  }
+
+  return {
+    index: -1,
+    destination: null,
+  };
+}
+
+function isFreshStreamingSnapshot(
+  updatedAt: number | null | undefined,
+  nowMs: number,
+): boolean {
+  return (
+    typeof updatedAt === "number" &&
+    Number.isFinite(updatedAt) &&
+    Math.max(0, nowMs - updatedAt) <= EXTERNAL_RTMP_STATUS_MAX_AGE_MS
+  );
+}
+
+function resolveStreamingManifestStatusFromUpdatedAt(
+  updatedAt: number | null | undefined,
+  nowMs: number,
+): StreamManifestStatus {
+  if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt)) {
+    return "missing";
+  }
+  return isFreshStreamingSnapshot(updatedAt, nowMs) ? "ok" : "stale";
+}
+
+function resolveCanonicalPlaybackUrl(params: {
+  destination: ExternalRtmpDestination | null;
+  delivery: ReturnType<typeof resolveStreamDeliveryInfo>;
+}): string | null {
+  return (
+    params.destination?.playbackUrl ??
+    params.delivery.playbackUrl ??
+    params.delivery.llhlsUrl ??
+    params.delivery.hlsUrl ??
+    null
+  );
+}
+
+function hasFreshContradictorySourceError(params: {
+  sourceRuntime: StreamSourceRuntime;
+  captureDiagnostics?: ExternalCaptureDiagnosticsBlob | null;
+  canonicalProbeSnapshot?: StreamPlaybackProbeResult | null;
+}): boolean {
+  if (params.sourceRuntime.ready === true) {
+    return false;
+  }
+
+  const probeUpdatedAt = asFiniteNumber(
+    params.canonicalProbeSnapshot?.updatedAt,
+  );
+  const fatalWriteAt = asFiniteNumber(
+    params.captureDiagnostics?.lastFatalWriteError?.at,
+  );
+  const workerHeartbeatAt = asFiniteNumber(
+    params.sourceRuntime.workerHeartbeatAt,
+  );
+  const freshestSourceIncidentAt = Math.max(
+    fatalWriteAt ?? Number.NEGATIVE_INFINITY,
+    workerHeartbeatAt ?? Number.NEGATIVE_INFINITY,
+  );
+
+  if (!Number.isFinite(freshestSourceIncidentAt)) {
+    return true;
+  }
+  if (probeUpdatedAt == null) {
+    return true;
+  }
+
+  return freshestSourceIncidentAt >= probeUpdatedAt;
+}
+
+function normalizeCanonicalStreamingTruth(params: {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  delivery: ReturnType<typeof resolveStreamDeliveryInfo>;
+  canonicalProbeSnapshot?: StreamPlaybackProbeResult | null;
+  sourceRuntime: StreamSourceRuntime;
+  localHlsManifest?: HlsManifestSnapshot | null;
+}): {
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  canonicalStatus: StreamingCanonicalStatusSnapshot;
+} {
+  if (params.delivery.mode === "self_hls") {
+    const playbackUrl = params.delivery.playbackUrl ?? null;
+    const externalManifestUpdatedAt = asFiniteNumber(
+      params.externalSnapshot?.hlsManifest?.updatedAt,
+    );
+    const localManifestUpdatedAt = asFiniteNumber(
+      params.localHlsManifest?.updatedAt,
+    );
+    const manifestUpdatedAt =
+      externalManifestUpdatedAt != null && localManifestUpdatedAt != null
+        ? Math.max(externalManifestUpdatedAt, localManifestUpdatedAt)
+        : (externalManifestUpdatedAt ?? localManifestUpdatedAt ?? null);
+    const nowMs = Date.now();
+    const manifestStatus = resolveStreamingManifestStatusFromUpdatedAt(
+      manifestUpdatedAt,
+      nowMs,
+    );
+    const sourceReady = params.sourceRuntime.ready === true;
+    const canonicalPlaybackReady = manifestStatus === "ok";
+    const canonicalTransportConnected = sourceReady && canonicalPlaybackReady;
+    const lastError = sourceReady
+      ? canonicalPlaybackReady
+        ? null
+        : manifestStatus === "stale"
+          ? "manifest_stale"
+          : playbackUrl
+            ? "manifest_not_ready"
+            : "playback_unconfigured"
+      : (params.sourceRuntime.degradedReason ?? "source_unavailable");
+
+    const selfHostedDestination = {
+      id: buildStreamDestinationId({
+        role: "canonical",
+        provider: "self_hls",
+        name: "Self-HLS",
+      }),
+      name: "Self-HLS",
+      role: "canonical" as const,
+      provider: "self_hls" as const,
+      transport: "hls" as const,
+      playbackUrl,
+      ingestUrl: null,
+      connected: canonicalPlaybackReady,
+      transportHealthy: canonicalTransportConnected,
+      playbackReady: canonicalPlaybackReady,
+      manifestStatus,
+      lastError,
+      error: lastError ?? undefined,
+      updatedAt: manifestUpdatedAt ?? undefined,
+    };
+
+    const destinations = Array.isArray(params.externalSnapshot?.destinations)
+      ? params.externalSnapshot!.destinations
+      : [];
+    const normalizedIndex = destinations.findIndex((candidate) => {
+      if (candidate.role === "canonical") return true;
+      if (candidate.id === selfHostedDestination.id) return true;
+      return (
+        normalizeStreamDestinationProvider(
+          candidate.provider ?? null,
+          candidate.name ?? null,
+        ) === "self_hls"
+      );
+    });
+
+    const normalizedSnapshot = params.externalSnapshot
+      ? {
+          ...params.externalSnapshot,
+          destinations:
+            normalizedIndex >= 0
+              ? params.externalSnapshot.destinations.map((candidate, index) =>
+                  index === normalizedIndex
+                    ? { ...candidate, ...selfHostedDestination }
+                    : candidate,
+                )
+              : [
+                  ...params.externalSnapshot.destinations,
+                  selfHostedDestination,
+                ],
+        }
+      : {
+          active: canonicalTransportConnected,
+          ffmpegRunning: sourceReady,
+          clientConnected: sourceReady,
+          destinations: [selfHostedDestination],
+          stats: {},
+          updatedAt: manifestUpdatedAt ?? nowMs,
+          hlsManifest: {
+            updatedAt: manifestUpdatedAt,
+            mediaSequence:
+              asFiniteNumber(params.localHlsManifest?.mediaSequence) ?? null,
+          },
+          delivery: params.delivery,
+        };
+
+    return {
+      externalSnapshot: normalizedSnapshot,
+      canonicalStatus: {
+        sourceReady,
+        canonicalTransportConnected,
+        canonicalPlaybackReady,
+        manifestStatus,
+        lastError,
+        updatedAt: manifestUpdatedAt,
+      },
+    };
+  }
+
+  const { index, destination } = findCanonicalStreamingDestination({
+    externalSnapshot: params.externalSnapshot,
+    delivery: params.delivery,
+  });
+  const playbackUrl = resolveCanonicalPlaybackUrl({
+    destination,
+    delivery: params.delivery,
+  });
+  const probeReady = params.canonicalProbeSnapshot?.ready === true;
+  const sourceReady = params.sourceRuntime.ready === true;
+  const contradictorySourceError = hasFreshContradictorySourceError({
+    sourceRuntime: params.sourceRuntime,
+    captureDiagnostics: params.externalSnapshot?.captureDiagnostics ?? null,
+    canonicalProbeSnapshot: params.canonicalProbeSnapshot ?? null,
+  });
+  const destinationError =
+    typeof destination?.error === "string" &&
+    destination.error.trim().length > 0
+      ? destination.error.trim()
+      : null;
+  const canonicalDestinationConnected =
+    probeReady || destination?.connected === true;
+  const canonicalTransportConnected =
+    sourceReady && canonicalDestinationConnected && !contradictorySourceError;
+  const canonicalPlaybackReady = probeReady;
+  const manifestStatus =
+    params.canonicalProbeSnapshot?.manifestStatus ??
+    (playbackUrl ? "unknown" : "missing");
+  const updatedAt =
+    params.canonicalProbeSnapshot?.updatedAt ??
+    destination?.startedAt ??
+    params.externalSnapshot?.updatedAt ??
+    null;
+  const lastError =
+    probeReady && !contradictorySourceError
+      ? null
+      : params.sourceRuntime.ready
+        ? (destinationError ??
+          params.canonicalProbeSnapshot?.lastError ??
+          (playbackUrl ? "delivery_disconnected" : "playback_unconfigured"))
+        : (params.sourceRuntime.degradedReason ??
+          destinationError ??
+          "source_unavailable");
+
+  if (!params.externalSnapshot || index < 0) {
+    return {
+      externalSnapshot: params.externalSnapshot,
+      canonicalStatus: {
+        sourceReady,
+        canonicalTransportConnected,
+        canonicalPlaybackReady,
+        manifestStatus,
+        lastError,
+        updatedAt,
+      },
+    };
+  }
+
+  const normalizedDestinations = params.externalSnapshot.destinations.map(
+    (candidate, candidateIndex) => {
+      if (candidateIndex !== index) {
+        return candidate;
+      }
+      return {
+        ...candidate,
+        connected: canonicalDestinationConnected,
+        transportHealthy:
+          sourceReady && probeReady && !contradictorySourceError,
+        playbackReady: canonicalPlaybackReady,
+        manifestStatus,
+        lastError,
+        error: lastError ?? undefined,
+        updatedAt: updatedAt ?? undefined,
+      };
+    },
+  );
+
+  return {
+    externalSnapshot: {
+      ...params.externalSnapshot,
+      destinations: normalizedDestinations,
+    },
+    canonicalStatus: {
+      sourceReady,
+      canonicalTransportConnected,
+      canonicalPlaybackReady,
+      manifestStatus,
+      lastError,
+      updatedAt,
+    },
+  };
+}
+
+export function buildStreamingStatusPayload(params: {
+  base: Record<string, unknown>;
+  externalSnapshot: ExternalRtmpStatusSnapshot | null;
+  canonicalProbeSnapshot?: StreamPlaybackProbeResult | null;
+  localHlsManifest?: HlsManifestSnapshot | null;
+  bridgeStats?:
+    | {
+        encoderFps?: number;
+        droppedFrames?: number;
+      }
+    | null
+    | undefined;
+  rendererHealth: ReturnType<typeof deriveBettingRendererHealth>;
+  captureStats?:
+    | {
+        clientConnected: boolean;
+        ffmpegRunning: boolean;
+      }
+    | null
+    | undefined;
+  persistedAuthorityState?: PersistedStreamingAuthorityState | null;
+  cloudflareLiveInputId?: string | null;
+}) {
+  const delivery =
+    params.externalSnapshot?.delivery ?? resolveStreamDeliveryInfo(process.env);
+  const sourceRuntime: StreamSourceRuntime = deriveStreamSourceRuntime({
+    externalStatusSnapshot: params.externalSnapshot,
+    externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+    rendererHealth: params.rendererHealth,
+    localHlsManifest: params.localHlsManifest,
+    captureStats: params.captureStats,
+    requireExternalWorker: REQUIRE_EXTERNAL_SOURCE_RUNTIME,
+  });
+  const normalizedCanonicalTruth = normalizeCanonicalStreamingTruth({
+    externalSnapshot: params.externalSnapshot,
+    delivery,
+    canonicalProbeSnapshot: params.canonicalProbeSnapshot ?? null,
+    sourceRuntime,
+    localHlsManifest: params.localHlsManifest,
+  });
+  const effectiveExternalSnapshot = normalizedCanonicalTruth.externalSnapshot;
+  const persistedAuthority = params.persistedAuthorityState ?? null;
+  const metrics = normalizeStreamingStatusMetrics({
+    externalSnapshot: effectiveExternalSnapshot,
+    bridgeStats: params.bridgeStats,
+  });
+  const hlsManifest = normalizeStreamingStatusManifest({
+    externalSnapshot: effectiveExternalSnapshot,
+    localHlsManifest: params.localHlsManifest,
+  });
+  const smoke = normalizeStreamingStatusSmoke({
+    externalSnapshot: effectiveExternalSnapshot,
+    deliveryModeFallback: delivery.mode,
+  });
+  const externalActive = asBoolean(effectiveExternalSnapshot?.active);
+  const externalFfmpegRunning = asBoolean(
+    effectiveExternalSnapshot?.ffmpegRunning,
+  );
+  const externalClientConnected = asBoolean(
+    effectiveExternalSnapshot?.clientConnected,
+  );
+  const activeCanonicalProvider =
+    persistedAuthority?.canonicalProviderState?.activeProvider ??
+    (delivery.mode === "self_hls"
+      ? "self_hls"
+      : normalizeStreamDestinationProvider(delivery.provider, "Cloudflare"));
+  const publicDestinations = redactIngestUrlsFromDestinations(
+    (effectiveExternalSnapshot?.destinations ??
+      params.base.destinations ??
+      []) as readonly unknown[],
+  );
+  const publicDelivery = redactIngestUrlFromDelivery(delivery);
+  const cloudflarePlaybackProbe =
+    activeCanonicalProvider === "cloudflare_stream" &&
+    params.canonicalProbeSnapshot
+      ? {
+          ready: params.canonicalProbeSnapshot.ready,
+          manifestStatus: params.canonicalProbeSnapshot.manifestStatus,
+          lastError: params.canonicalProbeSnapshot.lastError,
+          updatedAt: params.canonicalProbeSnapshot.updatedAt,
+        }
+      : null;
+  const publicCloudflareStatus = {
+    liveInputId: null,
+    lifecycle: null,
+    lastWebhook: null,
+    lastPlaybackProbe: cloudflarePlaybackProbe,
+    lastExternalTransportError: null,
+  };
+
+  return {
+    ...params.base,
+    running: externalActive ?? params.base.running,
+    bridgeActive: externalActive ?? params.base.bridgeActive,
+    ffmpegRunning: externalFfmpegRunning ?? params.base.ffmpegRunning,
+    clientConnected: externalClientConnected ?? params.base.clientConnected,
+    destinations: publicDestinations,
+    metrics,
+    captureFps: metrics.captureFps,
+    encodeFps: metrics.encodeFps,
+    droppedFrames: metrics.droppedFrames,
+    renderTick: metrics.renderTick,
+    duelStateTick: metrics.duelStateTick,
+    latestFrameAt: metrics.latestFrameAt,
+    latestRenderTickAt: metrics.latestRenderTickAt,
+    latestDuelStateTickAt: metrics.latestDuelStateTickAt,
+    latestVisualChangeAt: metrics.latestVisualChangeAt,
+    visualChangeAgeMs: metrics.visualChangeAgeMs,
+    hlsManifest,
+    hlsManifestUpdatedAt: hlsManifest.updatedAt,
+    hlsMediaSequence: hlsManifest.mediaSequence,
+    delivery: publicDelivery,
+    ingest: smoke.ingest,
+    smoke,
+    deliveryMode: publicDelivery.mode,
+    deliveryProvider: publicDelivery.provider ?? null,
+    playbackUrl: publicDelivery.playbackUrl ?? null,
+    rendererHealth: params.rendererHealth,
+    sourceRuntime,
+    canonicalStatus: normalizedCanonicalTruth.canonicalStatus,
+    authority: {
+      activeCanonicalProvider,
+      primaryHealthySince:
+        persistedAuthority?.canonicalProviderState?.primaryHealthySince ?? null,
+      updatedAt: persistedAuthority?.canonicalProviderState?.updatedAt ?? null,
+    },
+    cloudflare: publicCloudflareStatus,
+    captureDiagnostics: null,
+  };
+}
 
 function getInventorySnapshot(
   world: World,
@@ -167,6 +993,51 @@ async function getThoughtsSnapshot(
   return thoughts.slice(0, Math.max(1, Math.min(limit, 50)));
 }
 
+export function normalizeStreamingThoughtLimit(
+  rawLimit: string | undefined,
+): number {
+  const parsed = Number.parseInt(rawLimit || "20", 10);
+  if (!Number.isFinite(parsed)) {
+    return 20;
+  }
+  return Math.max(1, Math.min(parsed, 50));
+}
+
+export function allocateNextStreamingSseClientId(
+  currentNextClientId: number,
+  clients: ReadonlyMap<number, unknown>,
+): { clientId: number; nextClientId: number } {
+  const maxClientId = Number.MAX_SAFE_INTEGER;
+  let candidate = currentNextClientId;
+
+  for (let attempts = 0; attempts <= maxClientId; attempts += 1) {
+    if (!Number.isSafeInteger(candidate) || candidate <= 0) {
+      candidate = 1;
+    }
+    if (!clients.has(candidate)) {
+      const nextClientId = candidate >= maxClientId ? 1 : candidate + 1;
+      return { clientId: candidate, nextClientId };
+    }
+    candidate = candidate >= maxClientId ? 1 : candidate + 1;
+  }
+
+  throw new Error("Streaming SSE client id space exhausted");
+}
+
+export function buildStreamingResultNotFoundPayload(): {
+  error: "Not found";
+  message: "Resolved duel not found";
+} {
+  return {
+    error: "Not found",
+    message: "Resolved duel not found",
+  };
+}
+
+export function isValidStreamingResultDuelId(duelId: string): boolean {
+  return STREAMING_RESULT_DUEL_ID_PATTERN.test(duelId);
+}
+
 /**
  * Register streaming routes
  */
@@ -174,6 +1045,7 @@ export function registerStreamingRoutes(
   fastify: FastifyInstance,
   world: World,
 ): void {
+  ensureRateLimitDecorator(fastify);
   const sseClients = new Map<number, FastifyReply>();
   const replayFrames: StreamingSseFrame[] = [];
   let replayFramesTotalBytes = 0;
@@ -206,6 +1078,21 @@ export function registerStreamingRoutes(
   let lastBroadcastSeq = 0;
   let statePushInterval: ReturnType<typeof setInterval> | null = null;
   let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  const configuredStreamingDelivery = resolveStreamDeliveryInfo(process.env);
+  const canonicalPlaybackProbePoller = acquirePlaybackProbePoller(
+    configuredStreamingDelivery.mode === "external_hls"
+      ? (configuredStreamingDelivery.playbackUrl ??
+          configuredStreamingDelivery.llhlsUrl ??
+          configuredStreamingDelivery.hlsUrl)
+      : null,
+    {
+      intervalMs: Math.max(
+        2_000,
+        Math.min(EXTERNAL_RTMP_STATUS_MAX_AGE_MS, 5_000),
+      ),
+      timeoutMs: Math.min(EXTERNAL_RTMP_STATUS_MAX_AGE_MS, 4_000),
+    },
+  );
   const bettingRoutes = registerStreamingBettingRoutes({
     fastify,
     world,
@@ -228,6 +1115,26 @@ export function registerStreamingRoutes(
     externalStatusFile: EXTERNAL_RTMP_STATUS_FILE || null,
     externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
   });
+  const cloudflareLiveInputId =
+    process.env.STREAM_CLOUDFLARE_LIVE_INPUT_ID?.trim() || null;
+  const getStorageDb = () =>
+    (
+      world.getSystem("database") as
+        | {
+            getDb?: () => ReturnType<DatabaseSystem["getDb"]>;
+          }
+        | null
+        | undefined
+    )?.getDb?.() ?? null;
+  const loadPersistedStreamState = () =>
+    loadPersistedStreamingAuthorityState(getStorageDb());
+  const loadPersistedStreamStateSafely = async () => {
+    try {
+      return await loadPersistedStreamState();
+    } catch {
+      return null;
+    }
+  };
 
   const formatSseEvent = (event: string, data: string, id?: number): string => {
     const normalizedData = data.replace(/\n/g, "\ndata: ");
@@ -437,11 +1344,43 @@ export function registerStreamingRoutes(
     }
   };
 
+  const redactOracleProofFromCycle = (cycle: unknown): unknown => {
+    if (!cycle || typeof cycle !== "object") {
+      return cycle;
+    }
+
+    const {
+      duelKeyHex: _k,
+      duelEndTime: _e,
+      seed: _s,
+      replayHash: _r,
+      ...publicCycle
+    } = cycle as Record<string, unknown>;
+
+    return publicCycle;
+  };
+
+  const redactOracleProofFromState = <T extends { cycle: unknown }>(
+    state: T,
+  ): T =>
+    ({
+      ...state,
+      cycle: redactOracleProofFromCycle(state.cycle),
+    }) as T;
+
+  const rawSourceTimeEnabled = isRawSourceTimeEmissionEnabled();
+
   const getPublicStreamingState = (
     scheduler: NonNullable<ReturnType<typeof getStreamingDuelScheduler>>,
   ): ReturnType<typeof scheduler.getStreamingState> | null => {
     if (STREAMING_PUBLIC_DELAY_MS <= 0) {
-      return scheduler.getStreamingState();
+      const rawState = scheduler.getStreamingState();
+      const live = redactOracleProofFromState(rawState);
+      return attachRawSourceTime(live, Date.now(), {
+        stampEmittedAt: true,
+        enabled: rawSourceTimeEnabled,
+        sourceCycle: rawState.cycle,
+      });
     }
 
     // Keep delayed replay frames fresh for REST polling consumers
@@ -454,12 +1393,13 @@ export function registerStreamingRoutes(
       captureStreamingFrame(true);
     }
 
-    const delayed = parseReplayFrameState(getLatestEligibleReplayFrame());
+    const delayedFrame = getLatestEligibleReplayFrame();
+    const delayed = parseReplayFrameState(delayedFrame);
     if (!delayed) return null;
 
-    return {
+    const base = {
       type: "STREAMING_STATE_UPDATE" as const,
-      cycle: delayed.cycle as ReturnType<
+      cycle: redactOracleProofFromCycle(delayed.cycle) as ReturnType<
         typeof scheduler.getStreamingState
       >["cycle"],
       leaderboard: delayed.leaderboard as ReturnType<
@@ -471,6 +1411,13 @@ export function registerStreamingRoutes(
           ? delayed.cameraTarget
           : null,
     };
+    // For REST polling consumers the source-emission anchor is the
+    // replay frame's original `emittedAt` — the raw time at which the
+    // frame was captured upstream, not the time of this REST response.
+    return attachRawSourceTime(base, delayedFrame?.emittedAt ?? Date.now(), {
+      stampEmittedAt: true,
+      enabled: rawSourceTimeEnabled,
+    });
   };
 
   const captureStreamingFrame = (
@@ -479,7 +1426,8 @@ export function registerStreamingRoutes(
     const scheduler = getStreamingDuelScheduler();
     if (!scheduler) return null;
 
-    const state = scheduler.getStreamingState();
+    const rawState = scheduler.getStreamingState();
+    const state = redactOracleProofFromState(rawState);
     const serialized = JSON.stringify(state);
     if (
       !forceNewFrame &&
@@ -493,8 +1441,18 @@ export function registerStreamingRoutes(
     sequence += 1;
 
     const emittedAt = Date.now();
+    // When the raw-source-time contract is enabled, inject `sourceTimeline`
+    // into the cycle BEFORE serialization so SSE consumers see it inside
+    // `cycle` alongside the existing fields. `emittedAt` at the envelope
+    // root stays unconditional — it's part of the long-standing SSE
+    // envelope contract, so `stampEmittedAt: false` here.
+    const stateWithTimeline = attachRawSourceTime(state, emittedAt, {
+      stampEmittedAt: false,
+      enabled: rawSourceTimeEnabled,
+      sourceCycle: rawState.cycle,
+    });
     const payload = JSON.stringify({
-      ...state,
+      ...stateWithTimeline,
       type: "STREAMING_STATE_UPDATE",
       seq: sequence,
       emittedAt,
@@ -570,6 +1528,7 @@ export function registerStreamingRoutes(
     for (const clientId of [...sseClients.keys()]) {
       removeSseClient(clientId, "shutdown");
     }
+    canonicalPlaybackProbePoller?.release();
     bettingRoutes.close();
     done();
   });
@@ -578,7 +1537,7 @@ export function registerStreamingRoutes(
   fastify.get(
     "/api/streaming/state",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
       const scheduler = getStreamingDuelScheduler();
@@ -604,7 +1563,7 @@ export function registerStreamingRoutes(
   fastify.get(
     "/api/streaming/metrics",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
       const bettingMetrics = bettingRoutes.getMetrics();
@@ -676,7 +1635,7 @@ export function registerStreamingRoutes(
   }>(
     "/api/streaming/state/events",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
     },
     async (request, reply) => {
       if (sseClients.size >= STREAMING_SSE_MAX_CLIENTS) {
@@ -699,7 +1658,12 @@ export function registerStreamingRoutes(
       raw.flushHeaders?.();
       raw.write("retry: 2000\n\n");
 
-      const clientId = nextClientId++;
+      const allocation = allocateNextStreamingSseClientId(
+        nextClientId,
+        sseClients,
+      );
+      const clientId = allocation.clientId;
+      nextClientId = allocation.nextClientId;
       sseClients.set(clientId, reply);
       sseMetrics.totalConnected += 1;
       sseMetrics.peakConnected = Math.max(
@@ -806,9 +1770,15 @@ export function registerStreamingRoutes(
   fastify.get(
     "/api/streaming/duel-context",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        await STREAMING_STATUS_CODEQL_LIMITER.consume(_request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
       const scheduler = getStreamingDuelScheduler();
       if (!scheduler) {
         return reply.status(503).send({
@@ -870,9 +1840,15 @@ export function registerStreamingRoutes(
   }>(
     "/api/streaming/agent/:characterId/monologues",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
     },
     async (request, reply) => {
+      try {
+        await STREAMING_STATUS_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
       if (STREAMING_PUBLIC_DELAY_MS > 0) {
         return reply.send({
           characterId: request.params.characterId,
@@ -881,7 +1857,7 @@ export function registerStreamingRoutes(
           delayed: true,
         });
       }
-      const limit = Number.parseInt(request.query.limit || "20", 10);
+      const limit = normalizeStreamingThoughtLimit(request.query.limit);
       const thoughts = await getThoughtsSnapshot(
         request.params.characterId,
         limit,
@@ -899,9 +1875,15 @@ export function registerStreamingRoutes(
   }>(
     "/api/streaming/agent/:characterId/inventory",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
     },
     async (request, reply) => {
+      try {
+        await STREAMING_STATUS_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
       if (STREAMING_PUBLIC_DELAY_MS > 0) {
         return reply.send({
           characterId: request.params.characterId,
@@ -923,9 +1905,15 @@ export function registerStreamingRoutes(
   fastify.get(
     "/api/streaming/leaderboard",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        await STREAMING_STATUS_CODEQL_LIMITER.consume(_request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
       const scheduler = getStreamingDuelScheduler();
 
       if (!scheduler) {
@@ -953,9 +1941,15 @@ export function registerStreamingRoutes(
   }>(
     "/api/streaming/leaderboard/details",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
     },
     async (request, reply) => {
+      try {
+        await STREAMING_STATUS_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
       const scheduler = getStreamingDuelScheduler();
 
       if (!scheduler) {
@@ -987,7 +1981,21 @@ export function registerStreamingRoutes(
           : Number.POSITIVE_INFINITY;
       const recentDuels = scheduler
         .getRecentDuels(historyLimit)
-        .filter((duel) => duel.finishedAt <= cutoff);
+        .filter((duel) => duel.finishedAt <= cutoff)
+        // Strip oracle-proof fields. They are persisted on RecentDuelEntry
+        // for the keeper-only /api/streaming/results/:duelId catch-up path
+        // (bearer-auth). Leaking them on this public, unauthenticated handler
+        // would defeat that auth boundary — a caller could harvest proofs
+        // from this endpoint and skip the bearer check entirely.
+        .map(
+          ({
+            duelKeyHex: _k,
+            duelEndTime: _e,
+            seed: _s,
+            replayHash: _r,
+            ...publicEntry
+          }) => publicEntry,
+        );
       const delayedUpdatedAt =
         STREAMING_PUBLIC_DELAY_MS > 0
           ? (getLatestEligibleReplayFrame()?.emittedAt ?? Date.now())
@@ -1002,15 +2010,143 @@ export function registerStreamingRoutes(
     },
   );
 
+  // Authoritative per-duel oracle result lookup for the hyperbet keeper.
+  //
+  // When the keeper misses a live `duel_ended` event (for example a restart
+  // window), the bundle is stuck at LOCKED with no path forward because
+  // Solana resolution requires the deterministic proof material
+  // (duelKeyHex + seed + replayHash) that only arrive on that event. This
+  // endpoint lets the keeper reconstruct the same authorized report payload
+  // from the durable streaming_duel_history row.
+  //
+  // Bearer-auth requires HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN (matches the
+  // hyperbet keeper). The endpoint intentionally never falls back to the
+  // general betting feed token because it returns settlement proof material.
+  const authorizeResultsLookup = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => {
+    const env = process.env as Record<string, string | undefined>;
+    const resolution = resolveOracleProofAccessToken(env);
+    const requiredToken = resolution.token;
+
+    if (!requiredToken) {
+      return reply.status(503).send({
+        error: "Service unavailable",
+        message: "Oracle proof auth token is not configured",
+      });
+    }
+
+    const token = extractBettingFeedToken({
+      authorizationHeader: request.headers.authorization,
+    });
+    if (hasValidBettingFeedToken(requiredToken, token)) {
+      return;
+    }
+
+    return reply.status(401).send({
+      error: "Unauthorized",
+      message: "Missing or invalid oracle proof token",
+    });
+  };
+
+  fastify.get<{
+    Params: { duelId: string };
+  }>(
+    "/api/streaming/results/:duelId",
+    {
+      config: { rateLimit: AUTHENTICATED_RESULTS_RATE_LIMIT },
+      preHandler: authorizeResultsLookup,
+    },
+    async (request, reply) => {
+      const duelId = request.params.duelId?.trim();
+      if (!duelId) {
+        return reply.status(400).send({
+          error: "Bad request",
+          message: "duelId is required",
+        });
+      }
+      if (!isValidStreamingResultDuelId(duelId)) {
+        return reply.status(400).send({
+          error: "Bad request",
+          message: "Invalid duelId format",
+        });
+      }
+
+      const db = getStorageDb();
+      if (!db) {
+        return reply.status(503).send({
+          error: "Service unavailable",
+          message: "Database is not available",
+        });
+      }
+
+      const { streamingDuelHistory } = await import("../database/schema.js");
+      const { eq } = await import("drizzle-orm");
+
+      const rows = await db
+        .select()
+        .from(streamingDuelHistory)
+        .where(eq(streamingDuelHistory.duelId, duelId))
+        .limit(1);
+      const row = rows[0];
+
+      if (!row) {
+        return reply.status(404).send(buildStreamingResultNotFoundPayload());
+      }
+
+      // Audit trail: oracle-proof material (duelKeyHex, seed, replayHash) is
+      // settlement-grade data. Hash the caller IP so logs can correlate access
+      // patterns without storing direct keeper network identifiers.
+      fastify.log.info(
+        {
+          duelId: row.duelId,
+          cycleId: row.cycleId,
+          callerIpHash: hashAuditValue(request.ip),
+        },
+        "[streaming] oracle-proof retrieval",
+      );
+
+      // Legacy rows written before migration 0055 may not carry the oracle
+      // proof fields. Callers must handle this by waiting and retrying —
+      // the current live duel will write fresh rows with the full proof.
+      // The 409 response intentionally does NOT leak the schema-migration
+      // number; that's an internal detail.
+      if (!row.seed || !row.replayHash || !row.duelKeyHex) {
+        return reply.status(409).send({
+          error: "Incomplete proof",
+          message: "Oracle proof is not available for this duel.",
+          duelId: row.duelId,
+          cycleId: row.cycleId,
+        });
+      }
+
+      return reply.send({
+        duelId: row.duelId,
+        cycleId: row.cycleId,
+        duelKeyHex: row.duelKeyHex,
+        duelEndTime: row.duelEndTime,
+        seed: row.seed,
+        replayHash: row.replayHash,
+        winnerId: row.winnerId,
+        winnerName: row.winnerName,
+        loserId: row.loserId,
+        loserName: row.loserName,
+        winReason: row.winReason,
+        damageWinner: row.damageWinner,
+        damageLoser: row.damageLoser,
+        finishedAt: row.finishedAt,
+      });
+    },
+  );
+
   // Get streaming configuration
   fastify.get(
     "/api/streaming/config",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: STREAMING_STATUS_RATE_LIMIT },
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
-      const betUrl =
-        (process.env.STREAMING_PUBLIC_BET_URL || "").trim() || null;
       return reply.send({
         enabled: process.env.STREAMING_DUEL_ENABLED !== "false",
         cycleDuration: STREAMING_TIMING.CYCLE_DURATION,
@@ -1022,49 +2158,72 @@ export function registerStreamingRoutes(
         publicDelayMs: STREAMING_PUBLIC_DELAY_MS,
         publicDelayDefaultMs: STREAMING_PUBLIC_DELAY_DEFAULT_MS,
         publicDelayOverridden: STREAMING_PUBLIC_DELAY_OVERRIDDEN,
-        wsUrl: process.env.PUBLIC_WS_URL || getDefaultPublicWsUrl(),
-        betUrl,
-        bettingBridgeEnabled: process.env.DUEL_BETTING_ENABLED === "true",
-      });
-    },
-  );
-
-  /**
-   * Public betting CTA for stream overlays (no secrets).
-   * Set STREAMING_PUBLIC_BET_URL to your prediction-market / wallet-connect page.
-   */
-  fastify.get(
-    "/api/streaming/betting",
-    {
-      config: { rateLimit: false },
-    },
-    async (_request: FastifyRequest, reply: FastifyReply) => {
-      const betUrl =
-        (process.env.STREAMING_PUBLIC_BET_URL || "").trim() || null;
-      return reply.send({
-        betUrl,
-        bettingBridgeEnabled: process.env.DUEL_BETTING_ENABLED === "true",
-        hint:
-          betUrl != null
-            ? "Wagers typically lock when the countdown starts. Pick a side before the bell."
-            : "Set STREAMING_PUBLIC_BET_URL on the server to show a bet link on stream.",
+        wsUrl: process.env.PUBLIC_WS_URL || "ws://localhost:5555/ws",
       });
     },
   );
 
   // Get RTMP bridge status
+  //
+  // Rate limiting layers: global @fastify/rate-limit plugin (100/min per IP,
+  // http-server.ts), per-route config.rateLimit (120/min), and
+  // codeqlStatusRateLimitPreHandler which invokes rate-limiter-flexible in
+  // the exact pattern CodeQL's RouteHandlerLimitedByRateLimiterFlexible
+  // class recognizes.
   fastify.get(
     "/api/streaming/rtmp/status",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: { max: 120, timeWindow: "1 minute" } },
+      preHandler: codeqlStatusRateLimitPreHandler,
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
+      const persistedAuthorityState = await loadPersistedStreamStateSafely();
       const externalSnapshot = await loadExternalRtmpStatusSnapshot(
         EXTERNAL_RTMP_STATUS_FILE || null,
         EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
       );
+      const canonicalProbeSnapshot = canonicalPlaybackProbePoller
+        ? await canonicalPlaybackProbePoller
+            .refresh()
+            .then(() => canonicalPlaybackProbePoller.getSnapshot())
+        : null;
+      const localHlsManifest = readLocalHlsManifestSnapshot(process.env);
       if (externalSnapshot) {
-        return reply.send(externalSnapshot);
+        const rendererHealth = deriveBettingRendererHealth(
+          getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
+          {
+            externalStatusSnapshot: externalSnapshot,
+            externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+            localHlsManifest,
+            captureStats: {
+              clientConnected: externalSnapshot.clientConnected === true,
+              ffmpegRunning: externalSnapshot.ffmpegRunning === true,
+            },
+          },
+        );
+
+        return reply.send(
+          buildStreamingStatusPayload({
+            base: {
+              running: externalSnapshot.active === true,
+              bridgeActive: externalSnapshot.active === true,
+              ffmpegRunning: externalSnapshot.ffmpegRunning === true,
+              clientConnected: externalSnapshot.clientConnected === true,
+              destinations: externalSnapshot.destinations,
+              stats: externalSnapshot.stats,
+            },
+            externalSnapshot,
+            canonicalProbeSnapshot,
+            localHlsManifest,
+            rendererHealth,
+            persistedAuthorityState,
+            cloudflareLiveInputId,
+            captureStats: {
+              clientConnected: externalSnapshot.clientConnected === true,
+              ffmpegRunning: externalSnapshot.ffmpegRunning === true,
+            },
+          }),
+        );
       }
 
       try {
@@ -1077,28 +2236,45 @@ export function registerStreamingRoutes(
         }
         const status = bridge.getStatus();
         const stats = bridge.getStats();
-
-        return reply.send({
-          ...status,
-          stats: {
-            bytesReceived: stats.bytesReceived,
-            bytesReceivedMB: (stats.bytesReceived / 1024 / 1024).toFixed(2),
-            uptimeSeconds: Math.floor(stats.uptime / 1000),
-            destinations: stats.destinations,
-            healthy: stats.healthy,
-            droppedFrames: stats.droppedFrames,
-            backpressured: stats.backpressured,
-            spectators: stats.spectators,
-            processMemory: stats.processMemory,
+        const rendererHealth = deriveBettingRendererHealth(
+          getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
+          {
+            externalStatusSnapshot: externalSnapshot,
+            externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+            localHlsManifest,
           },
-          rendererHealth: deriveBettingRendererHealth(
-            getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
-            {
-              externalStatusSnapshot: externalSnapshot,
-              externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+        );
+
+        return reply.send(
+          buildStreamingStatusPayload({
+            base: {
+              ...status,
+              stats: {
+                bytesReceived: stats.bytesReceived,
+                bytesReceivedMB: (stats.bytesReceived / 1024 / 1024).toFixed(2),
+                uptimeSeconds: Math.floor(stats.uptime / 1000),
+                destinations: stats.destinations,
+                healthy: stats.healthy,
+                droppedFrames: stats.droppedFrames,
+                encoderFps: null,
+                backpressured: stats.backpressured,
+                spectators: stats.spectators,
+                processMemory: stats.processMemory,
+              },
             },
-          ),
-        });
+            externalSnapshot,
+            canonicalProbeSnapshot,
+            localHlsManifest,
+            bridgeStats: stats,
+            rendererHealth,
+            persistedAuthorityState,
+            cloudflareLiveInputId,
+            captureStats: {
+              clientConnected: status.clientConnected,
+              ffmpegRunning: status.ffmpegRunning,
+            },
+          }),
+        );
       } catch {
         return reply.status(503).send({
           error: "RTMP bridge not initialized",
@@ -1109,33 +2285,101 @@ export function registerStreamingRoutes(
   );
 
   // Get stream capture status (headless browser → HLS pipeline)
+  // Same CodeQL-visible rate-limiter-flexible preHandler as /rtmp/status;
+  // see comment there for the rationale.
   fastify.get(
     "/api/streaming/capture/status",
     {
-      config: { rateLimit: false },
+      config: { rateLimit: { max: 120, timeWindow: "1 minute" } },
+      preHandler: codeqlStatusRateLimitPreHandler,
     },
     async (_request: FastifyRequest, reply: FastifyReply) => {
       try {
+        const persistedAuthorityState = await loadPersistedStreamStateSafely();
         const capture = getStreamCapture();
+        const localHlsManifest = readLocalHlsManifestSnapshot(process.env);
         const externalSnapshot = await loadExternalRtmpStatusSnapshot(
           EXTERNAL_RTMP_STATUS_FILE || null,
           EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
           { allowStale: true },
         );
-        return reply.send({
-          ...capture.getStats(),
-          rendererHealth: deriveBettingRendererHealth(
-            getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
-            {
-              externalStatusSnapshot: externalSnapshot,
-              externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
-            },
-          ),
-        });
+        const canonicalProbeSnapshot = canonicalPlaybackProbePoller
+          ? await canonicalPlaybackProbePoller
+              .refresh()
+              .then(() => canonicalPlaybackProbePoller.getSnapshot())
+          : null;
+        const captureStats = capture.getStats();
+        const rendererHealth = deriveBettingRendererHealth(
+          getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
+          {
+            externalStatusSnapshot: externalSnapshot,
+            externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+            localHlsManifest,
+            captureStats,
+          },
+        );
+        return reply.send(
+          buildStreamingStatusPayload({
+            base: captureStats,
+            externalSnapshot,
+            canonicalProbeSnapshot,
+            localHlsManifest,
+            rendererHealth,
+            persistedAuthorityState,
+            cloudflareLiveInputId,
+            captureStats,
+          }),
+        );
       } catch {
         return reply.status(503).send({
           error: "Stream capture not initialized",
           message: "The stream capture pipeline has not been started",
+        });
+      }
+    },
+  );
+
+  fastify.get(
+    "/api/streaming/capture/smoke",
+    {
+      preHandler: fastify.rateLimit(STREAMING_STATUS_RATE_LIMIT),
+    },
+    async (_request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        const externalSnapshot = await loadExternalRtmpStatusSnapshot(
+          EXTERNAL_RTMP_STATUS_FILE || null,
+          EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+          { allowStale: true },
+        );
+        const delivery =
+          externalSnapshot?.delivery ?? resolveStreamDeliveryInfo(process.env);
+        return reply.send({
+          ...normalizeStreamingStatusSmoke({
+            externalSnapshot,
+            deliveryModeFallback: delivery.mode,
+          }),
+          sourceRuntime: deriveStreamSourceRuntime({
+            externalStatusSnapshot: externalSnapshot,
+            externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+            rendererHealth: deriveBettingRendererHealth(
+              getStreamingDuelScheduler()?.getCurrentCycle() ?? null,
+              {
+                externalStatusSnapshot: externalSnapshot,
+                externalStatusMaxAgeMs: EXTERNAL_RTMP_STATUS_MAX_AGE_MS,
+                localHlsManifest: readLocalHlsManifestSnapshot(process.env),
+                captureStats: getStreamCapture().getStats(),
+              },
+            ),
+            localHlsManifest: readLocalHlsManifestSnapshot(process.env),
+            captureStats: getStreamCapture().getStats(),
+            requireExternalWorker: REQUIRE_EXTERNAL_SOURCE_RUNTIME,
+          }),
+        });
+      } catch {
+        return reply.status(503).send({
+          error: "Stream capture smoke unavailable",
+          message:
+            "The stream capture smoke summary is not available right now",
         });
       }
     },

--- a/packages/server/src/startup/__tests__/agent-routes.test.ts
+++ b/packages/server/src/startup/__tests__/agent-routes.test.ts
@@ -9,27 +9,53 @@ type MappingRow = {
   updatedAt?: Date;
 };
 
-const agentMappingsTable = {
-  __table: "agentMappings",
-  accountId: "accountId",
-  agentId: "agentId",
-  agentName: "agentName",
-  characterId: "characterId",
+type ThoughtRow = {
+  characterId: string;
+  content: string;
+  decisionPath?: string | null;
+  timestamp: number;
+  type: string;
 };
 
-const usersTable = {
-  __table: "users",
-  id: "id",
-};
-
-const charactersTable = {
-  __table: "characters",
-  accountId: "accountId",
-  id: "id",
-};
+const {
+  agentMappingsTable,
+  agentThoughtsTable,
+  charactersTable,
+  serverNetworkState,
+  usersTable,
+} = vi.hoisted(() => ({
+  agentMappingsTable: {
+    __table: "agentMappings",
+    accountId: "accountId",
+    agentId: "agentId",
+    agentName: "agentName",
+    characterId: "characterId",
+  },
+  agentThoughtsTable: {
+    __table: "agentThoughts",
+    characterId: "characterId",
+    content: "content",
+    decisionPath: "decisionPath",
+    timestamp: "timestamp",
+    type: "type",
+  },
+  usersTable: {
+    __table: "users",
+    id: "id",
+  },
+  charactersTable: {
+    __table: "characters",
+    accountId: "accountId",
+    id: "id",
+  },
+  serverNetworkState: {
+    agentThoughts: new Map<string, ThoughtRow[]>(),
+  },
+}));
 
 vi.mock("../../database/schema.js", () => ({
   agentMappings: agentMappingsTable,
+  agentThoughts: agentThoughtsTable,
   characters: charactersTable,
   users: usersTable,
 }));
@@ -38,7 +64,10 @@ vi.mock("drizzle-orm", async (importOriginal) => {
   const actual = await importOriginal<typeof import("drizzle-orm")>();
   return {
     ...actual,
+    and: (...conditions: unknown[]) => ({ op: "and", conditions }),
+    desc: (column: string) => ({ direction: "desc", column }),
     eq: (column: string, value: unknown) => ({ column, value }),
+    gt: (column: string, value: unknown) => ({ column, value, op: "gt" }),
   };
 });
 
@@ -47,7 +76,24 @@ vi.mock("../../eliza/index.js", () => ({
   getRunningAgents: () => new Map(),
 }));
 
+vi.mock("../../systems/ServerNetwork/index.js", () => ({
+  ServerNetwork: serverNetworkState,
+}));
+
 import { registerAgentRoutes } from "../routes/agent-routes";
+import { createJWT } from "../../shared/utils";
+
+async function withAuth<T extends Record<string, unknown>>(
+  userId: string,
+  request: T,
+): Promise<T & { headers: { authorization: string } }> {
+  return {
+    ...request,
+    headers: {
+      authorization: `Bearer ${await createJWT({ userId })}`,
+    },
+  };
+}
 
 function createReplyRecorder() {
   return {
@@ -66,23 +112,35 @@ function createReplyRecorder() {
 
 function createFastifyRecorder() {
   const routes = new Map<string, Function>();
+  const pickHandler = (args: unknown[]): Function => {
+    const handler = args[args.length - 1];
+    if (typeof handler !== "function") {
+      throw new Error("Expected route handler");
+    }
+    return handler;
+  };
   const fastify = {
-    delete(path: string, handler: Function) {
-      routes.set(`DELETE ${path}`, handler);
+    delete(path: string, ...args: unknown[]) {
+      routes.set(`DELETE ${path}`, pickHandler(args));
       return this;
     },
-    get(path: string, handler: Function) {
-      routes.set(`GET ${path}`, handler);
+    get(path: string, ...args: unknown[]) {
+      routes.set(`GET ${path}`, pickHandler(args));
       return this;
     },
-    post(path: string, handler: Function) {
-      routes.set(`POST ${path}`, handler);
+    post(path: string, ...args: unknown[]) {
+      routes.set(`POST ${path}`, pickHandler(args));
       return this;
     },
-    put(path: string, handler: Function) {
-      routes.set(`PUT ${path}`, handler);
+    patch(path: string, ...args: unknown[]) {
+      routes.set(`PATCH ${path}`, pickHandler(args));
       return this;
     },
+    put(path: string, ...args: unknown[]) {
+      routes.set(`PUT ${path}`, pickHandler(args));
+      return this;
+    },
+    rateLimit: () => async () => {},
   };
 
   return {
@@ -91,9 +149,13 @@ function createFastifyRecorder() {
   };
 }
 
-function createMockDatabase(initialMappings: MappingRow[]) {
+function createMockDatabase(
+  initialMappings: MappingRow[],
+  initialThoughts: ThoughtRow[] = [],
+) {
   const state = {
     mappings: [...initialMappings],
+    thoughts: [...initialThoughts],
   };
 
   const db = {
@@ -144,28 +206,106 @@ function createMockDatabase(initialMappings: MappingRow[]) {
       },
     },
     select: () => ({
-      from: (table: { __table: string }) => ({
-        where: async (condition: {
-          column: keyof MappingRow;
-          value: unknown;
-        }) => {
-          if (table.__table === "agentMappings") {
-            return state.mappings.filter(
-              (mapping) => mapping[condition.column] === condition.value,
+      from: (table: { __table: string }) => {
+        const applyCondition = (
+          row: MappingRow | ThoughtRow,
+          condition: {
+            column?: string;
+            conditions?: Array<{
+              column?: string;
+              op?: string;
+              value?: unknown;
+            }>;
+            op?: string;
+            value?: unknown;
+          },
+        ): boolean => {
+          if (condition.op === "and" && condition.conditions) {
+            return condition.conditions.every((entry) =>
+              applyCondition(row, entry),
             );
           }
-          return [];
-        },
-      }),
+          if (!condition.column) {
+            return true;
+          }
+          const value = (row as Record<string, unknown>)[condition.column];
+          if (condition.op === "gt") {
+            return Number(value) > Number(condition.value);
+          }
+          return value === condition.value;
+        };
+        const filterRows = (condition: {
+          column?: string;
+          conditions?: Array<{ column?: string; op?: string; value?: unknown }>;
+          op?: string;
+          value?: unknown;
+        }) => {
+          if (table.__table === "agentMappings") {
+            return state.mappings.filter((mapping) =>
+              applyCondition(mapping, condition),
+            );
+          }
+          if (table.__table === "agentThoughts") {
+            return state.thoughts.filter((thought) =>
+              applyCondition(thought, condition),
+            );
+          }
+          return [] as Array<MappingRow | ThoughtRow>;
+        };
+        return {
+          where: (condition: {
+            column?: string;
+            conditions?: Array<{
+              column?: string;
+              op?: string;
+              value?: unknown;
+            }>;
+            op?: string;
+            value?: unknown;
+          }) => {
+            const rows = filterRows(condition);
+            return {
+              then: (
+                onfulfilled: (value: Array<MappingRow | ThoughtRow>) => unknown,
+              ) => Promise.resolve(onfulfilled(rows)),
+              orderBy: (order?: {
+                column?: string;
+                direction?: "desc" | "asc";
+              }) => {
+                const sorted = [...rows];
+                if (order?.column) {
+                  sorted.sort((left, right) => {
+                    const leftValue = (left as Record<string, unknown>)[
+                      order.column!
+                    ];
+                    const rightValue = (right as Record<string, unknown>)[
+                      order.column!
+                    ];
+                    const direction = order.direction === "desc" ? -1 : 1;
+                    if (leftValue === rightValue) return 0;
+                    return leftValue! > rightValue! ? direction : -direction;
+                  });
+                }
+                return {
+                  limit: async (count: number) => sorted.slice(0, count),
+                };
+              },
+            };
+          },
+        };
+      },
     }),
   };
 
   return { db, state };
 }
 
-function setupRoutes(initialMappings: MappingRow[]) {
+function setupRoutes(
+  initialMappings: MappingRow[],
+  initialThoughts: ThoughtRow[] = [],
+) {
   const { fastify, routes } = createFastifyRecorder();
-  const { db, state } = createMockDatabase(initialMappings);
+  const { db, state } = createMockDatabase(initialMappings, initialThoughts);
   const world = {
     getSystem: (name: string) => (name === "database" ? { db } : undefined),
   };
@@ -175,6 +315,7 @@ function setupRoutes(initialMappings: MappingRow[]) {
   return {
     deleteMapping: routes.get("DELETE /api/agents/mappings/:agentId")!,
     getMapping: routes.get("GET /api/agents/mapping/:agentId")!,
+    getThoughts: routes.get("GET /api/agents/:agentId/thoughts")!,
     listMappings: routes.get("GET /api/agents/mappings/:accountId")!,
     saveMapping: routes.get("POST /api/agents/mappings")!,
     state,
@@ -186,10 +327,79 @@ describe("agent route mapping cache", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    serverNetworkState.agentThoughts.clear();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("requires authentication for account-scoped mapping routes", async () => {
+    const { deleteMapping, listMappings, saveMapping } = setupRoutes([
+      {
+        agentId: "agent-1",
+        accountId: "account-old",
+        characterId: "character-1",
+        agentName: "Alpha",
+      },
+    ]);
+
+    const listReply = createReplyRecorder();
+    await listMappings(
+      { params: { accountId: "account-old" } } as never,
+      listReply as never,
+    );
+    expect(listReply.statusCode).toBe(401);
+
+    const saveReply = createReplyRecorder();
+    await saveMapping(
+      {
+        body: {
+          agentId: "agent-1",
+          accountId: "account-old",
+          characterId: "character-1",
+          agentName: "Alpha",
+        },
+      } as never,
+      saveReply as never,
+    );
+    expect(saveReply.statusCode).toBe(401);
+
+    const deleteReply = createReplyRecorder();
+    await deleteMapping(
+      { params: { agentId: "agent-1" } } as never,
+      deleteReply as never,
+    );
+    expect(deleteReply.statusCode).toBe(401);
+  });
+
+  it("rejects cross-account mapping access", async () => {
+    const { deleteMapping, listMappings } = setupRoutes([
+      {
+        agentId: "agent-1",
+        accountId: "account-owner",
+        characterId: "character-1",
+        agentName: "Alpha",
+      },
+    ]);
+
+    const listReply = createReplyRecorder();
+    await listMappings(
+      (await withAuth("account-other", {
+        params: { accountId: "account-owner" },
+      })) as never,
+      listReply as never,
+    );
+    expect(listReply.statusCode).toBe(403);
+
+    const deleteReply = createReplyRecorder();
+    await deleteMapping(
+      (await withAuth("account-other", {
+        params: { agentId: "agent-1" },
+      })) as never,
+      deleteReply as never,
+    );
+    expect(deleteReply.statusCode).toBe(403);
   });
 
   it("invalidates old and new account mapping lists when ownership changes", async () => {
@@ -204,25 +414,27 @@ describe("agent route mapping cache", () => {
 
     const firstListReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       firstListReply as never,
     );
     expect(firstListReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-1"]),
+      count: 2,
       success: true,
     });
 
     const saveReply = createReplyRecorder();
     await saveMapping(
-      {
+      (await withAuth("account-new", {
         body: {
           agentId: "agent-1",
           accountId: "account-new",
           characterId: "character-2",
           agentName: "Beta",
         },
-      } as never,
+      })) as never,
       saveReply as never,
     );
     expect(saveReply.payload).toMatchObject({ success: true });
@@ -237,7 +449,9 @@ describe("agent route mapping cache", () => {
 
     const oldAccountReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       oldAccountReply as never,
     );
     expect(oldAccountReply.payload).toMatchObject({
@@ -248,12 +462,14 @@ describe("agent route mapping cache", () => {
 
     const newAccountReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-new" } } as never,
+      (await withAuth("account-new", {
+        params: { accountId: "account-new" },
+      })) as never,
       newAccountReply as never,
     );
     expect(newAccountReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-2"]),
+      count: 2,
       success: true,
     });
 
@@ -282,12 +498,14 @@ describe("agent route mapping cache", () => {
 
     const listReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       listReply as never,
     );
     expect(listReply.payload).toMatchObject({
-      agentIds: ["agent-1"],
-      count: 1,
+      agentIds: expect.arrayContaining(["agent-1", "character-1"]),
+      count: 2,
       success: true,
     });
 
@@ -303,7 +521,9 @@ describe("agent route mapping cache", () => {
 
     const deleteReply = createReplyRecorder();
     await deleteMapping(
-      { params: { agentId: "agent-1" } } as never,
+      (await withAuth("account-old", {
+        params: { agentId: "agent-1" },
+      })) as never,
       deleteReply as never,
     );
     expect(deleteReply.payload).toMatchObject({ success: true });
@@ -321,7 +541,9 @@ describe("agent route mapping cache", () => {
 
     const deletedListReply = createReplyRecorder();
     await listMappings(
-      { params: { accountId: "account-old" } } as never,
+      (await withAuth("account-old", {
+        params: { accountId: "account-old" },
+      })) as never,
       deletedListReply as never,
     );
     expect(deletedListReply.payload).toMatchObject({
@@ -343,14 +565,14 @@ describe("agent route mapping cache", () => {
 
     const saveReply = createReplyRecorder();
     await saveMapping(
-      {
+      (await withAuth("account-new", {
         body: {
           agentId: "agent-2",
           accountId: "account-new",
           characterId: "character-2",
           agentName: "Gamma",
         },
-      } as never,
+      })) as never,
       saveReply as never,
     );
     expect(saveReply.payload).toMatchObject({ success: true });
@@ -367,6 +589,54 @@ describe("agent route mapping cache", () => {
       agentName: "Gamma",
       characterId: "character-2",
       success: true,
+    });
+  });
+
+  it("defaults invalid thoughts limit before cold-start DB hydrate", async () => {
+    const { getThoughts } = setupRoutes(
+      [
+        {
+          agentId: "agent-1",
+          accountId: "account-1",
+          characterId: "character-1",
+          agentName: "Alpha",
+        },
+      ],
+      [
+        {
+          characterId: "character-1",
+          content: "fresh thought",
+          decisionPath: null,
+          timestamp: 200,
+          type: "reasoning",
+        },
+        {
+          characterId: "character-1",
+          content: "older thought",
+          decisionPath: null,
+          timestamp: 100,
+          type: "reasoning",
+        },
+      ],
+    );
+
+    const reply = createReplyRecorder();
+    await getThoughts(
+      {
+        params: { agentId: "agent-1" },
+        query: { limit: "foo" },
+      } as never,
+      reply as never,
+    );
+
+    expect(reply.statusCode).toBe(200);
+    expect(reply.payload).toMatchObject({
+      success: true,
+      count: 2,
+      thoughts: [
+        expect.objectContaining({ content: "fresh thought", timestamp: 200 }),
+        expect.objectContaining({ content: "older thought", timestamp: 100 }),
+      ],
     });
   });
 });

--- a/packages/server/src/startup/http-server.ts
+++ b/packages/server/src/startup/http-server.ts
@@ -33,7 +33,11 @@ import Fastify, {
   type FastifyReply,
 } from "fastify";
 import fs from "fs-extra";
+import { timingSafeEqual } from "node:crypto";
+import { Readable } from "node:stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import path from "path";
+import { RateLimiterMemory } from "rate-limiter-flexible";
 import type { ServerConfig } from "./config.js";
 import {
   getDefaultElizaOsApiUrl,
@@ -48,12 +52,60 @@ import {
   enforceSameSiteCookies,
 } from "../middleware/csrf.js";
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function derivePagesProjectHost(hostname: string): string | null {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized.endsWith(".pages.dev")) {
+    return null;
+  }
+
+  const segments = normalized.split(".");
+  if (segments.length < 3) {
+    return null;
+  }
+
+  return segments.slice(-3).join(".");
+}
+
+export function buildPagesPreviewOriginPatterns(
+  origin: string | null | undefined,
+): RegExp[] {
+  const trimmed = origin?.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return [];
+    }
+
+    const projectHost = derivePagesProjectHost(parsed.hostname);
+    if (!projectHost) {
+      return [];
+    }
+
+    return [
+      new RegExp(
+        `^${escapeRegExp(parsed.protocol)}//(?:[a-z0-9-]+\\.)+${escapeRegExp(projectHost)}$`,
+        "i",
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * SECURITY: Validate Origin header for state-changing requests.
  * This provides additional protection against cross-origin attacks
  * even though we don't use cookies (which would make CSRF a non-issue).
  */
-function createOriginValidator(allowedOrigins: (string | RegExp)[]) {
+export function createOriginValidator(allowedOrigins: (string | RegExp)[]) {
   return function validateOrigin(origin: string | undefined): boolean {
     if (!origin) return true; // Server-to-server or same-origin requests may not have Origin
 
@@ -74,6 +126,16 @@ type PublicRootInfo = {
   assetsPath: string;
   source: "server-public" | "client-dist";
 };
+
+const PUBLIC_DEBUG_CODEQL_LIMITER = new RateLimiterMemory({
+  points: 240,
+  duration: 60,
+});
+
+const GAME_ASSETS_CODEQL_LIMITER = new RateLimiterMemory({
+  points: 240,
+  duration: 60,
+});
 
 async function resolvePublicRoot(
   config: ServerConfig,
@@ -148,6 +210,11 @@ export async function createHttpServer(
     process.env.PUBLIC_APP_URL ||
     getDefaultPublicAppUrl();
   const serverUrl = process.env.SERVER_URL || `http://localhost:${config.port}`;
+  const derivedPagesPreviewOrigins = [
+    ...buildPagesPreviewOriginPatterns(clientUrl),
+    ...buildPagesPreviewOriginPatterns(process.env.PUBLIC_APP_URL),
+    ...buildPagesPreviewOriginPatterns(process.env.CLIENT_URL),
+  ];
 
   const allowedOrigins = [
     // Production domains (HTTPS)
@@ -162,8 +229,6 @@ export async function createHttpServer(
     "https://hyperscape.pages.dev",
     "https://hyperscape-betting.pages.dev",
     "https://hyperbet.pages.dev",
-    "https://hyperbet-solana.pages.dev",
-    "https://hyperbet-bsc.pages.dev",
     "https://hyperscape-production.up.railway.app",
     "https://api.hyperbet.win",
     "https://bsc-api.hyperbet.win",
@@ -171,8 +236,6 @@ export async function createHttpServer(
     "http://hyperscape.pages.dev",
     "http://hyperscape-betting.pages.dev",
     "http://hyperbet.pages.dev",
-    "http://hyperbet-solana.pages.dev",
-    "http://hyperbet-bsc.pages.dev",
     // Development (from env vars or defaults)
     elizaOSUrl, // ElizaOS API
     clientUrl, // Game Client
@@ -183,8 +246,6 @@ export async function createHttpServer(
     /^https?:\/\/.+\.hyperbet\.win$/, // hyperbet.win subdomains
     /^https?:\/\/.+\.hyperscape-betting\.pages\.dev$/, // Existing Hyperbet Pages preview deployments
     /^https?:\/\/.+\.hyperbet\.pages\.dev$/, // Hyperbet Pages preview deployments
-    /^https?:\/\/.+\.hyperbet-solana\.pages\.dev$/, // Hyperbet Solana preview deployments
-    /^https?:\/\/.+\.hyperbet-bsc\.pages\.dev$/, // Hyperbet BSC preview deployments
     /^https?:\/\/(www\.)?hyperscape\.gg$/, // hyperscape.gg apex and www
     /^https?:\/\/.+\.hyperscape\.gg$/, // hyperscape.gg subdomains
     /^https?:\/\/.+\.hyperscape\.pages\.dev$/, // Cloudflare Pages preview deployments
@@ -192,6 +253,7 @@ export async function createHttpServer(
     /^https:\/\/.+\.warpcast\.com$/,
     /^https:\/\/.+\.privy\.io$/,
     /^https:\/\/.+\.up\.railway\.app$/,
+    ...derivedPagesPreviewOrigins,
   ];
 
   // Add custom domain from env if set
@@ -222,6 +284,23 @@ export async function createHttpServer(
   // SECURITY: Add Origin validation for state-changing requests
   // This provides defense-in-depth against cross-origin attacks
   const isValidOrigin = createOriginValidator(allowedOrigins);
+  const isLocalhostOrigin = (origin: string): boolean => {
+    // Parse the origin and check the hostname is literally localhost/loopback.
+    // A substring match like origin.includes("localhost") is exploitable by
+    // origins such as `http://evil-localhost.com` or `https://localhost.evil`.
+    try {
+      const parsed = new URL(origin);
+      const host = parsed.hostname;
+      return (
+        host === "localhost" ||
+        host === "127.0.0.1" ||
+        host === "[::1]" ||
+        host === "::1"
+      );
+    } catch {
+      return false;
+    }
+  };
   fastify.addHook("preHandler", async (request, reply) => {
     // Only check state-changing methods
     if (["POST", "PUT", "DELETE", "PATCH"].includes(request.method)) {
@@ -232,7 +311,7 @@ export async function createHttpServer(
       // - Health check endpoints
       if (
         origin &&
-        !origin.includes("localhost") &&
+        !isLocalhostOrigin(origin) &&
         !request.url.startsWith("/health") &&
         !isValidOrigin(origin)
       ) {
@@ -272,25 +351,35 @@ export async function createHttpServer(
             ? header[0]
             : undefined;
 
-      // Disable origin lock check to allow direct client requests (fixes 403 Forbidden)
-      // if (!presented || presented !== cloudflareOriginSecret) {
-      //   return reply.status(403).send({
-      //     error: "Forbidden",
-      //     message: "Origin not authorized",
-      //   });
-      // }
+      const expected = Buffer.from(cloudflareOriginSecret);
+      const actual = presented ? Buffer.from(presented) : null;
+      const authorized =
+        actual != null &&
+        actual.length === expected.length &&
+        timingSafeEqual(actual, expected);
+
+      if (!authorized) {
+        return reply.status(403).send({
+          error: "Forbidden",
+          message: "Origin not authorized",
+        });
+      }
     });
     console.log("[HTTP] ✅ Cloudflare origin secret enforcement enabled");
   }
 
-  // Configure rate limiting for production security
+  // Always register the rate-limit plugin so route-level limiters are wired.
+  // The global limiter remains policy-controlled for dev/test ergonomics.
   if (isRateLimitEnabled()) {
     await fastify.register(rateLimit, getGlobalRateLimit());
     console.log(
       "[HTTP] ✅ Rate limiting enabled (100 requests/min per IP globally)",
     );
   } else {
-    console.log("[HTTP] ⚠️  Rate limiting disabled (development mode)");
+    await fastify.register(rateLimit, { global: false });
+    console.log(
+      "[HTTP] ⚠️  Global rate limiting disabled (development mode); route-level rate limiters remain available",
+    );
   }
 
   // Configure CSRF protection for state-changing requests
@@ -359,30 +448,50 @@ export async function createHttpServer(
     reply.status(500).send({ error: "Internal server error" });
   });
 
-  // Debug endpoint to see public directory contents
-  fastify.get("/debug/public", async (_req, reply) => {
-    const publicDir = path.join(config.__dirname, "public");
-    const assetsDir = path.join(publicDir, "assets");
-    let publicContents: string[] = [];
-    let assetsContents: string[] = [];
-    try {
-      publicContents = await fs.readdir(publicDir);
-    } catch (e) {
-      publicContents = [`ERROR: ${e}`];
-    }
-    try {
-      assetsContents = await fs.readdir(assetsDir);
-    } catch (e) {
-      assetsContents = [`ERROR: ${e}`];
-    }
-    return reply.send({
-      publicDir,
-      assetsDir,
-      publicContents,
-      assetsContents: assetsContents.slice(0, 20), // Limit to 20 items
-      configDirname: config.__dirname,
-    });
-  });
+  const allowPublicDebugRoute =
+    process.env.NODE_ENV !== "production" ||
+    process.env.ENABLE_PUBLIC_DEBUG_ROUTE === "true";
+  if (allowPublicDebugRoute) {
+    ensureRateLimitDecorator(fastify);
+    // Debug endpoint to see public directory contents
+    fastify.get(
+      "/debug/public",
+      {
+        preHandler: fastify.rateLimit({
+          max: 240,
+          timeWindow: "1 minute",
+        }),
+      },
+      async (request, reply) => {
+        try {
+          await PUBLIC_DEBUG_CODEQL_LIMITER.consume(request.ip);
+        } catch {
+          return reply.code(429).send({ error: "Too Many Requests" });
+        }
+        const publicDir = path.join(config.__dirname, "public");
+        const assetsDir = path.join(publicDir, "assets");
+        let publicContents: string[] = [];
+        let assetsContents: string[] = [];
+        try {
+          publicContents = await fs.readdir(publicDir);
+        } catch (e) {
+          publicContents = [`ERROR: ${e}`];
+        }
+        try {
+          assetsContents = await fs.readdir(assetsDir);
+        } catch (e) {
+          assetsContents = [`ERROR: ${e}`];
+        }
+        return reply.send({
+          publicDir,
+          assetsDir,
+          publicContents,
+          assetsContents: assetsContents.slice(0, 20), // Limit to 20 items
+          configDirname: config.__dirname,
+        });
+      },
+    );
+  }
 
   // SPA catch-all route - serve index.html for any unmatched routes
   // This must be registered AFTER all other routes
@@ -558,15 +667,24 @@ async function registerStaticFiles(
       : null;
 
   if (gameAssetsRoot) {
-    await fastify.register(statics, {
-      root: gameAssetsRoot,
-      prefix: "/game-assets/",
-      decorateReply: false,
-      setHeaders: (res, filePath) => {
-        setAssetHeaders(res, filePath);
-      },
-    });
-    console.log(`[HTTP] ✅ Registered /game-assets/ → ${gameAssetsRoot}`);
+    const gameAssetsFallbackUrl =
+      process.env["GAME_ASSETS_FALLBACK_URL"]?.trim() || null;
+    if (gameAssetsFallbackUrl) {
+      registerGameAssetsRoute(fastify, gameAssetsRoot, gameAssetsFallbackUrl);
+      console.log(
+        `[HTTP] ✅ Registered /game-assets/ → ${gameAssetsRoot} (fallback: ${gameAssetsFallbackUrl})`,
+      );
+    } else {
+      await fastify.register(statics, {
+        root: gameAssetsRoot,
+        prefix: "/game-assets/",
+        decorateReply: false,
+        setHeaders: (res, filePath) => {
+          setAssetHeaders(res, filePath);
+        },
+      });
+      console.log(`[HTTP] ✅ Registered /game-assets/ → ${gameAssetsRoot}`);
+    }
 
     const legacyAssetsRoot = hasCachedAssetsDir
       ? config.assetsDir
@@ -768,6 +886,199 @@ function setAssetHeaders(
   // browser) can fetch assets served from :5555 without triggering CORP blocks.
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+}
+
+export function normalizeGameAssetPath(rawPath: string): string | null {
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(rawPath);
+  } catch {
+    return null;
+  }
+
+  if (decodedPath.includes("\0")) {
+    return null;
+  }
+
+  const normalizedPath = path.posix.normalize(decodedPath).replace(/^\/+/, "");
+  if (
+    normalizedPath.length === 0 ||
+    normalizedPath === "." ||
+    normalizedPath === ".." ||
+    normalizedPath.startsWith("../")
+  ) {
+    return null;
+  }
+  return normalizedPath;
+}
+
+function copyHeaderIfPresent(
+  reply: FastifyReply,
+  upstreamHeaders: Headers,
+  headerName: string,
+): void {
+  const value = upstreamHeaders.get(headerName);
+  if (value) {
+    reply.header(headerName, value);
+  }
+}
+
+const GAME_ASSET_PROXY_RATE_LIMIT = {
+  max: 240,
+  timeWindow: "1 minute",
+} as const;
+type RateLimitedFastify = FastifyInstance & {
+  rateLimit: NonNullable<FastifyInstance["rateLimit"]>;
+};
+
+function ensureRateLimitDecorator(
+  fastify: FastifyInstance,
+): asserts fastify is RateLimitedFastify {
+  if (typeof fastify.rateLimit === "function") {
+    return;
+  }
+  throw new Error(
+    "HTTP routes require @fastify/rate-limit to be registered before route setup",
+  );
+}
+
+function buildGameAssetFallbackUrl(
+  fallbackBaseUrl: string,
+  normalizedPath: string,
+): URL | null {
+  if (!/^[A-Za-z0-9/_\-.]+$/.test(normalizedPath)) {
+    return null;
+  }
+
+  try {
+    const baseUrl = new URL(
+      fallbackBaseUrl.endsWith("/") ? fallbackBaseUrl : `${fallbackBaseUrl}/`,
+    );
+    if (baseUrl.protocol !== "http:" && baseUrl.protocol !== "https:") {
+      return null;
+    }
+
+    const nextUrl = new URL(baseUrl.toString());
+    nextUrl.pathname = path.posix.join(baseUrl.pathname, normalizedPath);
+    nextUrl.search = "";
+    nextUrl.hash = "";
+    return nextUrl;
+  } catch {
+    return null;
+  }
+}
+
+function registerGameAssetsRoute(
+  fastify: FastifyInstance,
+  gameAssetsRoot: string,
+  fallbackBaseUrl: string,
+): void {
+  const resolvedRoot = path.resolve(gameAssetsRoot);
+  const fallbackRoot = fallbackBaseUrl.endsWith("/")
+    ? fallbackBaseUrl
+    : `${fallbackBaseUrl}/`;
+  ensureRateLimitDecorator(fastify);
+  fastify.route({
+    method: ["GET", "HEAD"],
+    url: "/game-assets/*",
+    handler: async (request, reply) => {
+      try {
+        await GAME_ASSETS_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
+      const rawPath = String((request.params as { "*": string })["*"] || "");
+      const normalizedPath = normalizeGameAssetPath(rawPath);
+      if (!normalizedPath) {
+        return reply.code(400).send({ error: "Invalid asset path" });
+      }
+
+      const localAssetPath = path.resolve(resolvedRoot, normalizedPath);
+      if (
+        localAssetPath === resolvedRoot ||
+        !localAssetPath.startsWith(`${resolvedRoot}${path.sep}`)
+      ) {
+        return reply.code(400).send({ error: "Invalid asset path" });
+      }
+
+      if (await fs.pathExists(localAssetPath)) {
+        setAssetHeaders(reply.raw, localAssetPath);
+        if (request.method === "HEAD") {
+          const stats = await fs.stat(localAssetPath);
+          reply.header("Content-Length", String(stats.size));
+          return reply.code(200).send();
+        }
+        return reply.send(fs.createReadStream(localAssetPath));
+      }
+
+      if (normalizedPath.startsWith("manifests/")) {
+        return reply.code(404).send({ error: "Asset not found" });
+      }
+
+      const fallbackUrl = buildGameAssetFallbackUrl(
+        fallbackRoot,
+        normalizedPath,
+      );
+      if (!fallbackUrl) {
+        return reply.code(400).send({ error: "Invalid asset path" });
+      }
+
+      console.warn(
+        `[HTTP] Local asset miss for /game-assets/${normalizedPath}; proxying to ${fallbackUrl.toString()}`,
+      );
+
+      let upstreamResponse: Response;
+      try {
+        upstreamResponse = await fetch(fallbackUrl, {
+          method: request.method,
+          redirect: "follow",
+          signal: AbortSignal.timeout(15_000),
+        });
+      } catch (error) {
+        const errorName = error instanceof Error ? error.name : "";
+        return reply
+          .code(
+            errorName === "TimeoutError" || errorName === "AbortError"
+              ? 504
+              : 502,
+          )
+          .send({
+            error:
+              errorName === "TimeoutError" || errorName === "AbortError"
+                ? "Asset fallback timed out"
+                : "Asset fallback failed",
+          });
+      }
+      if (!upstreamResponse.ok) {
+        return reply
+          .code(upstreamResponse.status)
+          .send({ error: "Asset not found" });
+      }
+
+      setAssetHeaders(reply.raw, normalizedPath);
+      copyHeaderIfPresent(reply, upstreamResponse.headers, "content-type");
+      copyHeaderIfPresent(reply, upstreamResponse.headers, "content-length");
+      copyHeaderIfPresent(reply, upstreamResponse.headers, "etag");
+      copyHeaderIfPresent(reply, upstreamResponse.headers, "last-modified");
+      copyHeaderIfPresent(reply, upstreamResponse.headers, "accept-ranges");
+
+      if (request.method === "HEAD") {
+        return reply.code(200).send();
+      }
+
+      if (!upstreamResponse.body) {
+        return reply
+          .code(502)
+          .send({ error: "Asset fallback returned no body" });
+      }
+
+      return reply.send(
+        Readable.fromWeb(
+          upstreamResponse.body as unknown as NodeReadableStream,
+        ),
+      );
+    },
+  });
 }
 
 /**

--- a/packages/server/src/startup/routes/agent-routes.ts
+++ b/packages/server/src/startup/routes/agent-routes.ts
@@ -17,6 +17,7 @@
 
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import type { World } from "@hyperscape/shared";
+import { RateLimiterMemory } from "rate-limiter-flexible";
 import { getDefaultPublicWsUrl } from "../../shared/public-ws-url.js";
 import { createJWT } from "../../shared/utils.js";
 import {
@@ -31,6 +32,14 @@ import type {
 // Command acknowledgment delay (ms) - allows plugin to process before response
 const COMMAND_ACK_DELAY_MS = 100;
 const AGENT_MAPPING_CACHE_TTL_MS = 5000;
+const AGENT_MANAGEMENT_RATE_LIMIT = {
+  max: 60,
+  timeWindow: "1 minute",
+};
+const AGENT_MANAGEMENT_CODEQL_LIMITER = new RateLimiterMemory({
+  points: 60,
+  duration: 60,
+});
 
 type AgentRouteCharacterRecord = {
   accountId: string;
@@ -49,6 +58,20 @@ type AgentMappingRecord = {
 type CachedValue<T> = {
   expiresAt: number;
   value: T;
+};
+
+function normalizeThoughtsLimit(rawLimit: string | undefined): number {
+  const parsed = Number.parseInt(rawLimit || "100", 10);
+  if (!Number.isFinite(parsed)) {
+    return 100;
+  }
+  return Math.max(1, Math.min(parsed, 200));
+}
+
+type AgentRouteSelectQuery = PromiseLike<unknown[]> & {
+  orderBy: (order: unknown) => {
+    limit: (count: number) => Promise<unknown[]>;
+  };
 };
 
 type AgentRouteDb = {
@@ -75,7 +98,7 @@ type AgentRouteDb = {
   };
   select: (fields?: unknown) => {
     from: (table: unknown) => {
-      where: (condition: unknown) => Promise<unknown[]>;
+      where: (condition: unknown) => AgentRouteSelectQuery;
     };
   };
   update: (table: unknown) => {
@@ -107,11 +130,10 @@ export function registerAgentRoutes(
   world: World,
 ): void {
   console.log("[AgentRoutes] Registering agent credential routes...");
-
   const getVerifiedUserId = async (
     request: FastifyRequest,
   ): Promise<string | null> => {
-    const authHeader = request.headers.authorization;
+    const authHeader = request.headers?.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return null;
     }
@@ -141,6 +163,29 @@ export function registerAgentRoutes(
     return null;
   };
 
+  const authorizeAccountAccess = async (
+    request: FastifyRequest,
+    reply: FastifyReply,
+    accountId: string,
+  ): Promise<boolean> => {
+    const verifiedUserId = await getVerifiedUserId(request);
+    if (!verifiedUserId) {
+      await reply.status(401).send({
+        success: false,
+        error: "Unauthorized",
+      });
+      return false;
+    }
+    if (verifiedUserId !== accountId) {
+      await reply.status(403).send({
+        success: false,
+        error: "Forbidden",
+      });
+      return false;
+    }
+    return true;
+  };
+
   const agentMappingByIdCache = new Map<
     string,
     CachedValue<AgentMappingRecord | null>
@@ -160,6 +205,23 @@ export function registerAgentRoutes(
     const databaseSystem = getDatabaseSystem();
     return databaseSystem?.db ?? databaseSystem?.getDb?.() ?? null;
   };
+
+  const withAgentManagementRateLimit =
+    (
+      handler: (
+        request: FastifyRequest,
+        reply: FastifyReply,
+      ) => Promise<unknown>,
+    ) =>
+    async (request: FastifyRequest, reply: FastifyReply): Promise<unknown> => {
+      try {
+        await AGENT_MANAGEMENT_CODEQL_LIMITER.consume(request.ip);
+      } catch {
+        return reply.code(429).send({ error: "Too Many Requests" });
+      }
+
+      return handler(request, reply);
+    };
 
   const getCachedValue = <T>(
     cache: Map<string, CachedValue<T>>,
@@ -417,95 +479,107 @@ export function registerAgentRoutes(
    *   serverUrl: "ws://localhost:5556/ws"
    * }
    */
-  fastify.post("/api/agents/credentials", async (request, reply) => {
-    try {
-      const body = request.body as {
-        characterId: string;
-        accountId: string;
-      };
+  fastify.post(
+    "/api/agents/credentials",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const body = request.body as {
+          characterId: string;
+          accountId: string;
+        };
 
-      if (!body.characterId || !body.accountId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required fields: characterId, accountId",
+        if (!body.characterId || !body.accountId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required fields: characterId, accountId",
+          });
+        }
+
+        const { characterId, accountId } = body;
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Generating credentials for:", {
+          characterId,
+          accountId,
         });
-      }
 
-      const { characterId, accountId } = body;
+        // Verify character exists and belongs to this account
+        const databaseSystem = world.getSystem("database") as
+          | {
+              getCharactersAsync: (
+                accountId: string,
+              ) => Promise<Array<{ id: string; name: string }>>;
+            }
+          | undefined;
 
-      console.log("[AgentRoutes] Generating credentials for:", {
-        characterId,
-        accountId,
-      });
+        if (!databaseSystem) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
 
-      // Verify character exists and belongs to this account
-      const databaseSystem = world.getSystem("database") as
-        | {
-            getCharactersAsync: (
-              accountId: string,
-            ) => Promise<Array<{ id: string; name: string }>>;
-          }
-        | undefined;
+        const characters = await databaseSystem.getCharactersAsync(accountId);
+        const character = characters.find((c) => c.id === characterId);
 
-      if (!databaseSystem) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
+        if (!character) {
+          console.warn(
+            `[AgentRoutes] Character ${characterId} not found or not owned by ${accountId}`,
+          );
+          return reply.status(403).send({
+            success: false,
+            error: "Character not found or access denied",
+          });
+        }
+
+        console.log("[AgentRoutes] Character verified:", character.name);
+
+        // Generate 7-day Hyperscape JWT
+        const authToken = await createJWT({
+          userId: accountId,
+          characterId: characterId,
+          isAgent: true,
+        });
+
+        console.log(
+          `[AgentRoutes] ✅ Generated 7-day JWT for agent: ${character.name}`,
+        );
+
+        // Get server URL from environment or use default
+        const serverUrl =
+          process.env.HYPERSCAPE_SERVER_URL ||
+          process.env.PUBLIC_WS_URL ||
+          getDefaultPublicWsUrl();
+
+        return reply.send({
+          success: true,
+          authToken,
+          characterId,
+          serverUrl,
+          message: `Credentials generated for ${character.name} (expires in 7 days)`,
+        });
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to generate credentials:",
+          error,
+        );
+
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to generate credentials",
         });
       }
-
-      const characters = await databaseSystem.getCharactersAsync(accountId);
-      const character = characters.find((c) => c.id === characterId);
-
-      if (!character) {
-        console.warn(
-          `[AgentRoutes] Character ${characterId} not found or not owned by ${accountId}`,
-        );
-        return reply.status(403).send({
-          success: false,
-          error: "Character not found or access denied",
-        });
-      }
-
-      console.log("[AgentRoutes] Character verified:", character.name);
-
-      // Generate 7-day Hyperscape JWT
-      const authToken = await createJWT({
-        userId: accountId,
-        characterId: characterId,
-        isAgent: true,
-      });
-
-      console.log(
-        `[AgentRoutes] ✅ Generated 7-day JWT for agent: ${character.name}`,
-      );
-
-      // Get server URL from environment or use default
-      const serverUrl =
-        process.env.HYPERSCAPE_SERVER_URL ||
-        process.env.PUBLIC_WS_URL ||
-        getDefaultPublicWsUrl();
-
-      return reply.send({
-        success: true,
-        authToken,
-        characterId,
-        serverUrl,
-        message: `Credentials generated for ${character.name} (expires in 7 days)`,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to generate credentials:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to generate credentials",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/wallet-auth
@@ -565,35 +639,7 @@ export function registerAgentRoutes(
       const accountId = `wallet:${walletType}:${walletAddress}`;
 
       // Get database access
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              select: (fields?: unknown) => {
-                from: (table: unknown) => {
-                  where: (condition: unknown) => Promise<unknown[]>;
-                };
-              };
-              insert: (table: unknown) => {
-                values: (values: Record<string, unknown>) => {
-                  onConflictDoUpdate: (config: {
-                    target: unknown;
-                    set: unknown;
-                  }) => Promise<unknown>;
-                } & Promise<unknown>;
-              };
-              query: {
-                characters: {
-                  findFirst: (opts: {
-                    where: (
-                      chars: { accountId: unknown },
-                      ops: { eq: (a: unknown, b: string) => unknown },
-                    ) => unknown;
-                  }) => Promise<{ id: string; name: string } | null>;
-                };
-              };
-            };
-          }
-        | undefined;
+      const databaseSystem = getDatabaseSystem();
 
       if (!databaseSystem?.db) {
         return reply.status(500).send({
@@ -640,7 +686,15 @@ export function registerAgentRoutes(
           createdAt: Date.now(),
         });
 
-        character = { id: characterId, name: agentName };
+        character = {
+          id: characterId,
+          accountId,
+          name: agentName,
+        };
+      }
+
+      if (!character) {
+        throw new Error("Failed to resolve character after wallet auth");
       }
 
       // Generate 7-day JWT
@@ -741,72 +795,84 @@ export function registerAgentRoutes(
    *   agentIds: ["agent-id-1", "agent-id-2", ...]
    * }
    */
-  fastify.get("/api/agents/mappings/:accountId", async (request, reply) => {
-    try {
-      const params = request.params as { accountId: string };
-      const { accountId } = params;
+  fastify.get(
+    "/api/agents/mappings/:accountId",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const params = request.params as { accountId: string };
+        const { accountId } = params;
 
-      if (!accountId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required parameter: accountId",
+        if (!accountId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required parameter: accountId",
+          });
+        }
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Fetching agent mappings for:", accountId);
+
+        const db = getDatabaseDb();
+        if (!db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
+
+        const mappings = await listAgentMappingsByAccount(db, accountId);
+
+        const agentIds = mappings.flatMap((m) => [m.agentId, m.characterId]);
+
+        // Model duel agents are public streaming participants; include them in
+        // mapping lookup so dashboards can discover live duel roster.
+        const { getRunningAgents } = await import("../../eliza/index.js");
+        const runningModelAgents = getRunningAgents() as Map<
+          string,
+          {
+            characterId: string;
+          }
+        >;
+
+        for (const [, runningAgent] of runningModelAgents) {
+          if (runningAgent.characterId) {
+            agentIds.push(runningAgent.characterId);
+          }
+        }
+
+        const uniqueAgentIds = Array.from(new Set(agentIds));
+
+        console.log(
+          `[AgentRoutes] Found ${uniqueAgentIds.length} agent(s) for ${accountId}`,
+        );
+
+        return reply.send({
+          success: true,
+          agentIds: uniqueAgentIds,
+          count: uniqueAgentIds.length,
         });
-      }
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to fetch agent mappings:",
+          error,
+        );
 
-      console.log("[AgentRoutes] Fetching agent mappings for:", accountId);
-
-      const db = getDatabaseDb();
-      if (!db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to fetch agent mappings",
         });
       }
-
-      const mappings = await listAgentMappingsByAccount(db, accountId);
-
-      const agentIds = mappings.flatMap((m) => [m.agentId, m.characterId]);
-
-      // Model duel agents are public streaming participants; include them in
-      // mapping lookup so dashboards can discover live duel roster.
-      const { getRunningAgents } = await import("../../eliza/index.js");
-      const runningModelAgents = getRunningAgents() as Map<
-        string,
-        {
-          characterId: string;
-        }
-      >;
-
-      for (const [, runningAgent] of runningModelAgents) {
-        if (runningAgent.characterId) {
-          agentIds.push(runningAgent.characterId);
-        }
-      }
-
-      const uniqueAgentIds = Array.from(new Set(agentIds));
-
-      console.log(
-        `[AgentRoutes] Found ${uniqueAgentIds.length} agent(s) for ${accountId}`,
-      );
-
-      return reply.send({
-        success: true,
-        agentIds: uniqueAgentIds,
-        count: uniqueAgentIds.length,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to fetch agent mappings:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to fetch agent mappings",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/mappings
@@ -827,121 +893,130 @@ export function registerAgentRoutes(
    *   success: true
    * }
    */
-  fastify.post("/api/agents/mappings", async (request, reply) => {
-    try {
-      const body = request.body as {
-        agentId: string;
-        accountId: string;
-        characterId: string;
-        agentName: string;
-      };
+  fastify.post(
+    "/api/agents/mappings",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const body = request.body as {
+          agentId: string;
+          accountId: string;
+          characterId: string;
+          agentName: string;
+        };
 
-      if (
-        !body.agentId ||
-        !body.accountId ||
-        !body.characterId ||
-        !body.agentName
-      ) {
-        return reply.status(400).send({
-          success: false,
-          error:
-            "Missing required fields: agentId, accountId, characterId, agentName",
+        if (
+          !body.agentId ||
+          !body.accountId ||
+          !body.characterId ||
+          !body.agentName
+        ) {
+          return reply.status(400).send({
+            success: false,
+            error:
+              "Missing required fields: agentId, accountId, characterId, agentName",
+          });
+        }
+
+        const { agentId, accountId, characterId, agentName } = body;
+        if (!(await authorizeAccountAccess(request, reply, accountId))) {
+          return;
+        }
+
+        console.log("[AgentRoutes] Saving agent mapping:", {
+          agentId,
+          accountId,
+          characterId,
+          agentName,
         });
-      }
 
-      const { agentId, accountId, characterId, agentName } = body;
-
-      console.log("[AgentRoutes] Saving agent mapping:", {
-        agentId,
-        accountId,
-        characterId,
-        agentName,
-      });
-
-      // Get database system
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              insert: (table: unknown) => {
-                values: (values: unknown) => {
-                  onConflictDoUpdate: (config: {
-                    target: unknown;
-                    set: unknown;
-                  }) => Promise<unknown>;
+        // Get database system
+        const databaseSystem = world.getSystem("database") as
+          | {
+              db: {
+                insert: (table: unknown) => {
+                  values: (values: unknown) => {
+                    onConflictDoUpdate: (config: {
+                      target: unknown;
+                      set: unknown;
+                    }) => Promise<unknown>;
+                  };
                 };
               };
-            };
-          }
-        | undefined;
+            }
+          | undefined;
 
-      if (!databaseSystem || !databaseSystem.db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
-        return reply.status(500).send({
-          success: false,
-          error: "Database system not available",
-        });
-      }
+        if (!databaseSystem || !databaseSystem.db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
 
-      // Import schema
-      const { agentMappings } = await import("../../database/schema.js");
-      const existingMapping = await getAgentMappingById(
-        databaseSystem.db as AgentRouteDb,
-        agentId,
-        true,
-      );
+        // Import schema
+        const { agentMappings } = await import("../../database/schema.js");
+        const existingMapping = await getAgentMappingById(
+          databaseSystem.db as AgentRouteDb,
+          agentId,
+          true,
+        );
 
-      // Insert or update mapping
-      await databaseSystem.db
-        .insert(agentMappings)
-        .values({
+        // Insert or update mapping
+        await databaseSystem.db
+          .insert(agentMappings)
+          .values({
+            agentId,
+            accountId,
+            characterId,
+            agentName,
+            streamingDuelEnabled: true,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: agentMappings.agentId,
+            set: {
+              accountId,
+              characterId,
+              agentName,
+              updatedAt: new Date(),
+            },
+          });
+        invalidateAgentMappingCache(
+          agentId,
+          existingMapping?.accountId,
+          accountId,
+        );
+        primeAgentMappingCache({
           agentId,
           accountId,
           characterId,
           agentName,
           streamingDuelEnabled: true,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .onConflictDoUpdate({
-          target: agentMappings.agentId,
-          set: {
-            accountId,
-            characterId,
-            agentName,
-            updatedAt: new Date(),
-          },
         });
-      invalidateAgentMappingCache(
-        agentId,
-        existingMapping?.accountId,
-        accountId,
-      );
-      primeAgentMappingCache({
-        agentId,
-        accountId,
-        characterId,
-        agentName,
-        streamingDuelEnabled: true,
-      });
 
-      console.log(`[AgentRoutes] ✅ Agent mapping saved for: ${agentName}`);
+        console.log(`[AgentRoutes] ✅ Agent mapping saved for: ${agentName}`);
 
-      return reply.send({
-        success: true,
-        message: `Agent mapping saved for ${agentName}`,
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to save agent mapping:", error);
+        return reply.send({
+          success: true,
+          message: `Agent mapping saved for ${agentName}`,
+        });
+      } catch (error) {
+        console.error("[AgentRoutes] ❌ Failed to save agent mapping:", error);
 
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to save agent mapping",
-      });
-    }
-  });
+        return reply.status(500).send({
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to save agent mapping",
+        });
+      }
+    }),
+  );
 
   /**
    * GET /api/agents/mapping/:agentId
@@ -1150,54 +1225,81 @@ export function registerAgentRoutes(
    *   message: "Agent mapping deleted"
    * }
    */
-  fastify.delete("/api/agents/mappings/:agentId", async (request, reply) => {
-    try {
-      const params = request.params as { agentId: string };
-      const { agentId } = params;
+  fastify.delete(
+    "/api/agents/mappings/:agentId",
+    {
+      config: { rateLimit: AGENT_MANAGEMENT_RATE_LIMIT },
+    },
+    withAgentManagementRateLimit(async (request, reply) => {
+      try {
+        const params = request.params as { agentId: string };
+        const { agentId } = params;
 
-      if (!agentId) {
-        return reply.status(400).send({
-          success: false,
-          error: "Missing required parameter: agentId",
+        if (!agentId) {
+          return reply.status(400).send({
+            success: false,
+            error: "Missing required parameter: agentId",
+          });
+        }
+
+        console.log("[AgentRoutes] Deleting agent mapping for:", agentId);
+
+        const db = getDatabaseDb();
+        if (!db) {
+          console.error("[AgentRoutes] DatabaseSystem not available");
+          return reply.status(500).send({
+            success: false,
+            error: "Database system not available",
+          });
+        }
+
+        const existingMapping = await getAgentMappingById(db, agentId, true);
+        if (!existingMapping) {
+          return reply.status(404).send({
+            success: false,
+            error: "Agent mapping not found",
+          });
+        }
+        if (
+          !(await authorizeAccountAccess(
+            request,
+            reply,
+            existingMapping.accountId,
+          ))
+        ) {
+          return;
+        }
+
+        const { agentMappings } = await schemaModulePromise;
+        const { eq } = await drizzleModulePromise;
+
+        await db
+          .delete(agentMappings)
+          .where(eq(agentMappings.agentId, agentId));
+        invalidateAgentMappingCache(agentId, existingMapping?.accountId);
+
+        console.log(`[AgentRoutes] ✅ Agent mapping deleted for: ${agentId}`);
+
+        return reply.send({
+          success: true,
+          message: "Agent mapping deleted",
         });
-      }
+      } catch (error) {
+        console.error(
+          "[AgentRoutes] ❌ Failed to delete agent mapping:",
+          error,
+        );
 
-      console.log("[AgentRoutes] Deleting agent mapping for:", agentId);
-
-      const db = getDatabaseDb();
-      if (!db) {
-        console.error("[AgentRoutes] DatabaseSystem not available");
         return reply.status(500).send({
           success: false,
-          error: "Database system not available",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to delete agent mapping",
         });
       }
-
-      const existingMapping = await getAgentMappingById(db, agentId, true);
-      const { agentMappings } = await schemaModulePromise;
-      const { eq } = await drizzleModulePromise;
-
-      await db.delete(agentMappings).where(eq(agentMappings.agentId, agentId));
-      invalidateAgentMappingCache(agentId, existingMapping?.accountId);
-
-      console.log(`[AgentRoutes] ✅ Agent mapping deleted for: ${agentId}`);
-
-      return reply.send({
-        success: true,
-        message: "Agent mapping deleted",
-      });
-    } catch (error) {
-      console.error("[AgentRoutes] ❌ Failed to delete agent mapping:", error);
-
-      return reply.status(500).send({
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Failed to delete agent mapping",
-      });
-    }
-  });
+    }),
+  );
 
   /**
    * POST /api/agents/:agentId/message
@@ -2880,7 +2982,7 @@ export function registerAgentRoutes(
       }
 
       // Parse query params
-      const limit = Math.min(parseInt(query.limit || "100", 10), 200);
+      const limit = normalizeThoughtsLimit(query.limit);
       const since = query.since ? parseInt(query.since, 10) : 0;
 
       const db = getDatabaseDb();
@@ -2926,13 +3028,23 @@ export function registerAgentRoutes(
         try {
           const { agentThoughts: agentThoughtsTable } =
             await import("../../database/schema.js");
-          const { desc, eq } = await import("drizzle-orm");
-          const rows = await db
+          const { and, desc, eq, gt } = await import("drizzle-orm");
+          const conditions = [eq(agentThoughtsTable.characterId, characterId)];
+          if (since > 0) {
+            conditions.push(gt(agentThoughtsTable.timestamp, since));
+          }
+          const rows = (await db
             .select()
             .from(agentThoughtsTable)
-            .where(eq(agentThoughtsTable.characterId, characterId))
+            .where(and(...conditions))
             .orderBy(desc(agentThoughtsTable.timestamp))
-            .limit(limit);
+            .limit(limit)) as Array<{
+            characterId: string;
+            type: string;
+            content: string;
+            timestamp: number;
+            decisionPath?: string | null;
+          }>;
           thoughts = rows.map((r) => ({
             id: `${r.characterId}-thought-${r.timestamp}`,
             type: r.type,
@@ -2952,11 +3064,10 @@ export function registerAgentRoutes(
       }
 
       // Filter by since timestamp and limit
-      let filteredThoughts = thoughts;
-      if (since > 0) {
-        filteredThoughts = thoughts.filter((t) => t.timestamp > since);
-      }
-      filteredThoughts = filteredThoughts.slice(0, limit);
+      const filteredThoughts =
+        since > 0
+          ? thoughts.filter((t) => t.timestamp > since).slice(0, limit)
+          : thoughts.slice(0, limit);
 
       return reply.send({
         success: true,
@@ -3087,42 +3198,7 @@ export function registerAgentRoutes(
       const inputCharacterId = body.characterId;
 
       // Get character from database to retrieve accountId and name
-      const databaseSystem = world.getSystem("database") as
-        | {
-            db: {
-              select: (fields?: unknown) => {
-                from: (table: unknown) => {
-                  where: (condition: unknown) => Promise<unknown[]>;
-                };
-              };
-              insert: (table: unknown) => {
-                values: (values: Record<string, unknown>) => {
-                  onConflictDoUpdate: (config: {
-                    set: Record<string, unknown>;
-                    target: unknown;
-                  }) => Promise<unknown>;
-                } & Promise<unknown>;
-              };
-              delete: (table: unknown) => {
-                where: (condition: unknown) => Promise<unknown>;
-              };
-              query: {
-                characters: {
-                  findFirst: (opts: {
-                    where: (
-                      chars: { id: unknown },
-                      ops: { eq: (a: unknown, b: string) => unknown },
-                    ) => unknown;
-                  }) => Promise<{
-                    id: string;
-                    accountId: string;
-                    name: string;
-                  } | null>;
-                };
-              };
-            };
-          }
-        | undefined;
+      const databaseSystem = getDatabaseSystem();
 
       if (!databaseSystem?.db) {
         return reply.status(500).send({

--- a/packages/server/src/startup/shutdown.ts
+++ b/packages/server/src/startup/shutdown.ts
@@ -18,7 +18,7 @@
  * Handles signals:
  * - SIGINT (Ctrl+C) - User termination
  * - SIGTERM (Docker stop, systemd) - Graceful shutdown
- * - SIGUSR2 (Hot reload) - Dev mode restart
+ * - SIGUSR2 (Hot reload in development, restart in production)
  * - uncaughtException - Crash handling
  * - unhandledRejection - Promise error handling
  *
@@ -130,6 +130,9 @@ export function registerShutdownHandlers(
       /^(1|true|yes|on)$/i.test(
         process.env.SERVER_SURVIVE_UNHANDLED_REJECTION || "",
       ));
+  const preserveProcessOnSigusr2 =
+    process.env.NODE_ENV !== "production" &&
+    !/^(1|true|yes|on)$/i.test(process.env.SERVER_EXIT_ON_SIGUSR2 || "");
 
   if (surviveUnhandledRejection) {
     console.log(
@@ -147,7 +150,10 @@ export function registerShutdownHandlers(
    * Graceful shutdown handler
    *
    * Performs cleanup in the correct order to prevent data loss.
-   * Handles hot reload (SIGUSR2) differently from termination signals.
+   * Handles hot reload (SIGUSR2) differently from termination signals only
+   * outside production. Production process managers may use SIGUSR2 during
+   * reloads; keeping the process alive after closing HTTP leaves PM2 "online"
+   * while Caddy has no upstream listener.
    *
    * @param signal - Signal that triggered shutdown
    */
@@ -261,13 +267,19 @@ export function registerShutdownHandlers(
     // Step 9: Clear startup flag
     clearStartupFlag();
 
-    // For hot reload (SIGUSR2), don't exit process
-    if (signal === "SIGUSR2") {
+    // For development hot reload (SIGUSR2), don't exit process.
+    if (signal === "SIGUSR2" && preserveProcessOnSigusr2) {
       isShuttingDown = false; // Reset so next reload can proceed
       return;
     }
 
-    // For termination signals, exit after short delay
+    if (signal === "SIGUSR2") {
+      console.warn(
+        "[Shutdown] SIGUSR2 completed cleanup; exiting so the process manager can restart with a live HTTP listener.",
+      );
+    }
+
+    // For termination/restart signals, exit after short delay
     setTimeout(() => {
       process.exit(0);
     }, 100);

--- a/packages/server/src/startup/uws-server.ts
+++ b/packages/server/src/startup/uws-server.ts
@@ -10,7 +10,7 @@
  * EventEmitter-like NodeWebSocket interface that Socket/ConnectionHandler expect.
  */
 
-import * as uWS from "uWebSockets.js";
+import type * as uWS from "uWebSockets.js";
 import type { World } from "@hyperscape/shared";
 import {
   UwsWebSocketAdapter,
@@ -18,11 +18,16 @@ import {
 } from "./UwsWebSocketAdapter.js";
 import type { NodeWebSocket } from "../shared/types/network.types.js";
 
+type UwsModule = typeof import("uWebSockets.js");
+
 /** Module-level listen socket for graceful shutdown */
 let _listenSocket: uWS.us_listen_socket | null = null;
 
 /** Module-level uWS app reference for pub/sub broadcasting */
 let _uwsApp: uWS.TemplatedApp | null = null;
+
+/** Loaded uWS module, if the runtime supports it */
+let _uwsModule: UwsModule | null = null;
 
 /**
  * Get the uWS app instance for pub/sub operations.
@@ -30,6 +35,14 @@ let _uwsApp: uWS.TemplatedApp | null = null;
  */
 export function getUwsApp(): uWS.TemplatedApp | null {
   return _uwsApp;
+}
+
+async function loadUwsModule(): Promise<UwsModule> {
+  if (_uwsModule) {
+    return _uwsModule;
+  }
+  _uwsModule = await import("uWebSockets.js");
+  return _uwsModule;
 }
 
 /**
@@ -64,10 +77,11 @@ function parseQueryString(qs: string): Record<string, string> {
  * @param port - Port to listen on (default: 5556 via UWS_PORT env var)
  * @returns Promise that resolves with the uWS listen socket (for shutdown)
  */
-export function createUwsServer(
+export async function createUwsServer(
   world: World,
   port: number,
 ): Promise<uWS.us_listen_socket | null> {
+  const uWS = await loadUwsModule();
   const app = uWS.App();
   _uwsApp = app;
 
@@ -173,8 +187,8 @@ export function createUwsServer(
  * Safe to call even if uWS was never started.
  */
 export function closeUwsServer(): void {
-  if (_listenSocket) {
-    uWS.us_listen_socket_close(_listenSocket);
+  if (_listenSocket && _uwsModule) {
+    _uwsModule.us_listen_socket_close(_listenSocket);
     _listenSocket = null;
     console.log("[uWS] Listen socket closed");
   }

--- a/packages/server/src/streaming/cloudflare-authority.ts
+++ b/packages/server/src/streaming/cloudflare-authority.ts
@@ -1,0 +1,575 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { IncomingHttpHeaders } from "node:http";
+import type { DatabaseSystem } from "../systems/DatabaseSystem/index.js";
+import { storage } from "../database/schema.js";
+import type {
+  StreamCanonicalProvider,
+  StreamManifestStatus,
+} from "./delivery-config.js";
+
+type StorageDb = ReturnType<DatabaseSystem["getDb"]>;
+
+export const CANONICAL_PROVIDER_STATE_STORAGE_KEY =
+  "streaming:canonical-provider-state";
+export const CLOUDFLARE_LIFECYCLE_STORAGE_KEY =
+  "streaming:cloudflare:lifecycle";
+export const CLOUDFLARE_LAST_WEBHOOK_STORAGE_KEY =
+  "streaming:cloudflare:last-webhook";
+export const CLOUDFLARE_LAST_LIFECYCLE_POLL_STORAGE_KEY =
+  "streaming:cloudflare:last-lifecycle-poll";
+export const CLOUDFLARE_LAST_PLAYBACK_PROBE_STORAGE_KEY =
+  "streaming:cloudflare:last-playback-probe";
+export const CLOUDFLARE_RECONCILIATION_STORAGE_KEY =
+  "streaming:cloudflare:reconciliation";
+
+export type PersistedCanonicalProviderState = {
+  activeProvider: StreamCanonicalProvider | null;
+  primaryHealthySince: number | null;
+  updatedAt: number;
+};
+
+export type PersistedCloudflareLifecycleState = {
+  eventType: string | null;
+  eventName: string | null;
+  liveInputId: string | null;
+  videoId: string | null;
+  status: "connected" | "disconnected" | "errored" | "unknown";
+  errorCode: string | null;
+  errorMessage: string | null;
+  occurredAt: number | null;
+  receivedAt: number;
+};
+
+export type PersistedCloudflareWebhookState = {
+  eventType: string | null;
+  eventName: string | null;
+  liveInputId: string | null;
+  videoId: string | null;
+  occurredAt: number | null;
+  receivedAt: number;
+};
+
+export type PersistedCloudflareLifecyclePollState = {
+  liveInputId: string | null;
+  videoUid: string | null;
+  status: "connected" | "disconnected" | "errored" | "unknown";
+  providerLive: boolean;
+  statusSummary: string | null;
+  playbackUrl: string | null;
+  occurredAt: number | null;
+  receivedAt: number;
+};
+
+export type PersistedCloudflarePlaybackProbeState = {
+  playbackUrl: string | null;
+  ready: boolean;
+  manifestStatus: StreamManifestStatus;
+  statusCode: number | null;
+  lastError: string | null;
+  updatedAt: number;
+};
+
+export type PersistedCloudflareReconciliationState = {
+  revision: number;
+  decision: "ready" | "blocked";
+  reason:
+    | "source_unready"
+    | "provider_not_live"
+    | "probe_unready"
+    | "authority_stale"
+    | null;
+  updatedAt: number;
+  liveInputId: string | null;
+  videoUid: string | null;
+  lifecycleStatus: string | null;
+  providerLive: boolean;
+  playbackUrl: string | null;
+  playbackProbeReady: boolean;
+  playbackProbeStatusCode: number | null;
+  playbackManifestStatus: StreamManifestStatus;
+};
+
+export type PersistedStreamingAuthorityState = {
+  canonicalProviderState: PersistedCanonicalProviderState | null;
+  cloudflareLifecycle: PersistedCloudflareLifecycleState | null;
+  cloudflareLastWebhook: PersistedCloudflareWebhookState | null;
+  cloudflareLifecyclePoll: PersistedCloudflareLifecyclePollState | null;
+  cloudflarePlaybackProbe: PersistedCloudflarePlaybackProbeState | null;
+  cloudflareReconciliation: PersistedCloudflareReconciliationState | null;
+};
+
+export type SummarizedCloudflareLiveWebhook = {
+  webhook: PersistedCloudflareWebhookState;
+  lifecycle: PersistedCloudflareLifecycleState;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readFirstString(
+  value: Record<string, unknown> | null,
+  keys: string[],
+): string | null {
+  if (!value) return null;
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function readNestedString(
+  payload: Record<string, unknown> | null,
+  candidates: string[][],
+): string | null {
+  for (const path of candidates) {
+    let cursor: unknown = payload;
+    for (const segment of path) {
+      cursor = asRecord(cursor)?.[segment];
+    }
+    if (typeof cursor === "string" && cursor.trim().length > 0) {
+      return cursor.trim();
+    }
+  }
+  return null;
+}
+
+function readNestedTimestamp(
+  payload: Record<string, unknown> | null,
+  candidates: string[][],
+): number | null {
+  for (const path of candidates) {
+    let cursor: unknown = payload;
+    for (const segment of path) {
+      cursor = asRecord(cursor)?.[segment];
+    }
+    if (typeof cursor === "number" && Number.isFinite(cursor)) {
+      return cursor;
+    }
+    if (typeof cursor === "string" && cursor.trim().length > 0) {
+      const numeric = Number(cursor);
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+      const parsed = Date.parse(cursor);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+}
+
+function parseStoredJson<T>(rawValue: string | null | undefined): T | null {
+  if (!rawValue) return null;
+  try {
+    return JSON.parse(rawValue) as T;
+  } catch (error) {
+    console.warn(
+      `[CloudflareAuthority] Failed to parse persisted JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+async function readStoredJson<T>(
+  db: StorageDb | null | undefined,
+  key: string,
+): Promise<T | null> {
+  if (!db) return null;
+  const rows = await db
+    .select()
+    .from(storage)
+    .where(eq(storage.key, key))
+    .limit(1);
+  return parseStoredJson<T>(rows[0]?.value);
+}
+
+async function writeStoredJson(
+  db: StorageDb | null | undefined,
+  key: string,
+  value: unknown,
+): Promise<void> {
+  if (!db) return;
+  const now = Date.now();
+  const payload = JSON.stringify(value);
+  await db
+    .insert(storage)
+    .values({
+      key,
+      value: payload,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: storage.key,
+      set: {
+        value: payload,
+        updatedAt: now,
+      },
+    });
+}
+
+function deriveLifecycleStatus(eventType: string | null) {
+  const normalized = eventType?.trim().toLowerCase() ?? "";
+  if (normalized.includes("disconnected")) {
+    return "disconnected" as const;
+  }
+  if (normalized.includes("connected")) {
+    return "connected" as const;
+  }
+  if (normalized.includes("error")) {
+    return "errored" as const;
+  }
+  return "unknown" as const;
+}
+
+function isFreshTimestamp(
+  updatedAt: number | null | undefined,
+  nowMs: number,
+  freshnessMs: number,
+): boolean {
+  return (
+    typeof updatedAt === "number" &&
+    Number.isFinite(updatedAt) &&
+    Math.max(0, nowMs - updatedAt) <= freshnessMs
+  );
+}
+
+function stableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stableJsonValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, stableJsonValue(entry)]),
+    );
+  }
+  return value;
+}
+
+function buildReconciliationComparable(
+  state: Omit<PersistedCloudflareReconciliationState, "revision" | "updatedAt">,
+): string {
+  return JSON.stringify(stableJsonValue(state));
+}
+
+type CloudflareProviderEvidence = {
+  liveInputId: string | null;
+  videoUid: string | null;
+  lifecycleStatus: string | null;
+  providerLive: boolean;
+  updatedAt: number;
+};
+
+function resolveCloudflareProviderEvidence(params: {
+  lifecycle: PersistedCloudflareLifecycleState | null;
+  lifecyclePoll: PersistedCloudflareLifecyclePollState | null;
+  nowMs: number;
+  freshnessMs: number;
+}): CloudflareProviderEvidence | null {
+  const candidates: CloudflareProviderEvidence[] = [];
+
+  if (
+    params.lifecycle &&
+    isFreshTimestamp(
+      params.lifecycle.receivedAt,
+      params.nowMs,
+      params.freshnessMs,
+    )
+  ) {
+    candidates.push({
+      liveInputId: params.lifecycle.liveInputId,
+      videoUid: params.lifecycle.videoId,
+      lifecycleStatus: params.lifecycle.status,
+      providerLive: params.lifecycle.status === "connected",
+      updatedAt: params.lifecycle.receivedAt,
+    });
+  }
+
+  if (
+    params.lifecyclePoll &&
+    isFreshTimestamp(
+      params.lifecyclePoll.receivedAt,
+      params.nowMs,
+      params.freshnessMs,
+    )
+  ) {
+    candidates.push({
+      liveInputId: params.lifecyclePoll.liveInputId,
+      videoUid: params.lifecyclePoll.videoUid,
+      lifecycleStatus: params.lifecyclePoll.status,
+      providerLive: params.lifecyclePoll.providerLive,
+      updatedAt: params.lifecyclePoll.receivedAt,
+    });
+  }
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort((left, right) => right.updatedAt - left.updatedAt)[0]!;
+}
+
+export function verifyCloudflareWebhookSecret(
+  headers: IncomingHttpHeaders | Record<string, unknown>,
+  secret: string | null | undefined,
+): boolean {
+  const expectedSecret = secret?.trim() ?? "";
+  const rawHeader =
+    headers["cf-webhook-auth"] ??
+    Object.entries(headers).find(
+      ([headerName]) => headerName.toLowerCase() === "cf-webhook-auth",
+    )?.[1];
+  const receivedSecret = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+  const normalizedReceived =
+    typeof receivedSecret === "string" ? receivedSecret.trim() : "";
+  const left = createHash("sha256").update(normalizedReceived).digest();
+  const right = createHash("sha256").update(expectedSecret).digest();
+  return Boolean(
+    expectedSecret && normalizedReceived && timingSafeEqual(left, right),
+  );
+}
+
+export function summarizeCloudflareLiveWebhook(params: {
+  payload: unknown;
+  receivedAt?: number;
+}): SummarizedCloudflareLiveWebhook {
+  const payload = asRecord(params.payload);
+  const event = asRecord(payload?.event);
+  const receivedAt = params.receivedAt ?? Date.now();
+  const eventType =
+    readNestedString(payload, [
+      ["alert_type"],
+      ["event", "type"],
+      ["type"],
+      ["eventType"],
+    ]) ?? null;
+  const eventName =
+    readNestedString(payload, [["name"], ["event", "name"]]) ?? eventType;
+  const liveInputId =
+    readNestedString(payload, [
+      ["event", "input_id"],
+      ["event", "input_uid"],
+      ["event", "live_input_id"],
+      ["event", "live_input_uid"],
+      ["input_id"],
+      ["input_uid"],
+      ["live_input_id"],
+      ["live_input_uid"],
+    ]) ?? null;
+  const videoId = readNestedString(payload, [
+    ["event", "video_id"],
+    ["event", "video_uid"],
+    ["video_id"],
+    ["video_uid"],
+  ]);
+  const occurredAt = readNestedTimestamp(payload, [
+    ["event", "timestamp"],
+    ["event", "occurred_at"],
+    ["timestamp"],
+    ["occurred_at"],
+  ]);
+  const errorCode =
+    readFirstString(event, ["error_code", "code"]) ??
+    readFirstString(payload, ["error_code", "code"]);
+  const errorMessage =
+    readFirstString(event, ["error_message", "message"]) ??
+    readFirstString(payload, ["error_message", "message"]);
+
+  const webhook: PersistedCloudflareWebhookState = {
+    eventType,
+    eventName,
+    liveInputId,
+    videoId,
+    occurredAt,
+    receivedAt,
+  };
+
+  return {
+    webhook,
+    lifecycle: {
+      ...webhook,
+      status: deriveLifecycleStatus(eventType),
+      errorCode,
+      errorMessage,
+    },
+  };
+}
+
+export function reconcileCloudflareAuthority(params: {
+  sourceRuntimeReady: boolean;
+  lifecycle: PersistedCloudflareLifecycleState | null;
+  lifecyclePoll: PersistedCloudflareLifecyclePollState | null;
+  playbackProbe: PersistedCloudflarePlaybackProbeState | null;
+  previous: PersistedCloudflareReconciliationState | null;
+  nowMs?: number;
+  freshnessMs: number;
+  playbackUrl?: string | null;
+}): PersistedCloudflareReconciliationState {
+  const nowMs = params.nowMs ?? Date.now();
+  const providerEvidence = resolveCloudflareProviderEvidence({
+    lifecycle: params.lifecycle,
+    lifecyclePoll: params.lifecyclePoll,
+    nowMs,
+    freshnessMs: params.freshnessMs,
+  });
+  const playbackProbeFresh =
+    params.playbackProbe &&
+    isFreshTimestamp(params.playbackProbe.updatedAt, nowMs, params.freshnessMs)
+      ? params.playbackProbe
+      : null;
+  const providerLive = providerEvidence?.providerLive === true;
+  const playbackProbeReady = playbackProbeFresh?.ready === true;
+
+  let reason: PersistedCloudflareReconciliationState["reason"] = null;
+  if (!params.sourceRuntimeReady) {
+    reason = "source_unready";
+  } else if (providerEvidence && !providerLive) {
+    reason = "provider_not_live";
+  } else if (
+    providerEvidence &&
+    providerLive &&
+    playbackProbeFresh &&
+    !playbackProbeReady
+  ) {
+    reason = "probe_unready";
+  } else if (!providerEvidence || !playbackProbeFresh) {
+    reason = "authority_stale";
+  }
+
+  const comparableState = {
+    decision: reason == null ? "ready" : "blocked",
+    reason,
+    liveInputId:
+      providerEvidence?.liveInputId ?? params.lifecycle?.liveInputId ?? null,
+    videoUid: providerEvidence?.videoUid ?? params.lifecycle?.videoId ?? null,
+    lifecycleStatus: providerEvidence?.lifecycleStatus ?? null,
+    providerLive,
+    playbackUrl:
+      playbackProbeFresh?.playbackUrl ??
+      params.playbackUrl?.trim() ??
+      params.playbackProbe?.playbackUrl ??
+      null,
+    playbackProbeReady,
+    playbackProbeStatusCode: playbackProbeFresh?.statusCode ?? null,
+    playbackManifestStatus:
+      playbackProbeFresh?.manifestStatus ??
+      ("unknown" satisfies StreamManifestStatus),
+  } satisfies Omit<
+    PersistedCloudflareReconciliationState,
+    "revision" | "updatedAt"
+  >;
+
+  const previousComparable =
+    params.previous == null
+      ? null
+      : buildReconciliationComparable({
+          decision: params.previous.decision,
+          reason: params.previous.reason,
+          liveInputId: params.previous.liveInputId,
+          videoUid: params.previous.videoUid,
+          lifecycleStatus: params.previous.lifecycleStatus,
+          providerLive: params.previous.providerLive,
+          playbackUrl: params.previous.playbackUrl,
+          playbackProbeReady: params.previous.playbackProbeReady,
+          playbackProbeStatusCode: params.previous.playbackProbeStatusCode,
+          playbackManifestStatus: params.previous.playbackManifestStatus,
+        });
+  const nextComparable = buildReconciliationComparable(comparableState);
+
+  return {
+    revision:
+      previousComparable === nextComparable
+        ? (params.previous?.revision ?? 1)
+        : (params.previous?.revision ?? 0) + 1,
+    updatedAt: nowMs,
+    ...comparableState,
+  };
+}
+
+export async function loadPersistedStreamingAuthorityState(
+  db: StorageDb | null | undefined,
+): Promise<PersistedStreamingAuthorityState> {
+  return {
+    canonicalProviderState:
+      await readStoredJson<PersistedCanonicalProviderState>(
+        db,
+        CANONICAL_PROVIDER_STATE_STORAGE_KEY,
+      ),
+    cloudflareLifecycle:
+      await readStoredJson<PersistedCloudflareLifecycleState>(
+        db,
+        CLOUDFLARE_LIFECYCLE_STORAGE_KEY,
+      ),
+    cloudflareLastWebhook:
+      await readStoredJson<PersistedCloudflareWebhookState>(
+        db,
+        CLOUDFLARE_LAST_WEBHOOK_STORAGE_KEY,
+      ),
+    cloudflareLifecyclePoll:
+      await readStoredJson<PersistedCloudflareLifecyclePollState>(
+        db,
+        CLOUDFLARE_LAST_LIFECYCLE_POLL_STORAGE_KEY,
+      ),
+    cloudflarePlaybackProbe:
+      await readStoredJson<PersistedCloudflarePlaybackProbeState>(
+        db,
+        CLOUDFLARE_LAST_PLAYBACK_PROBE_STORAGE_KEY,
+      ),
+    cloudflareReconciliation:
+      await readStoredJson<PersistedCloudflareReconciliationState>(
+        db,
+        CLOUDFLARE_RECONCILIATION_STORAGE_KEY,
+      ),
+  };
+}
+
+export async function persistCanonicalProviderState(
+  db: StorageDb | null | undefined,
+  state: PersistedCanonicalProviderState,
+): Promise<void> {
+  await writeStoredJson(db, CANONICAL_PROVIDER_STATE_STORAGE_KEY, state);
+}
+
+export async function persistCloudflareLifecycleState(
+  db: StorageDb | null | undefined,
+  state: PersistedCloudflareLifecycleState,
+): Promise<void> {
+  await writeStoredJson(db, CLOUDFLARE_LIFECYCLE_STORAGE_KEY, state);
+}
+
+export async function persistCloudflareWebhookState(
+  db: StorageDb | null | undefined,
+  state: PersistedCloudflareWebhookState,
+): Promise<void> {
+  await writeStoredJson(db, CLOUDFLARE_LAST_WEBHOOK_STORAGE_KEY, state);
+}
+
+export async function persistCloudflareLifecyclePollState(
+  db: StorageDb | null | undefined,
+  state: PersistedCloudflareLifecyclePollState,
+): Promise<void> {
+  await writeStoredJson(db, CLOUDFLARE_LAST_LIFECYCLE_POLL_STORAGE_KEY, state);
+}
+
+export async function persistCloudflarePlaybackProbeState(
+  db: StorageDb | null | undefined,
+  state: PersistedCloudflarePlaybackProbeState,
+): Promise<void> {
+  await writeStoredJson(db, CLOUDFLARE_LAST_PLAYBACK_PROBE_STORAGE_KEY, state);
+}
+
+export async function persistCloudflareReconciliationState(
+  db: StorageDb | null | undefined,
+  state: PersistedCloudflareReconciliationState,
+): Promise<void> {
+  await writeStoredJson(db, CLOUDFLARE_RECONCILIATION_STORAGE_KEY, state);
+}

--- a/packages/server/src/streaming/delivery-config.ts
+++ b/packages/server/src/streaming/delivery-config.ts
@@ -1,0 +1,292 @@
+export type StreamDeliveryMode = "self_hls" | "external_hls";
+export type StreamDestinationRole = "canonical" | "fallback" | "mirror";
+export type StreamDestinationProvider =
+  | "cloudflare_stream"
+  | "self_hls"
+  | "twitch"
+  | "kick"
+  | "youtube"
+  | "custom";
+export type StreamCanonicalProvider = "cloudflare_stream" | "self_hls";
+export type StreamDeliveryTransport =
+  | "llhls"
+  | "hls"
+  | "rtmps"
+  | "srt"
+  | "unknown";
+export type StreamManifestStatus = "ok" | "stale" | "missing" | "unknown";
+export type StreamPublicReadiness = {
+  ready: boolean;
+  reason: string | null;
+  updatedAt: number | null;
+};
+export type StreamDestinationState = {
+  id: string;
+  name: string;
+  role: StreamDestinationRole;
+  provider: StreamDestinationProvider;
+  transport: StreamDeliveryTransport;
+  playbackUrl: string | null;
+  ingestUrl: string | null;
+  connected: boolean;
+  transportHealthy: boolean;
+  playbackReady: boolean;
+  manifestStatus: StreamManifestStatus;
+  lastError: string | null;
+  updatedAt: number | null;
+};
+export type StreamChannelState = {
+  id: string;
+  mode: "always_on";
+  presentationDelayMs: number;
+  activeDuelId: string | null;
+  activeDuelKey: string | null;
+  canonicalDestinationId: string;
+  fallbackDestinationId: string | null;
+  publicPlaybackUrl: string | null;
+  publicReadiness: StreamPublicReadiness;
+  destinations: StreamDestinationState[];
+};
+
+export type StreamDeliveryInfo = {
+  mode: StreamDeliveryMode;
+  provider: string | null;
+  playbackUrl: string | null;
+  hlsUrl: string | null;
+  llhlsUrl: string | null;
+  ingestUrl: string | null;
+};
+
+export type StreamExternalDeliveryInfo = {
+  provider: string | null;
+  playbackUrl: string | null;
+  hlsUrl: string | null;
+  llhlsUrl: string | null;
+  ingestUrl: string | null;
+};
+
+function isCanonicalProvider(
+  value: StreamDestinationProvider,
+): value is StreamCanonicalProvider {
+  return value === "cloudflare_stream" || value === "self_hls";
+}
+
+function asNonEmptyString(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function normalizePrefix(value: string | null): string {
+  if (!value) return "live/";
+  const trimmed = value.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed ? `${trimmed}/` : "live/";
+}
+
+function normalizeDeliveryMode(
+  rawValue: string | undefined,
+  options: {
+    hasExternalPlayback: boolean;
+  },
+): StreamDeliveryMode {
+  const normalized = (rawValue || "").trim().toLowerCase();
+  if (normalized === "external_hls") {
+    return "external_hls";
+  }
+  if (normalized === "self_hls") {
+    return "self_hls";
+  }
+  if (options.hasExternalPlayback) {
+    return "external_hls";
+  }
+  return "self_hls";
+}
+
+export function resolveStreamDeliveryInfo(
+  env: NodeJS.ProcessEnv = process.env,
+): StreamDeliveryInfo {
+  const playbackUrl = asNonEmptyString(env.STREAM_PLAYBACK_URL);
+  const external = resolveExternalStreamDeliveryInfo(env);
+  const hasExternalPlayback = Boolean(external.hlsUrl || external.llhlsUrl);
+  const mode = normalizeDeliveryMode(env.STREAM_DELIVERY_MODE, {
+    hasExternalPlayback,
+  });
+
+  return {
+    mode,
+    provider: mode === "external_hls" ? external.provider : null,
+    playbackUrl:
+      mode === "external_hls"
+        ? external.playbackUrl
+        : (playbackUrl ??
+          (hasExternalPlayback
+            ? null
+            : (external.hlsUrl ?? external.llhlsUrl))),
+    hlsUrl: mode === "external_hls" ? external.hlsUrl : null,
+    llhlsUrl: mode === "external_hls" ? external.llhlsUrl : null,
+    ingestUrl: mode === "external_hls" ? external.ingestUrl : null,
+  };
+}
+
+export function resolveExternalStreamDeliveryInfo(
+  env: NodeJS.ProcessEnv = process.env,
+): StreamExternalDeliveryInfo {
+  const provider =
+    asNonEmptyString(env.STREAM_EXTERNAL_DELIVERY_PROVIDER) ??
+    asNonEmptyString(env.STREAM_DELIVERY_PROVIDER);
+  const hlsUrl =
+    asNonEmptyString(env.STREAM_EXTERNAL_PLAYBACK_HLS_URL) ??
+    asNonEmptyString(env.STREAM_PLAYBACK_HLS_URL);
+  const llhlsUrl =
+    asNonEmptyString(env.STREAM_EXTERNAL_PLAYBACK_LLHLS_URL) ??
+    asNonEmptyString(env.STREAM_PLAYBACK_LLHLS_URL);
+  const ingestUrl =
+    asNonEmptyString(env.STREAM_EXTERNAL_INGEST_RTMPS_URL) ??
+    asNonEmptyString(env.STREAM_INGEST_RTMPS_URL);
+
+  return {
+    provider,
+    playbackUrl: llhlsUrl ?? hlsUrl,
+    hlsUrl,
+    llhlsUrl,
+    ingestUrl,
+  };
+}
+
+export function normalizeStreamDestinationProvider(
+  value: string | null | undefined,
+  name: string | null | undefined = null,
+): StreamDestinationProvider {
+  const normalized = (value || name || "").trim().toLowerCase();
+  if (!normalized) return "custom";
+  if (
+    normalized.includes("cloudflare") ||
+    normalized.includes("cloudflare_stream")
+  ) {
+    return "cloudflare_stream";
+  }
+  if (normalized.includes("self_hls") || normalized.includes("self-hls")) {
+    return "self_hls";
+  }
+  if (normalized.includes("twitch")) {
+    return "twitch";
+  }
+  if (normalized.includes("kick")) {
+    return "kick";
+  }
+  if (normalized.includes("youtube")) {
+    return "youtube";
+  }
+  return "custom";
+}
+
+export function inferStreamDeliveryTransport(params: {
+  playbackUrl?: string | null;
+  ingestUrl?: string | null;
+}): StreamDeliveryTransport {
+  const playbackUrl = params.playbackUrl?.trim().toLowerCase() ?? "";
+  const ingestUrl = params.ingestUrl?.trim().toLowerCase() ?? "";
+  if (playbackUrl.includes("protocol=llhls")) {
+    return "llhls";
+  }
+  if (playbackUrl.endsWith(".m3u8")) {
+    return "hls";
+  }
+  if (ingestUrl.startsWith("srt://")) {
+    return "srt";
+  }
+  if (ingestUrl.startsWith("rtmp://") || ingestUrl.startsWith("rtmps://")) {
+    return "rtmps";
+  }
+  return "unknown";
+}
+
+function slugify(value: string | null | undefined, fallback: string): string {
+  const normalized = (value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || fallback;
+}
+
+export function buildStreamDestinationId(params: {
+  role: StreamDestinationRole;
+  provider: StreamDestinationProvider;
+  name?: string | null;
+}): string {
+  const { role, provider, name } = params;
+  if (role === "canonical" && provider === "cloudflare_stream") {
+    return "canonical-cloudflare";
+  }
+  if (role === "fallback" && provider === "self_hls") {
+    return "fallback-self-hls";
+  }
+  if (role === "mirror" && provider === "twitch") {
+    return "mirror-twitch";
+  }
+  if (role === "mirror" && provider === "kick") {
+    return "mirror-kick";
+  }
+  if (role === "mirror" && provider === "youtube") {
+    return "mirror-youtube";
+  }
+  return `${role}-${slugify(name ?? provider, provider)}`;
+}
+
+export function resolveSelfHostedStreamPlaybackUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const explicit = asNonEmptyString(env.STREAM_PLAYBACK_URL);
+  if (explicit) {
+    return explicit;
+  }
+
+  const publicUrl = asNonEmptyString(env.HLS_CDN_PUBLIC_URL);
+  if (publicUrl) {
+    const prefix = normalizePrefix(asNonEmptyString(env.HLS_CDN_PREFIX));
+    return `${publicUrl.replace(/\/$/, "")}/${prefix}stream.m3u8`;
+  }
+
+  return "/live/stream.m3u8";
+}
+
+export function resolveStreamPresentationDelayMs(
+  env: NodeJS.ProcessEnv = process.env,
+  mode: StreamDeliveryMode = resolveStreamDeliveryInfo(env).mode,
+): number {
+  const parsed = Number(env.STREAM_PRESENTATION_DELAY_MS);
+  if (Number.isFinite(parsed)) {
+    return Math.max(0, parsed);
+  }
+  return mode === "external_hls" ? 4_000 : 0;
+}
+
+export function resolveStreamCanonicalProviderPriority(
+  env: NodeJS.ProcessEnv = process.env,
+): StreamCanonicalProvider[] {
+  const explicit = asNonEmptyString(env.STREAM_CANONICAL_PROVIDER_PRIORITY);
+  if (explicit) {
+    const parsed = explicit
+      .split(",")
+      .map((value) => normalizeStreamDestinationProvider(value, value))
+      .filter(isCanonicalProvider);
+    if (parsed.length > 0) {
+      return [...new Set(parsed)];
+    }
+  }
+
+  const mode = resolveStreamDeliveryInfo(env).mode;
+  return mode === "external_hls"
+    ? ["cloudflare_stream", "self_hls"]
+    : ["self_hls", "cloudflare_stream"];
+}
+
+export function resolveStreamFailbackSoakMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const parsed = Number(env.STREAM_FAILBACK_SOAK_MS);
+  if (!Number.isFinite(parsed)) {
+    return 30_000;
+  }
+  return Math.max(0, parsed);
+}

--- a/packages/server/src/streaming/destination-probe.ts
+++ b/packages/server/src/streaming/destination-probe.ts
@@ -1,0 +1,348 @@
+import type {
+  StreamManifestStatus,
+  StreamPublicReadiness,
+} from "./delivery-config.js";
+import * as dnsPromises from "node:dns/promises";
+import { isIP } from "node:net";
+
+export type StreamPlaybackProbeResult = {
+  playbackUrl: string;
+  ready: boolean;
+  manifestStatus: StreamManifestStatus;
+  statusCode: number | null;
+  lastError: string | null;
+  updatedAt: number;
+};
+
+type PlaybackProbePoller = {
+  snapshot: StreamPlaybackProbeResult | null;
+  refreshPromise: Promise<void> | null;
+  interval: ReturnType<typeof setInterval>;
+  refCount: number;
+};
+
+type PlaybackProbeDependencies = {
+  lookup?: typeof dnsPromises.lookup;
+  fetch?: typeof fetch;
+};
+
+const playbackProbePollers = new Map<string, PlaybackProbePoller>();
+
+function isPrivateIpv4Address(hostname: string): boolean {
+  const parts = hostname.split(".").map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19))
+  );
+}
+
+function isBlockedPrivateHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  if (
+    normalized === "localhost" ||
+    normalized === "localhost.localdomain" ||
+    normalized.endsWith(".local")
+  ) {
+    return true;
+  }
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) {
+    return isPrivateIpv4Address(normalized);
+  }
+  if (ipVersion === 6) {
+    if (normalized.startsWith("::ffff:")) {
+      return isPrivateIpv4Address(normalized.slice("::ffff:".length));
+    }
+    return (
+      normalized === "::1" ||
+      normalized.startsWith("fe80:") ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd")
+    );
+  }
+  return false;
+}
+
+function validatePlaybackProbeUrlSyntax(playbackUrl: string): {
+  parsed: URL | null;
+  error: string | null;
+} {
+  let parsed: URL;
+  try {
+    parsed = new URL(playbackUrl);
+  } catch {
+    return {
+      parsed: null,
+      error: "invalid_playback_url",
+    };
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return {
+      parsed: null,
+      error: "unsupported_playback_protocol",
+    };
+  }
+
+  return {
+    parsed,
+    error: null,
+  };
+}
+
+async function validateResolvedPlaybackProbeHost(
+  parsed: URL,
+  lookup: typeof dnsPromises.lookup = dnsPromises.lookup,
+): Promise<string | null> {
+  const allowPrivateHosts = process.env.NODE_ENV === "development";
+  if (allowPrivateHosts) {
+    return null;
+  }
+
+  if (isBlockedPrivateHost(parsed.hostname)) {
+    return "private_playback_host_blocked";
+  }
+
+  try {
+    const resolvedAddresses = await lookup(parsed.hostname, {
+      all: true,
+      verbatim: true,
+    });
+    if (
+      resolvedAddresses.some((candidate) =>
+        isBlockedPrivateHost(candidate.address),
+      )
+    ) {
+      return "private_playback_host_blocked";
+    }
+  } catch {
+    // Let the normal fetch path report DNS/network failures. This validation
+    // layer is only responsible for fail-closing when the hostname resolves
+    // to a blocked private target.
+  }
+
+  return null;
+}
+
+function classifyProbeResult(params: {
+  statusCode: number | null;
+  lastError: string | null;
+}): Pick<StreamPlaybackProbeResult, "ready" | "manifestStatus" | "lastError"> {
+  if (params.lastError) {
+    return {
+      ready: false,
+      manifestStatus: "unknown",
+      lastError: params.lastError,
+    };
+  }
+
+  if (params.statusCode === 200 || params.statusCode === 206) {
+    return {
+      ready: true,
+      manifestStatus: "ok",
+      lastError: null,
+    };
+  }
+
+  if (params.statusCode === 204 || params.statusCode === 404) {
+    return {
+      ready: false,
+      manifestStatus: "missing",
+      lastError: null,
+    };
+  }
+
+  if (params.statusCode != null && params.statusCode >= 500) {
+    return {
+      ready: false,
+      manifestStatus: "stale",
+      lastError: null,
+    };
+  }
+
+  return {
+    ready: false,
+    manifestStatus: "unknown",
+    lastError: null,
+  };
+}
+
+export async function probePlaybackUrl(
+  playbackUrl: string,
+  timeoutMs = 4_000,
+  dependencies: PlaybackProbeDependencies = {},
+): Promise<StreamPlaybackProbeResult> {
+  const { parsed, error } = validatePlaybackProbeUrlSyntax(playbackUrl);
+  if (error || !parsed) {
+    return {
+      playbackUrl,
+      ready: false,
+      manifestStatus: "unknown",
+      statusCode: null,
+      lastError: error ?? "invalid_playback_url",
+      updatedAt: Date.now(),
+    };
+  }
+
+  const validationError = await validateResolvedPlaybackProbeHost(
+    parsed,
+    dependencies.lookup,
+  );
+  if (validationError) {
+    return {
+      playbackUrl,
+      ready: false,
+      manifestStatus: "unknown",
+      statusCode: null,
+      lastError: validationError,
+      updatedAt: Date.now(),
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const fetchImpl = dependencies.fetch ?? fetch;
+    const response = await fetchImpl(parsed, {
+      method: "GET",
+      cache: "no-store",
+      redirect: "manual",
+      headers: {
+        accept: "application/vnd.apple.mpegurl,text/plain,*/*",
+      },
+      signal: controller.signal,
+    });
+
+    try {
+      await response.body?.cancel();
+    } catch {
+      // Ignore cancellation issues on already-consumed or absent bodies.
+    }
+
+    const classified = classifyProbeResult({
+      statusCode: response.status,
+      lastError: null,
+    });
+    return {
+      playbackUrl,
+      statusCode: response.status,
+      updatedAt: Date.now(),
+      ...classified,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "playback_probe_failed";
+    const classified = classifyProbeResult({
+      statusCode: null,
+      lastError: message,
+    });
+    return {
+      playbackUrl,
+      statusCode: null,
+      updatedAt: Date.now(),
+      ...classified,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function refreshPlaybackProbePoller(
+  poller: PlaybackProbePoller,
+  playbackUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  if (poller.refreshPromise) {
+    return poller.refreshPromise;
+  }
+  poller.refreshPromise = probePlaybackUrl(playbackUrl, timeoutMs)
+    .then((snapshot) => {
+      poller.snapshot = snapshot;
+    })
+    .finally(() => {
+      poller.refreshPromise = null;
+    });
+  return poller.refreshPromise;
+}
+
+export function acquirePlaybackProbePoller(
+  playbackUrl: string | null,
+  options?: {
+    intervalMs?: number;
+    timeoutMs?: number;
+  },
+): {
+  getSnapshot(): StreamPlaybackProbeResult | null;
+  refresh(): Promise<void>;
+  release(): void;
+} | null {
+  if (!playbackUrl) {
+    return null;
+  }
+
+  const timeoutMs = Math.max(500, options?.timeoutMs ?? 4_000);
+  const intervalMs = Math.max(timeoutMs, options?.intervalMs ?? 5_000);
+  let poller = playbackProbePollers.get(playbackUrl);
+  if (!poller) {
+    poller = {
+      snapshot: null,
+      refreshPromise: null,
+      interval: setInterval(() => {
+        void refreshPlaybackProbePoller(poller!, playbackUrl, timeoutMs);
+      }, intervalMs),
+      refCount: 0,
+    };
+    poller.interval.unref?.();
+    playbackProbePollers.set(playbackUrl, poller);
+    void refreshPlaybackProbePoller(poller, playbackUrl, timeoutMs);
+  }
+
+  poller.refCount += 1;
+
+  return {
+    getSnapshot(): StreamPlaybackProbeResult | null {
+      return poller?.snapshot ?? null;
+    },
+    refresh(): Promise<void> {
+      if (!poller) {
+        return Promise.resolve();
+      }
+      return refreshPlaybackProbePoller(poller, playbackUrl, timeoutMs);
+    },
+    release(): void {
+      if (!poller) return;
+      poller.refCount = Math.max(0, poller.refCount - 1);
+      if (poller.refCount > 0) {
+        return;
+      }
+      clearInterval(poller.interval);
+      playbackProbePollers.delete(playbackUrl);
+    },
+  };
+}
+
+export function toPublicReadinessFromProbe(params: {
+  ready: boolean;
+  reason: string | null;
+  updatedAt: number;
+}): StreamPublicReadiness {
+  return {
+    ready: params.ready,
+    reason: params.reason,
+    updatedAt: params.updatedAt,
+  };
+}

--- a/packages/server/src/streaming/hls-cdn-sync.ts
+++ b/packages/server/src/streaming/hls-cdn-sync.ts
@@ -1,0 +1,400 @@
+/**
+ * HLS CDN Sync — Watches the local HLS output directory and uploads
+ * segments + playlists to an S3-compatible CDN (Cloudflare R2, AWS S3, etc.)
+ *
+ * Uses AWS Signature V4 over fetch — no @aws-sdk dependency required.
+ *
+ * Env vars:
+ *   HLS_CDN_ENABLED            — "true" to enable CDN sync
+ *   HLS_CDN_ENDPOINT           — S3 endpoint URL (e.g. https://<account>.r2.cloudflarestorage.com)
+ *   HLS_CDN_BUCKET             — Bucket name
+ *   HLS_CDN_ACCESS_KEY_ID      — Access key
+ *   HLS_CDN_SECRET_ACCESS_KEY  — Secret key
+ *   HLS_CDN_REGION             — Region (default: auto)
+ *   HLS_CDN_PREFIX             — Key prefix in bucket (default: live/)
+ *   HLS_CDN_PUBLIC_URL         — Public URL base for the CDN (e.g. https://stream.hyperscape.game)
+ *   HLS_OUTPUT_PATH            — Local .m3u8 path (must match rtmp-bridge config)
+ */
+
+import { watch, type FSWatcher } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { createHmac, createHash } from "node:crypto";
+import { basename, dirname, join } from "node:path";
+
+// ============================================================================
+// AWS Signature V4 (minimal, for S3 PUT only)
+// ============================================================================
+
+function hmacSha256(key: Buffer | string, data: string): Buffer {
+  return createHmac("sha256", key).update(data).digest();
+}
+
+function sha256Hex(data: Buffer | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function getSignatureKey(
+  secretKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+): Buffer {
+  const kDate = hmacSha256(`AWS4${secretKey}`, dateStamp);
+  const kRegion = hmacSha256(kDate, region);
+  const kService = hmacSha256(kRegion, service);
+  return hmacSha256(kService, "aws4_request");
+}
+
+function signS3PutRequest(params: {
+  endpoint: string;
+  bucket: string;
+  key: string;
+  body: Buffer;
+  contentType: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  now?: Date;
+}): { url: string; headers: Record<string, string> } {
+  const now = params.now ?? new Date();
+  const dateStamp = now.toISOString().slice(0, 10).replace(/-/g, "");
+  const amzDate = now
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}/, "");
+  const payloadHash = sha256Hex(params.body);
+
+  const url = `${params.endpoint}/${params.bucket}/${params.key}`;
+  const parsedUrl = new URL(url);
+  const host = parsedUrl.host;
+  const canonicalUri = parsedUrl.pathname;
+
+  const signedHeaders = "content-type;host;x-amz-content-sha256;x-amz-date";
+  const canonicalHeaders =
+    [
+      `content-type:${params.contentType}`,
+      `host:${host}`,
+      `x-amz-content-sha256:${payloadHash}`,
+      `x-amz-date:${amzDate}`,
+    ].join("\n") + "\n";
+
+  const canonicalRequest = [
+    "PUT",
+    canonicalUri,
+    "", // query string
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${params.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const signingKey = getSignatureKey(
+    params.secretAccessKey,
+    dateStamp,
+    params.region,
+    "s3",
+  );
+  const signature = hmacSha256(signingKey, stringToSign).toString("hex");
+
+  const authorization = `AWS4-HMAC-SHA256 Credential=${params.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    url,
+    headers: {
+      Authorization: authorization,
+      "Content-Type": params.contentType,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+      "Cache-Control": params.key.endsWith(".m3u8")
+        ? "no-cache, no-store, must-revalidate"
+        : "public, max-age=31536000, immutable",
+    },
+  };
+}
+
+/** @internal Pure helpers exposed for SigV4 regression tests. */
+export const __hlsCdnSyncTestInternals = {
+  signS3PutRequest,
+};
+
+// ============================================================================
+// HLS CDN Syncer
+// ============================================================================
+
+interface HlsCdnConfig {
+  endpoint: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  prefix: string;
+  publicUrl: string | null;
+  hlsDir: string;
+}
+
+function getConfig(): HlsCdnConfig | null {
+  if (process.env.HLS_CDN_ENABLED !== "true") return null;
+
+  const endpoint = process.env.HLS_CDN_ENDPOINT?.trim();
+  const bucket = process.env.HLS_CDN_BUCKET?.trim();
+  const accessKeyId = process.env.HLS_CDN_ACCESS_KEY_ID?.trim();
+  const secretAccessKey = process.env.HLS_CDN_SECRET_ACCESS_KEY?.trim();
+
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+    console.warn(
+      "[HLS-CDN] Missing required env vars (HLS_CDN_ENDPOINT, HLS_CDN_BUCKET, HLS_CDN_ACCESS_KEY_ID, HLS_CDN_SECRET_ACCESS_KEY)",
+    );
+    return null;
+  }
+
+  const hlsOutputPath = process.env.HLS_OUTPUT_PATH?.trim();
+  if (!hlsOutputPath) {
+    console.warn(
+      "[HLS-CDN] HLS_OUTPUT_PATH not set — cannot determine watch directory",
+    );
+    return null;
+  }
+
+  return {
+    endpoint: endpoint.replace(/\/$/, ""),
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region: process.env.HLS_CDN_REGION?.trim() || "auto",
+    prefix: process.env.HLS_CDN_PREFIX?.trim() || "live/",
+    publicUrl: process.env.HLS_CDN_PUBLIC_URL?.trim() || null,
+    hlsDir: dirname(hlsOutputPath),
+  };
+}
+
+/** Track uploaded segment hashes to avoid redundant uploads */
+const uploadedHashes = new Map<string, string>();
+const MAX_TRACKED_FILES = 500;
+
+/** Pending uploads (deduplication) */
+const pendingUploads = new Map<string, Promise<void>>();
+
+let watcher: FSWatcher | null = null;
+let syncInterval: ReturnType<typeof setInterval> | null = null;
+
+async function uploadFile(
+  config: HlsCdnConfig,
+  filePath: string,
+  fileName: string,
+): Promise<void> {
+  const existingUpload = pendingUploads.get(fileName);
+  if (existingUpload) {
+    await existingUpload;
+    return;
+  }
+
+  const uploadPromise = (async () => {
+    try {
+      const body = await readFile(filePath);
+      const hash = sha256Hex(body);
+
+      // Skip if unchanged (for .m3u8 which gets rewritten)
+      if (uploadedHashes.get(fileName) === hash) {
+        return;
+      }
+
+      const contentType = fileName.endsWith(".m3u8")
+        ? "application/vnd.apple.mpegurl"
+        : "video/MP2T";
+
+      const key = `${config.prefix}${fileName}`;
+      const { url, headers } = signS3PutRequest({
+        endpoint: config.endpoint,
+        bucket: config.bucket,
+        key,
+        body,
+        contentType,
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+        region: config.region,
+      });
+
+      const response = await fetch(url, {
+        method: "PUT",
+        headers,
+        body,
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        console.error(
+          `[HLS-CDN] Upload failed: ${fileName} → ${response.status} ${text.slice(0, 200)}`,
+        );
+        return;
+      }
+
+      uploadedHashes.set(fileName, hash);
+
+      // Evict old entries
+      if (uploadedHashes.size > MAX_TRACKED_FILES) {
+        const keys = [...uploadedHashes.keys()];
+        for (let i = 0; i < 100; i++) {
+          uploadedHashes.delete(keys[i]);
+        }
+      }
+    } catch (err) {
+      console.error(
+        `[HLS-CDN] Upload error: ${fileName}`,
+        err instanceof Error ? err.message : err,
+      );
+    } finally {
+      pendingUploads.delete(fileName);
+    }
+  })();
+
+  pendingUploads.set(fileName, uploadPromise);
+  await uploadPromise;
+}
+
+// HLS output produces structured filenames (e.g. index.m3u8, 0001.ts).
+// Restrict uploads to this allowlist so a crafted filename such as
+// "../../../etc/passwd" cannot traverse outside config.hlsDir, even if the
+// watcher or readdir output is ever influenced by a compromised capture
+// process. basename() alone is not enough — it strips prefixes but permits
+// arbitrary characters in the leaf.
+const HLS_SAFE_FILENAME_RE = /^[A-Za-z0-9._-]+$/;
+const isSafeHlsFilename = (name: string): boolean =>
+  HLS_SAFE_FILENAME_RE.test(name) &&
+  !name.startsWith(".") &&
+  !name.includes("..");
+
+async function syncDirectory(config: HlsCdnConfig): Promise<void> {
+  try {
+    const files = await readdir(config.hlsDir);
+    const hlsFiles = files.filter(
+      (f) => isSafeHlsFilename(f) && (f.endsWith(".ts") || f.endsWith(".m3u8")),
+    );
+
+    // Upload .ts segments first, then .m3u8 (so playlist references exist)
+    const segments = hlsFiles.filter((f) => f.endsWith(".ts"));
+    const playlists = hlsFiles.filter((f) => f.endsWith(".m3u8"));
+
+    await Promise.all(
+      segments.map((f) => uploadFile(config, join(config.hlsDir, f), f)),
+    );
+    await Promise.all(
+      playlists.map((f) => uploadFile(config, join(config.hlsDir, f), f)),
+    );
+  } catch (err) {
+    // Directory may not exist yet
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error(
+        "[HLS-CDN] Sync error",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+/**
+ * Start watching the HLS output directory and syncing to CDN.
+ * Returns the public CDN URL for the stream, or null if not configured.
+ */
+export function startHlsCdnSync(): string | null {
+  const config = getConfig();
+  if (!config) {
+    console.log("[HLS-CDN] CDN sync disabled");
+    return null;
+  }
+
+  const publicUrl = config.publicUrl
+    ? `${config.publicUrl.replace(/\/$/, "")}/${config.prefix}stream.m3u8`
+    : `${config.endpoint}/${config.bucket}/${config.prefix}stream.m3u8`;
+
+  if (watcher || syncInterval) {
+    console.warn("[HLS-CDN] CDN sync already running");
+    return publicUrl;
+  }
+
+  console.log(
+    `[HLS-CDN] Starting CDN sync: ${config.hlsDir} → ${config.endpoint}/${config.bucket}/${config.prefix}`,
+  );
+
+  // Watch for file changes
+  try {
+    watcher = watch(
+      config.hlsDir,
+      { persistent: false },
+      (eventType, filename) => {
+        if (!filename) return;
+        const rawFileName = filename.toString();
+        const safeFileName = basename(rawFileName);
+        if (safeFileName !== rawFileName) {
+          return;
+        }
+        if (!isSafeHlsFilename(safeFileName)) {
+          return;
+        }
+        if (safeFileName.endsWith(".ts") || safeFileName.endsWith(".m3u8")) {
+          void uploadFile(
+            config,
+            join(config.hlsDir, safeFileName),
+            safeFileName,
+          );
+        }
+      },
+    );
+    watcher.on("error", (err) => {
+      console.error("[HLS-CDN] Watcher error", err.message);
+    });
+  } catch {
+    console.warn(
+      "[HLS-CDN] Could not start watcher — falling back to polling only",
+    );
+  }
+
+  // Also poll periodically as a safety net (watcher can miss events)
+  syncInterval = setInterval(() => void syncDirectory(config), 2000);
+  syncInterval.unref();
+
+  // Initial sync
+  void syncDirectory(config);
+
+  console.log(`[HLS-CDN] Public stream URL: ${publicUrl}`);
+  return publicUrl;
+}
+
+/**
+ * Stop the CDN sync watcher and interval.
+ */
+export function stopHlsCdnSync(): void {
+  if (watcher) {
+    watcher.close();
+    watcher = null;
+  }
+  if (syncInterval) {
+    clearInterval(syncInterval);
+    syncInterval = null;
+  }
+  uploadedHashes.clear();
+  pendingUploads.clear();
+  console.log("[HLS-CDN] CDN sync stopped");
+}
+
+/**
+ * Get the configured CDN public URL for the stream, or the local fallback.
+ */
+export function getHlsStreamUrl(): string {
+  const publicUrl = process.env.HLS_CDN_PUBLIC_URL?.trim();
+  const prefix = process.env.HLS_CDN_PREFIX?.trim() || "live/";
+
+  if (publicUrl) {
+    return `${publicUrl.replace(/\/$/, "")}/${prefix}stream.m3u8`;
+  }
+
+  // Fall back to local /live/ path
+  return "/live/stream.m3u8";
+}

--- a/packages/server/src/streaming/index.ts
+++ b/packages/server/src/streaming/index.ts
@@ -43,3 +43,8 @@ export {
   type AllocRecord,
   type LeakSnapshot,
 } from "./stream-leak-diagnostics.js";
+export {
+  startHlsCdnSync,
+  stopHlsCdnSync,
+  getHlsStreamUrl,
+} from "./hls-cdn-sync.js";

--- a/packages/server/src/streaming/ingest-config.ts
+++ b/packages/server/src/streaming/ingest-config.ts
@@ -1,0 +1,156 @@
+export type StreamIngestProfile = "default" | "cloudflare_live";
+export type StreamIngestTransport = "rtmps" | "srt";
+
+export type StreamIngestSettings = {
+  profile: StreamIngestProfile;
+  transport: StreamIngestTransport;
+  audioSampleRate: number;
+  gopFrames: number;
+  probeOnly: boolean;
+  srtUrl: string | null;
+  srtStreamId: string | null;
+  srtPassphrase: string | null;
+};
+
+function isValidUrl(value: string, allowedProtocols: string[]): boolean {
+  try {
+    const parsed = new URL(value);
+    return allowedProtocols.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value == null) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+function parsePositiveInt(
+  value: string | undefined,
+  fallback: number,
+  minValue: number,
+): number {
+  const parsed = Number.parseInt(value || "", 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(minValue, parsed);
+}
+
+function asNonEmptyString(value: string | undefined): string | null {
+  const trimmed = value?.trim() || "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolveConfiguredRtmpsIngestUrl(env: NodeJS.ProcessEnv): string | null {
+  return (
+    asNonEmptyString(env.STREAM_EXTERNAL_INGEST_RTMPS_URL) ??
+    asNonEmptyString(env.STREAM_INGEST_RTMPS_URL)
+  );
+}
+
+export function resolveStreamIngestSettings(
+  env: NodeJS.ProcessEnv,
+): StreamIngestSettings {
+  const profile =
+    env.STREAM_INGEST_PROFILE?.trim() === "cloudflare_live"
+      ? "cloudflare_live"
+      : "default";
+  const transport =
+    env.STREAM_INGEST_TRANSPORT?.trim().toLowerCase() === "srt"
+      ? "srt"
+      : "rtmps";
+  const defaultFps = parsePositiveInt(env.STREAM_FPS, 30, 1);
+  const defaultGopFrames =
+    profile === "cloudflare_live"
+      ? Math.max(2, defaultFps * 2)
+      : parsePositiveInt(env.STREAM_GOP_SIZE, defaultFps, 1);
+  const gopFrames = parsePositiveInt(
+    env.STREAM_GOP_SIZE,
+    defaultGopFrames,
+    1,
+  );
+  const audioSampleRate = parsePositiveInt(
+    env.STREAM_AUDIO_SAMPLE_RATE,
+    profile === "cloudflare_live" ? 48_000 : 44_100,
+    8_000,
+  );
+
+  return {
+    profile,
+    transport,
+    audioSampleRate,
+    gopFrames,
+    probeOnly: parseBoolean(env.STREAM_CLOUDFLARE_PROBE_ONLY, false),
+    srtUrl: asNonEmptyString(env.STREAM_INGEST_SRT_URL),
+    srtStreamId: asNonEmptyString(env.STREAM_INGEST_SRT_STREAM_ID),
+    srtPassphrase: asNonEmptyString(env.STREAM_INGEST_SRT_PASSPHRASE),
+  };
+}
+
+export function validateStreamIngestSettings(
+  env: NodeJS.ProcessEnv,
+  settings: StreamIngestSettings = resolveStreamIngestSettings(env),
+): string[] {
+  const issues: string[] = [];
+  const deliveryMode = env.STREAM_DELIVERY_MODE?.trim().toLowerCase() ?? "self_hls";
+  const externalDeliveryEnabled =
+    deliveryMode === "external_hls" || settings.probeOnly === true;
+
+  if (!externalDeliveryEnabled) {
+    return issues;
+  }
+
+  if (settings.transport === "srt") {
+    if (!settings.srtUrl) {
+      issues.push("STREAM_INGEST_SRT_URL is required when STREAM_INGEST_TRANSPORT=srt");
+    } else if (!isValidUrl(settings.srtUrl, ["srt:"])) {
+      issues.push("STREAM_INGEST_SRT_URL must be a valid srt:// URL");
+    }
+
+    if (!settings.srtStreamId) {
+      issues.push("STREAM_INGEST_SRT_STREAM_ID is required when STREAM_INGEST_TRANSPORT=srt");
+    }
+
+    if (!settings.srtPassphrase) {
+      issues.push("STREAM_INGEST_SRT_PASSPHRASE is required when STREAM_INGEST_TRANSPORT=srt");
+    } else if (settings.srtPassphrase.length < 10) {
+      issues.push("STREAM_INGEST_SRT_PASSPHRASE must be at least 10 characters");
+    }
+
+    return issues;
+  }
+
+  const rtmpsUrl = resolveConfiguredRtmpsIngestUrl(env);
+  if (!rtmpsUrl) {
+    issues.push(
+      "STREAM_INGEST_RTMPS_URL or STREAM_EXTERNAL_INGEST_RTMPS_URL is required when STREAM_INGEST_TRANSPORT=rtmps",
+    );
+  } else if (!isValidUrl(rtmpsUrl, ["rtmp:", "rtmps:"])) {
+    issues.push(
+      "STREAM_INGEST_RTMPS_URL or STREAM_EXTERNAL_INGEST_RTMPS_URL must be a valid rtmp:// or rtmps:// URL",
+    );
+  }
+
+  const streamKey = asNonEmptyString(env.STREAM_INGEST_STREAM_KEY);
+  if (!streamKey) {
+    issues.push("STREAM_INGEST_STREAM_KEY is required when STREAM_INGEST_TRANSPORT=rtmps");
+  }
+
+  return issues;
+}
+
+export function assertValidStreamIngestSettings(
+  env: NodeJS.ProcessEnv,
+  settings?: StreamIngestSettings,
+): StreamIngestSettings {
+  const resolvedSettings = settings ?? resolveStreamIngestSettings(env);
+  const issues = validateStreamIngestSettings(env, resolvedSettings);
+  if (issues.length > 0) {
+    throw new Error(`Invalid stream ingest configuration: ${issues.join("; ")}`);
+  }
+  return resolvedSettings;
+}

--- a/packages/server/src/streaming/source-runtime.ts
+++ b/packages/server/src/streaming/source-runtime.ts
@@ -1,0 +1,179 @@
+export type StreamSourceStatusSource =
+  | "external_worker"
+  | "in_process_bridge"
+  | "none";
+
+export type StreamSourceCaptureMode =
+  | "cdp"
+  | "webcodecs"
+  | "mediarecorder"
+  | "x11_nvenc"
+  | "none";
+
+export type StreamSourceDegradedReason =
+  | "worker_missing"
+  | "browser_missing"
+  | "page_not_ready"
+  | "unexpected_navigation"
+  | "capture_stalled"
+  | "encoder_stalled"
+  | "manifest_stale"
+  | "destination_disconnected"
+  | "status_stale"
+  | "unknown";
+
+export type StreamSourceRuntime = {
+  ready: boolean;
+  statusSource: StreamSourceStatusSource;
+  captureMode: StreamSourceCaptureMode;
+  degradedReason: StreamSourceDegradedReason | null;
+  currentSceneUrl: string | null;
+  activeBundle: string | null;
+  lastFrameAt: number | null;
+  lastRenderTickAt: number | null;
+  lastVisualChangeAt: number | null;
+  lastRecoveryAt: number | null;
+  recoveryCount: number;
+  workerHeartbeatAt: number | null;
+};
+
+export type BrowserCaptureStatusSnapshot = {
+  lastChunkAt?: number | null;
+  lastChunkAgeMs?: number | null;
+  lastChunkMs?: number | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function normalizeNonNegativeFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, value)
+    : null;
+}
+
+export function normalizeStreamSourceStatusSource(
+  value: unknown,
+): StreamSourceStatusSource | null {
+  return value === "external_worker" ||
+    value === "in_process_bridge" ||
+    value === "none"
+    ? value
+    : null;
+}
+
+export function normalizeStreamSourceCaptureMode(
+  value: unknown,
+): StreamSourceCaptureMode | null {
+  return value === "cdp" ||
+    value === "webcodecs" ||
+    value === "mediarecorder" ||
+    value === "x11_nvenc" ||
+    value === "none"
+    ? value
+    : null;
+}
+
+export function normalizeStreamSourceDegradedReason(
+  value: unknown,
+): StreamSourceDegradedReason | null {
+  return value === "worker_missing" ||
+    value === "browser_missing" ||
+    value === "page_not_ready" ||
+    value === "unexpected_navigation" ||
+    value === "capture_stalled" ||
+    value === "encoder_stalled" ||
+    value === "manifest_stale" ||
+    value === "destination_disconnected" ||
+    value === "status_stale" ||
+    value === "unknown"
+    ? value
+    : null;
+}
+
+export function normalizeStreamSourceRuntime(
+  value: unknown,
+): StreamSourceRuntime | null {
+  const candidate = asRecord(value);
+  if (!candidate) return null;
+
+  return {
+    ready: candidate.ready === true,
+    statusSource:
+      normalizeStreamSourceStatusSource(candidate.statusSource) ?? "none",
+    captureMode:
+      normalizeStreamSourceCaptureMode(candidate.captureMode) ?? "none",
+    degradedReason: normalizeStreamSourceDegradedReason(
+      candidate.degradedReason,
+    ),
+    currentSceneUrl: asNonEmptyString(candidate.currentSceneUrl),
+    activeBundle: asNonEmptyString(candidate.activeBundle),
+    lastFrameAt: asFiniteNumber(candidate.lastFrameAt),
+    lastRenderTickAt: asFiniteNumber(candidate.lastRenderTickAt),
+    lastVisualChangeAt: asFiniteNumber(candidate.lastVisualChangeAt),
+    lastRecoveryAt: asFiniteNumber(candidate.lastRecoveryAt),
+    recoveryCount: Math.max(0, asFiniteNumber(candidate.recoveryCount) ?? 0),
+    workerHeartbeatAt: asFiniteNumber(candidate.workerHeartbeatAt),
+  };
+}
+
+export function resolveBrowserCaptureLastFrameAt(
+  status: BrowserCaptureStatusSnapshot | null | undefined,
+  nowMs: number,
+): number | null {
+  const lastChunkAt = normalizeNonNegativeFiniteNumber(status?.lastChunkAt);
+  if (lastChunkAt != null && lastChunkAt > 0) {
+    return lastChunkAt;
+  }
+
+  const lastChunkAgeMs =
+    normalizeNonNegativeFiniteNumber(status?.lastChunkAgeMs) ??
+    normalizeNonNegativeFiniteNumber(status?.lastChunkMs);
+  if (lastChunkAgeMs == null) {
+    return null;
+  }
+
+  return Math.max(0, nowMs - lastChunkAgeMs);
+}
+
+export function buildUnavailableStreamSourceRuntime(params?: {
+  statusSource?: StreamSourceStatusSource;
+  captureMode?: StreamSourceCaptureMode;
+  degradedReason?: StreamSourceDegradedReason | null;
+  currentSceneUrl?: string | null;
+  activeBundle?: string | null;
+  lastFrameAt?: number | null;
+  lastRenderTickAt?: number | null;
+  lastVisualChangeAt?: number | null;
+  lastRecoveryAt?: number | null;
+  recoveryCount?: number;
+  workerHeartbeatAt?: number | null;
+}): StreamSourceRuntime {
+  return {
+    ready: false,
+    statusSource: params?.statusSource ?? "none",
+    captureMode: params?.captureMode ?? "none",
+    degradedReason: params?.degradedReason ?? "unknown",
+    currentSceneUrl: params?.currentSceneUrl ?? null,
+    activeBundle: params?.activeBundle ?? null,
+    lastFrameAt: params?.lastFrameAt ?? null,
+    lastRenderTickAt: params?.lastRenderTickAt ?? null,
+    lastVisualChangeAt: params?.lastVisualChangeAt ?? null,
+    lastRecoveryAt: params?.lastRecoveryAt ?? null,
+    recoveryCount: Math.max(0, params?.recoveryCount ?? 0),
+    workerHeartbeatAt: params?.workerHeartbeatAt ?? null,
+  };
+}

--- a/packages/server/src/streaming/stream-capture.ts
+++ b/packages/server/src/streaming/stream-capture.ts
@@ -52,6 +52,23 @@ export function getStreamCapture(): {
     bridgeActive: boolean;
     ffmpegRunning: boolean;
     clientConnected: boolean;
+    bytesReceived: number;
+    uptime: number;
+    destinations: number;
+    restartAttempts: number;
+    lastCrash: number;
+    healthy: boolean;
+    droppedFrames: number;
+    backpressured: boolean;
+    spectators: number;
+    encoderFps?: number | null;
+    processMemory: {
+      rssBytes: number;
+      heapTotalBytes: number;
+      heapUsedBytes: number;
+      externalBytes: number;
+      arrayBuffersBytes: number;
+    };
   };
 } {
   const bridge = peekRTMPBridge();
@@ -64,6 +81,23 @@ export function getStreamCapture(): {
         bridgeActive: false,
         ffmpegRunning: false,
         clientConnected: false,
+        bytesReceived: 0,
+        uptime: 0,
+        destinations: 0,
+        restartAttempts: 0,
+        lastCrash: 0,
+        healthy: false,
+        droppedFrames: 0,
+        backpressured: false,
+        spectators: 0,
+        encoderFps: null,
+        processMemory: {
+          rssBytes: 0,
+          heapTotalBytes: 0,
+          heapUsedBytes: 0,
+          externalBytes: 0,
+          arrayBuffersBytes: 0,
+        },
       }),
     };
   }

--- a/packages/server/src/streaming/stream-destinations.test.ts
+++ b/packages/server/src/streaming/stream-destinations.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isStreamDestinationEnabled,
+  resolveEnabledStreamDestinations,
+} from "./stream-destinations.js";
+
+describe("stream destination selection", () => {
+  it("keeps destinations enabled by default for backwards compatibility", () => {
+    const enabledDestinations = resolveEnabledStreamDestinations(undefined);
+
+    expect(isStreamDestinationEnabled(enabledDestinations, "external")).toBe(
+      true,
+    );
+    expect(isStreamDestinationEnabled(enabledDestinations, "twitch")).toBe(
+      true,
+    );
+  });
+
+  it("allows self-HLS-only staging to disable external delivery", () => {
+    const enabledDestinations = resolveEnabledStreamDestinations("self_hls");
+
+    expect(isStreamDestinationEnabled(enabledDestinations, "external")).toBe(
+      false,
+    );
+    expect(isStreamDestinationEnabled(enabledDestinations, "twitch")).toBe(
+      false,
+    );
+  });
+
+  it("recognizes Cloudflare as the external delivery destination", () => {
+    const enabledDestinations = resolveEnabledStreamDestinations("cloudflare");
+
+    expect(isStreamDestinationEnabled(enabledDestinations, "external")).toBe(
+      true,
+    );
+    expect(isStreamDestinationEnabled(enabledDestinations, "twitch")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/server/src/streaming/stream-destinations.ts
+++ b/packages/server/src/streaming/stream-destinations.ts
@@ -1,5 +1,6 @@
 export type StreamDestinationKind =
   | "custom"
+  | "external"
   | "kick"
   | "multiplexer"
   | "pumpfun"
@@ -8,7 +9,12 @@ export type StreamDestinationKind =
   | "youtube";
 
 const DESTINATION_ALIASES: Record<string, StreamDestinationKind> = {
+  cloudflare: "external",
+  cloudflarelive: "external",
+  cloudflarestream: "external",
   custom: "custom",
+  external: "external",
+  externaldelivery: "external",
   kick: "kick",
   multiplexer: "multiplexer",
   pump: "pumpfun",

--- a/packages/server/src/streaming/stream-status-artifacts.ts
+++ b/packages/server/src/streaming/stream-status-artifacts.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type HlsManifestSnapshot = {
+  updatedAt: number | null;
+  mediaSequence: number | null;
+};
+
+const HLS_MANIFEST_CACHE_TTL_MS = 250;
+
+let cachedManifestPath: string | null = null;
+let cachedManifestReadAt = 0;
+let cachedManifestSnapshot: HlsManifestSnapshot | null = null;
+
+function asNonEmptyString(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+export function resolveExternalStatusFile(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const explicit = asNonEmptyString(env.RTMP_STATUS_FILE);
+  if (explicit) {
+    return explicit;
+  }
+
+  const hlsOutputPath = asNonEmptyString(env.HLS_OUTPUT_PATH);
+  if (!hlsOutputPath) {
+    return null;
+  }
+
+  return path.join(path.dirname(hlsOutputPath), "rtmp-status.json");
+}
+
+export function readLocalHlsManifestSnapshot(
+  env: NodeJS.ProcessEnv = process.env,
+): HlsManifestSnapshot {
+  const hlsOutputPath = asNonEmptyString(env.HLS_OUTPUT_PATH);
+  if (!hlsOutputPath) {
+    return {
+      updatedAt: null,
+      mediaSequence: null,
+    };
+  }
+
+  if (
+    cachedManifestPath === hlsOutputPath &&
+    cachedManifestSnapshot &&
+    Date.now() - cachedManifestReadAt <= HLS_MANIFEST_CACHE_TTL_MS
+  ) {
+    return cachedManifestSnapshot;
+  }
+
+  try {
+    const stat = fs.statSync(hlsOutputPath);
+    const rawManifest = fs.readFileSync(hlsOutputPath, "utf8");
+    const mediaSequenceMatch = rawManifest.match(
+      /#EXT-X-MEDIA-SEQUENCE:(\d+)/i,
+    );
+    const mediaSequence = mediaSequenceMatch
+      ? Number.parseInt(mediaSequenceMatch[1] || "", 10)
+      : null;
+
+    const snapshot = {
+      updatedAt: Number.isFinite(stat.mtimeMs) ? Math.round(stat.mtimeMs) : null,
+      mediaSequence:
+        mediaSequence != null && Number.isFinite(mediaSequence)
+          ? mediaSequence
+          : null,
+    };
+    cachedManifestPath = hlsOutputPath;
+    cachedManifestReadAt = Date.now();
+    cachedManifestSnapshot = snapshot;
+    return snapshot;
+  } catch {
+    const snapshot = {
+      updatedAt: null,
+      mediaSequence: null,
+    };
+    cachedManifestPath = hlsOutputPath;
+    cachedManifestReadAt = Date.now();
+    cachedManifestSnapshot = snapshot;
+    return snapshot;
+  }
+}

--- a/packages/server/src/streaming/types.ts
+++ b/packages/server/src/streaming/types.ts
@@ -1,3 +1,9 @@
+import type {
+  StreamDeliveryTransport,
+  StreamDestinationProvider,
+  StreamDestinationRole,
+} from "./delivery-config.js";
+
 /**
  * RTMP Streaming Types
  *
@@ -6,7 +12,13 @@
 
 /** RTMP destination configuration */
 export interface RTMPDestination {
+  id?: string;
   name: string;
+  role?: StreamDestinationRole;
+  provider?: StreamDestinationProvider;
+  transport?: StreamDeliveryTransport;
+  playbackUrl?: string | null;
+  ingestUrl?: string | null;
   url: string;
   key: string;
   enabled: boolean;
@@ -28,19 +40,34 @@ export interface StreamingConfig {
   preset: "ultrafast" | "veryfast" | "fast" | "medium";
   /** Keyframe interval in frames */
   gopSize: number;
-  /** Capture mode: 'cdp' uses Page.startScreencast, 'mediarecorder' uses legacy WebSocket path, 'webcodecs' uses hardware VideoEncoder */
-  captureMode: "cdp" | "mediarecorder" | "webcodecs";
+  /** Capture mode: 'cdp' uses Page.startScreencast, 'mediarecorder' uses legacy WebSocket path, 'webcodecs' uses hardware VideoEncoder, 'x11_nvenc' uses X11 desktop capture + NVENC encode */
+  captureMode: "cdp" | "mediarecorder" | "webcodecs" | "x11_nvenc";
   /** JPEG quality for CDP screencast frames (1-100, default 80) */
   jpegQuality: number;
 }
 
 /** Stream status for a single destination */
 export interface DestinationStatus {
+  id?: string;
   name: string;
+  role?: StreamDestinationRole;
+  provider?: StreamDestinationProvider;
+  transport?: StreamDeliveryTransport;
+  playbackUrl?: string | null;
+  ingestUrl?: string | null;
   connected: boolean;
   error?: string;
   bytesWritten: number;
   startedAt?: number;
+  /**
+   * Wallclock ms of the most recent fatal write-error attributed to this
+   * destination (slave-muxer failure, av_interleaved_write_frame error,
+   * RTMPS session invalidated, etc.). Used to prevent the "FFmpeg
+   * is still emitting `frame=` progress so everything must be OK" false
+   * positive from flipping `connected` back to `true` while the RTMP
+   * destination is actually dark.
+   */
+  lastWriteErrorAt?: number | null;
 }
 
 /** Overall streaming status */

--- a/packages/server/src/systems/DuelScheduler/BettingPoolManager.ts
+++ b/packages/server/src/systems/DuelScheduler/BettingPoolManager.ts
@@ -1,0 +1,522 @@
+/**
+ * BettingPoolManager — Handles bet placement, pool aggregation, and claim creation
+ *
+ * Works with the DuelBettingBridge for market lifecycle and the solanaBets/solanaPayoutJobs
+ * tables for persistence. Emits betting:pool:updated events on the World.
+ */
+
+import type { World } from "@hyperscape/shared";
+import { eq, and, sql } from "drizzle-orm";
+import { getDatabase } from "../../database/client.js";
+import {
+  solanaBets,
+  solanaPayoutJobs,
+  arenaRounds,
+} from "../../database/schema.js";
+import { Logger } from "../ServerNetwork/services";
+import { randomUUID } from "node:crypto";
+
+export interface BetPlacement {
+  roundId: string;
+  side: "A" | "B";
+  amount: string; // string to preserve precision
+  walletAddress: string;
+}
+
+export interface PoolState {
+  roundId: string;
+  sideATotal: string;
+  sideBTotal: string;
+  sideACount: number;
+  sideBCount: number;
+}
+
+export interface BetRecord {
+  id: string;
+  roundId: string;
+  side: string;
+  amount: string;
+  walletAddress: string;
+  status: string;
+  createdAt: number;
+}
+
+const MAX_BETS_BY_WALLET_LIMIT = 100;
+const MAX_BETTING_LEADERBOARD_LIMIT = 100;
+const MAX_BETS_PER_WALLET_PER_ROUND = 100;
+
+export class BettingPoolManager {
+  private readonly world: World;
+
+  constructor(world: World) {
+    this.world = world;
+  }
+
+  /**
+   * Place a bet on a duel market.
+   */
+  async placeBet(
+    bet: BetPlacement,
+  ): Promise<{ success: boolean; error?: string; betId?: string }> {
+    const db = getDatabase();
+
+    // Verify the round exists and is in betting phase
+    const bridge = (
+      this.world as World & {
+        duelBettingBridge?: {
+          getMarket(id: string): { status: string } | null;
+        };
+      }
+    ).duelBettingBridge;
+    const market = bridge?.getMarket(bet.roundId);
+
+    if (!market) {
+      return { success: false, error: "Market not found" };
+    }
+
+    if (market.status !== "betting") {
+      return {
+        success: false,
+        error: `Market is ${market.status}, betting is closed`,
+      };
+    }
+
+    if (!isValidPositiveDecimalAmount(bet.amount)) {
+      return { success: false, error: "Invalid bet amount" };
+    }
+
+    if (!isValidSolanaWalletAddress(bet.walletAddress)) {
+      return { success: false, error: "Invalid wallet address" };
+    }
+
+    const betId = randomUUID();
+    try {
+      const insertResult = await db.transaction(async (tx) => {
+        const lockedRounds = await tx.execute<{
+          id: string;
+          bettingClosesAt: number;
+          duelEndsAt: number | null;
+          winnerId: string | null;
+        }>(
+          sql`
+            SELECT
+              id,
+              "bettingClosesAt",
+              "duelEndsAt",
+              "winnerId"
+            FROM arena_rounds
+            WHERE id = ${bet.roundId}
+            FOR UPDATE
+          `,
+        );
+        const round = lockedRounds.rows[0];
+        if (!round) {
+          return { success: false, error: "Round not found" } as const;
+        }
+        if (
+          round.bettingClosesAt <= Date.now() ||
+          round.duelEndsAt !== null ||
+          round.winnerId !== null
+        ) {
+          return {
+            success: false,
+            error: "Market is locked, betting is closed",
+          } as const;
+        }
+
+        // The round row lock above serializes market-close checks for this
+        // round. This per-wallet xact lock makes the bet-count invariant
+        // explicit too: concurrent requests for the same wallet/round cannot
+        // both count N and insert N+1.
+        await tx.execute(sql`
+          SELECT pg_advisory_xact_lock(
+            hashtext(${bet.roundId}),
+            hashtext(${bet.walletAddress})
+          )
+        `);
+
+        const existingBetCountRows = await tx
+          .select({
+            count: sql<number>`COUNT(*)::INT`,
+          })
+          .from(solanaBets)
+          .where(
+            and(
+              eq(solanaBets.roundId, bet.roundId),
+              eq(solanaBets.bettorWallet, bet.walletAddress),
+              eq(solanaBets.status, "CONFIRMED"),
+            ),
+          );
+        const existingBetCount = Number(existingBetCountRows[0]?.count ?? 0);
+        if (existingBetCount >= MAX_BETS_PER_WALLET_PER_ROUND) {
+          return {
+            success: false,
+            error: "Too many bets for this wallet on this round",
+          } as const;
+        }
+
+        await tx.insert(solanaBets).values({
+          id: betId,
+          roundId: bet.roundId,
+          bettorWallet: bet.walletAddress,
+          side: bet.side,
+          sourceAsset: "GOLD",
+          sourceAmount: bet.amount,
+          goldAmount: bet.amount,
+          status: "CONFIRMED",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+        return { success: true } as const;
+      });
+      if (!insertResult.success) {
+        return { success: false, error: insertResult.error };
+      }
+    } catch (err) {
+      Logger.error(
+        "BettingPoolManager",
+        "Failed to insert bet",
+        err instanceof Error ? err : null,
+        {
+          roundId: bet.roundId,
+          wallet: redactWalletAddress(bet.walletAddress),
+        },
+      );
+      return { success: false, error: "Database error" };
+    }
+
+    // Emit pool update
+    const pool = await this.getPool(bet.roundId);
+    if (pool) {
+      this.world.emit("betting:pool:updated", {
+        roundId: bet.roundId,
+        sideATotal: pool.sideATotal,
+        sideBTotal: pool.sideBTotal,
+        sideACount: pool.sideACount,
+        sideBCount: pool.sideBCount,
+      });
+    }
+
+    Logger.info("BettingPoolManager", "Bet placed", {
+      betId,
+      roundId: bet.roundId,
+      side: bet.side,
+      amount: bet.amount,
+      wallet: redactWalletAddress(bet.walletAddress),
+    });
+
+    return { success: true, betId };
+  }
+
+  /**
+   * Get aggregated pool totals for a round.
+   */
+  async getPool(roundId: string): Promise<PoolState | null> {
+    const db = getDatabase();
+
+    try {
+      const result = await db
+        .select({
+          side: solanaBets.side,
+          total: sql<string>`COALESCE(SUM(CAST(${solanaBets.goldAmount} AS NUMERIC)), 0)::TEXT`,
+          count: sql<number>`COUNT(*)::INT`,
+        })
+        .from(solanaBets)
+        .where(
+          and(
+            eq(solanaBets.roundId, roundId),
+            eq(solanaBets.status, "CONFIRMED"),
+          ),
+        )
+        .groupBy(solanaBets.side);
+
+      const pool: PoolState = {
+        roundId,
+        sideATotal: "0",
+        sideBTotal: "0",
+        sideACount: 0,
+        sideBCount: 0,
+      };
+
+      for (const row of result) {
+        if (row.side === "A") {
+          pool.sideATotal = row.total;
+          pool.sideACount = row.count;
+        } else if (row.side === "B") {
+          pool.sideBTotal = row.total;
+          pool.sideBCount = row.count;
+        }
+      }
+
+      return pool;
+    } catch (err) {
+      Logger.error(
+        "BettingPoolManager",
+        "Failed to get pool",
+        err instanceof Error ? err : null,
+        { roundId },
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Get bet history for a wallet.
+   */
+  async getBetsByWallet(
+    walletAddress: string,
+    limit = 50,
+  ): Promise<BetRecord[]> {
+    const db = getDatabase();
+    const boundedLimit = Math.max(
+      1,
+      Math.min(Math.trunc(limit), MAX_BETS_BY_WALLET_LIMIT),
+    );
+
+    try {
+      const rows = await db
+        .select({
+          id: solanaBets.id,
+          roundId: solanaBets.roundId,
+          side: solanaBets.side,
+          amount: solanaBets.goldAmount,
+          walletAddress: solanaBets.bettorWallet,
+          status: solanaBets.status,
+          createdAt: solanaBets.createdAt,
+        })
+        .from(solanaBets)
+        .where(eq(solanaBets.bettorWallet, walletAddress))
+        .orderBy(sql`${solanaBets.createdAt} DESC`)
+        .limit(boundedLimit);
+
+      return rows;
+    } catch (err) {
+      Logger.error(
+        "BettingPoolManager",
+        "Failed to get bets by wallet",
+        err instanceof Error ? err : null,
+        { wallet: redactWalletAddress(walletAddress) },
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Create a claim/payout job for a winning bettor.
+   */
+  async createClaimJob(
+    roundId: string,
+    walletAddress: string,
+  ): Promise<{ success: boolean; error?: string; jobId?: string }> {
+    const db = getDatabase();
+
+    const jobId = randomUUID();
+    try {
+      const result = await db.transaction(async (tx) => {
+        // pg_try_advisory_xact_lock returns immediately with false if another
+        // transaction holds the lock, instead of blocking. If a concurrent
+        // claim for the same (round, wallet) pair hangs mid-transaction, the
+        // original pg_advisory_xact_lock would queue everyone behind it —
+        // that's an easy DoS vector on the payout path. Returning a conflict
+        // error lets the caller retry.
+        const lockRows = await tx.execute<{ acquired: boolean }>(sql`
+          SELECT pg_try_advisory_xact_lock(
+            hashtext(${roundId}),
+            hashtext(${walletAddress})
+          ) AS acquired
+        `);
+        if (!lockRows.rows[0]?.acquired) {
+          return {
+            success: false,
+            error: "A concurrent claim is in progress; retry shortly",
+          } as const;
+        }
+
+        const lockedRounds = await tx.execute<{
+          id: string;
+          winnerId: string | null;
+          agentAId: string;
+          agentBId: string;
+        }>(
+          sql`
+            SELECT
+              id,
+              "winnerId",
+              "agentAId",
+              "agentBId"
+            FROM arena_rounds
+            WHERE id = ${roundId}
+            FOR UPDATE
+          `,
+        );
+        const round = lockedRounds.rows[0];
+        if (!round) {
+          return { success: false, error: "Round not found" } as const;
+        }
+        if (!round.winnerId) {
+          return {
+            success: false,
+            error: "Round has not resolved yet",
+          } as const;
+        }
+
+        const winningSide =
+          round.winnerId === round.agentAId
+            ? "A"
+            : round.winnerId === round.agentBId
+              ? "B"
+              : null;
+        if (!winningSide) {
+          return {
+            success: false,
+            error: "Round winner does not match either bettor side",
+          } as const;
+        }
+
+        const bets = await tx
+          .select()
+          .from(solanaBets)
+          .where(
+            and(
+              eq(solanaBets.roundId, roundId),
+              eq(solanaBets.bettorWallet, walletAddress),
+              eq(solanaBets.status, "CONFIRMED"),
+            ),
+          );
+
+        if (bets.length === 0) {
+          return {
+            success: false,
+            error: "No confirmed bet found for this round",
+          } as const;
+        }
+
+        const hasWinningBet = bets.some((bet) => bet.side === winningSide);
+        if (!hasWinningBet) {
+          return {
+            success: false,
+            error: "No winning bet found for this round",
+          } as const;
+        }
+
+        // Deliberately status-blind: any payout job for this
+        // (round, wallet) pair is the idempotency record, including
+        // READY_FOR_PAYOUT / FAILED rows. Narrowing this by status would allow
+        // duplicate claim jobs unless a database unique constraint is added.
+        const existing = await tx
+          .select()
+          .from(solanaPayoutJobs)
+          .where(
+            and(
+              eq(solanaPayoutJobs.roundId, roundId),
+              eq(solanaPayoutJobs.bettorWallet, walletAddress),
+            ),
+          )
+          .limit(1);
+
+        if (existing.length > 0) {
+          return { success: true, jobId: existing[0].id } as const;
+        }
+
+        await tx.insert(solanaPayoutJobs).values({
+          id: jobId,
+          roundId,
+          bettorWallet: walletAddress,
+          status: "PENDING",
+          attempts: 0,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        });
+        return { success: true, jobId } as const;
+      });
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      Logger.info("BettingPoolManager", "Claim job created", {
+        jobId: result.jobId,
+        roundId,
+        wallet: redactWalletAddress(walletAddress),
+      });
+      return { success: true, jobId: result.jobId };
+    } catch (err) {
+      Logger.error(
+        "BettingPoolManager",
+        "Failed to create payout job",
+        err instanceof Error ? err : null,
+        { roundId, wallet: redactWalletAddress(walletAddress) },
+      );
+      return { success: false, error: "Database error" };
+    }
+  }
+
+  /**
+   * Get leaderboard — top bettors by total winnings.
+   */
+  async getLeaderboard(
+    limit = 20,
+  ): Promise<
+    Array<{ wallet: string; totalBets: number; totalWagered: string }>
+  > {
+    const db = getDatabase();
+    const boundedLimit = Math.max(
+      1,
+      Math.min(Math.trunc(limit), MAX_BETTING_LEADERBOARD_LIMIT),
+    );
+
+    try {
+      const rows = await db
+        .select({
+          wallet: solanaBets.bettorWallet,
+          totalBets: sql<number>`COUNT(*)::INT`,
+          totalWagered: sql<string>`COALESCE(SUM(CAST(${solanaBets.goldAmount} AS NUMERIC)), 0)::TEXT`,
+        })
+        .from(solanaBets)
+        .where(eq(solanaBets.status, "CONFIRMED"))
+        .groupBy(solanaBets.bettorWallet)
+        .orderBy(sql`SUM(CAST(${solanaBets.goldAmount} AS NUMERIC)) DESC`)
+        .limit(boundedLimit);
+
+      return rows;
+    } catch (err) {
+      Logger.error(
+        "BettingPoolManager",
+        "Failed to get leaderboard",
+        err instanceof Error ? err : null,
+      );
+      return [];
+    }
+  }
+}
+
+function isValidSolanaWalletAddress(walletAddress: string): boolean {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(walletAddress.trim());
+}
+
+// Integer portion capped at 18 digits (~10^18, covers lamports/gwei scale),
+// fractional capped at 8 digits. Unlimited precision previously admitted
+// strings like "1.123456789012345678901234567890" that could exacerbate
+// rounding errors in NUMERIC SUM aggregation and on-chain serialization.
+const BET_AMOUNT_PATTERN = /^(?:0|[1-9]\d{0,17})(?:\.\d{1,8})?$/;
+
+function isValidPositiveDecimalAmount(amount: string): boolean {
+  const normalized = amount.trim();
+  if (!BET_AMOUNT_PATTERN.test(normalized)) {
+    return false;
+  }
+  return !/^0+(?:\.0+)?$/.test(normalized);
+}
+
+/** @internal Pure helpers exposed for financial input-validation tests. */
+export const __bettingPoolManagerTestInternals = {
+  MAX_BETS_PER_WALLET_PER_ROUND,
+  isValidPositiveDecimalAmount,
+  isValidSolanaWalletAddress,
+};
+
+export function redactWalletAddress(walletAddress: string): string {
+  const trimmed = walletAddress.trim();
+  if (trimmed.length <= 12) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
+}

--- a/packages/server/src/systems/DuelScheduler/PayoutKeeper.ts
+++ b/packages/server/src/systems/DuelScheduler/PayoutKeeper.ts
@@ -1,0 +1,377 @@
+/**
+ * PayoutKeeper — Processes solanaPayoutJobs and sends winnings to bettors.
+ *
+ * Custodial model for launch: the server's operator wallet sends SOL/tokens
+ * to winning bettors. The fight oracle records results on-chain for verifiability.
+ *
+ * Polls the solanaPayoutJobs table every 5s for PENDING entries.
+ * Implements exponential backoff on failure, max 5 attempts.
+ */
+
+import { eq, and, inArray, sql } from "drizzle-orm";
+import { getDatabase } from "../../database/client.js";
+import {
+  solanaPayoutJobs,
+  solanaBets,
+  arenaRounds,
+} from "../../database/schema.js";
+import { Logger } from "../ServerNetwork/services";
+import { redactWalletAddress } from "./BettingPoolManager.js";
+
+const POLL_INTERVAL_MS = 5_000;
+const MAX_ATTEMPTS = 5;
+const BASE_BACKOFF_MS = 10_000;
+const MAX_BATCH_SIZE = 10;
+const PROCESSING_LEASE_MS = 60_000;
+const MAX_PERSISTED_ERROR_LENGTH = 240;
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let processing = false;
+
+type PayoutDb = ReturnType<typeof getDatabase>;
+type PayoutTransaction = Parameters<Parameters<PayoutDb["transaction"]>[0]>[0];
+type PayoutDbClient = Pick<PayoutTransaction, "execute" | "select" | "update">;
+
+function sanitizePayoutError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : "Unknown error";
+  const sanitized = raw
+    .replace(/https?:\/\/\S+/gi, "[url]")
+    .replace(/\b[1-9A-HJ-NP-Za-km-z]{32,88}\b/g, "[id]")
+    .replace(/\s+/g, " ")
+    .trim();
+  return (sanitized || "Unknown error").slice(0, MAX_PERSISTED_ERROR_LENGTH);
+}
+
+/**
+ * Start the payout keeper polling loop.
+ */
+export function startPayoutKeeper(): void {
+  if (pollTimer) return;
+
+  Logger.info("PayoutKeeper", "Starting payout keeper");
+
+  // Initial run
+  void processJobs();
+
+  pollTimer = setInterval(() => {
+    void processJobs();
+  }, POLL_INTERVAL_MS);
+  pollTimer.unref();
+}
+
+/**
+ * Stop the payout keeper.
+ */
+export function stopPayoutKeeper(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  processing = false;
+  Logger.info("PayoutKeeper", "Payout keeper stopped");
+}
+
+async function processJobs(): Promise<void> {
+  if (processing) return;
+  processing = true;
+
+  try {
+    const db = getDatabase();
+    const jobs = await db.transaction(async (tx) => {
+      const claimedJobIds = await claimDuePayoutJobIds(
+        tx,
+        Date.now(),
+        MAX_BATCH_SIZE,
+      );
+      return loadClaimedPayoutJobs(tx, claimedJobIds);
+    });
+    if (jobs.length === 0) {
+      return;
+    }
+
+    for (const job of jobs) {
+      await db.transaction(async (tx) => processOneJob(tx, job));
+    }
+  } catch (err) {
+    Logger.error(
+      "PayoutKeeper",
+      "Job processing loop failed",
+      err instanceof Error ? err : null,
+    );
+  } finally {
+    processing = false;
+  }
+}
+
+export async function claimDuePayoutJobIds(
+  tx: Pick<PayoutTransaction, "execute">,
+  now: number,
+  limit: number,
+): Promise<string[]> {
+  const boundedLimit = Math.max(1, Math.min(Math.trunc(limit), MAX_BATCH_SIZE));
+  const leaseUntil = now + PROCESSING_LEASE_MS;
+  const result = await tx.execute<{ id: string }>(sql`
+    WITH due AS (
+      SELECT "id"
+      FROM "solana_payout_jobs"
+      WHERE "status" = 'PENDING'
+        AND ("nextAttemptAt" IS NULL OR "nextAttemptAt" <= ${now})
+      ORDER BY "createdAt" ASC
+      LIMIT ${boundedLimit}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE "solana_payout_jobs"
+    SET "nextAttemptAt" = ${leaseUntil},
+        "updatedAt" = ${now}
+    WHERE "id" IN (SELECT "id" FROM due)
+    RETURNING "id"
+  `);
+
+  return result.rows
+    .map((row) => (typeof row.id === "string" ? row.id : null))
+    .filter((id): id is string => Boolean(id));
+}
+
+async function loadClaimedPayoutJobs(
+  tx: Pick<PayoutTransaction, "select">,
+  jobIds: readonly string[],
+): Promise<Array<typeof solanaPayoutJobs.$inferSelect>> {
+  if (jobIds.length === 0) {
+    return [];
+  }
+
+  const jobs = await tx
+    .select()
+    .from(solanaPayoutJobs)
+    .where(inArray(solanaPayoutJobs.id, [...jobIds]));
+  const jobsById = new Map(jobs.map((job) => [job.id, job]));
+
+  return jobIds
+    .map((jobId) => jobsById.get(jobId) ?? null)
+    .filter((job): job is typeof solanaPayoutJobs.$inferSelect => job !== null);
+}
+
+async function processOneJob(
+  db: PayoutDbClient,
+  job: typeof solanaPayoutJobs.$inferSelect,
+): Promise<void> {
+  try {
+    const lockRows = await db.execute<{ acquired: boolean }>(sql`
+      SELECT pg_try_advisory_xact_lock(
+        hashtext(${job.id}),
+        hashtext(${job.bettorWallet})
+      ) AS acquired
+    `);
+    if (!lockRows.rows[0]?.acquired) {
+      Logger.warn(
+        "PayoutKeeper",
+        "Payout job already locked by another worker",
+        {
+          jobId: job.id,
+          roundId: job.roundId,
+        },
+      );
+      return;
+    }
+
+    // Look up the round to check if it's resolved and who won
+    const rounds = await db
+      .select()
+      .from(arenaRounds)
+      .where(eq(arenaRounds.id, job.roundId))
+      .limit(1);
+
+    if (rounds.length === 0) {
+      await markFailed(db, job.id, "Round not found");
+      return;
+    }
+
+    const round = rounds[0];
+    if (!round.winnerId) {
+      // Round not resolved yet — schedule retry
+      await scheduleRetry(db, job.id, job.attempts, "Round not yet resolved");
+      return;
+    }
+
+    // Get the bettor's bets for this round
+    const bets = await db
+      .select()
+      .from(solanaBets)
+      .where(
+        and(
+          eq(solanaBets.roundId, job.roundId),
+          eq(solanaBets.bettorWallet, job.bettorWallet),
+          eq(solanaBets.status, "CONFIRMED"),
+        ),
+      );
+
+    if (bets.length === 0) {
+      await markFailed(db, job.id, "No confirmed bets found");
+      return;
+    }
+
+    // Determine if this bettor won
+    // Agent A is the round's agentAId, Agent B is agentBId
+    const winningSide =
+      round.winnerId === round.agentAId
+        ? "A"
+        : round.winnerId === round.agentBId
+          ? "B"
+          : null;
+    if (!winningSide) {
+      await markFailed(db, job.id, "Round winner does not match either side");
+      return;
+    }
+    const userBetOnWinner = bets.some((b) => b.side === winningSide);
+
+    if (!userBetOnWinner) {
+      // Bettor lost — mark job as complete (no payout needed).
+      // Guard on status='PENDING' so two instances racing on the same job
+      // won't both transition it; the loser's update matches zero rows.
+      const lostUpdate = await db
+        .update(solanaPayoutJobs)
+        .set({ status: "NO_PAYOUT", updatedAt: Date.now() })
+        .where(
+          and(
+            eq(solanaPayoutJobs.id, job.id),
+            eq(solanaPayoutJobs.status, "PENDING"),
+          ),
+        )
+        .returning({ id: solanaPayoutJobs.id });
+      if (lostUpdate.length === 0) {
+        // Another worker beat us to this job; skip logging to avoid noise.
+        return;
+      }
+
+      Logger.info("PayoutKeeper", "Bettor lost — no payout", {
+        jobId: job.id,
+        wallet: redactWalletAddress(job.bettorWallet),
+        roundId: job.roundId,
+      });
+      return;
+    }
+
+    // Calculate payout: (user's winning bet / total winning pool) * total pool
+    // For now, mark as READY_FOR_PAYOUT — actual transfer will be implemented
+    // when the token infrastructure is connected.
+    // Same status guard as above prevents duplicate transitions under races.
+    const readyUpdate = await db
+      .update(solanaPayoutJobs)
+      .set({
+        status: "READY_FOR_PAYOUT",
+        updatedAt: Date.now(),
+      })
+      .where(
+        and(
+          eq(solanaPayoutJobs.id, job.id),
+          eq(solanaPayoutJobs.status, "PENDING"),
+        ),
+      )
+      .returning({ id: solanaPayoutJobs.id });
+    if (readyUpdate.length === 0) {
+      return;
+    }
+
+    Logger.info("PayoutKeeper", "Payout job marked ready", {
+      jobId: job.id,
+      wallet: redactWalletAddress(job.bettorWallet),
+      roundId: job.roundId,
+      winningSide,
+    });
+
+    // Payout transfer plumbing is not wired in this branch yet. The keeper
+    // intentionally stops at READY_FOR_PAYOUT after recording the winner so a
+    // transfer-capable follow-up can calculate the final amount, submit the
+    // Solana transfer, persist claimSignature, and then mark COMPLETE.
+  } catch (err) {
+    Logger.error(
+      "PayoutKeeper",
+      "Failed to process job",
+      err instanceof Error ? err : null,
+      { jobId: job.id, roundId: job.roundId },
+    );
+    await scheduleRetry(db, job.id, job.attempts, sanitizePayoutError(err));
+  }
+}
+
+async function scheduleRetry(
+  db: PayoutDbClient,
+  jobId: string,
+  currentAttempts: number,
+  error: string,
+): Promise<void> {
+  const nextAttempt = currentAttempts + 1;
+
+  if (nextAttempt >= MAX_ATTEMPTS) {
+    await markFailed(db, jobId, error);
+    return;
+  }
+
+  const backoff = BASE_BACKOFF_MS * Math.pow(2, currentAttempts);
+  const nextAttemptAt = Date.now() + backoff;
+
+  // Guard on status='PENDING' so a concurrent worker that has already
+  // transitioned this job to READY_FOR_PAYOUT / NO_PAYOUT / FAILED can't
+  // be rolled back to PENDING by a late scheduleRetry call.
+  const retryUpdate = await db
+    .update(solanaPayoutJobs)
+    .set({
+      attempts: nextAttempt,
+      lastError: error,
+      nextAttemptAt,
+      updatedAt: Date.now(),
+    })
+    .where(
+      and(
+        eq(solanaPayoutJobs.id, jobId),
+        eq(solanaPayoutJobs.status, "PENDING"),
+      ),
+    )
+    .returning({ id: solanaPayoutJobs.id });
+  if (retryUpdate.length === 0) {
+    return;
+  }
+
+  Logger.warn("PayoutKeeper", "Scheduled retry", {
+    jobId,
+    attempt: nextAttempt,
+    backoffMs: backoff,
+    error,
+  });
+}
+
+async function markFailed(
+  db: PayoutDbClient,
+  jobId: string,
+  error: string,
+): Promise<void> {
+  // Same PENDING guard as scheduleRetry / processOneJob — prevents a stale
+  // worker from overwriting a terminal state set by another instance.
+  const failUpdate = await db
+    .update(solanaPayoutJobs)
+    .set({
+      status: "FAILED",
+      lastError: error,
+      updatedAt: Date.now(),
+    })
+    .where(
+      and(
+        eq(solanaPayoutJobs.id, jobId),
+        eq(solanaPayoutJobs.status, "PENDING"),
+      ),
+    )
+    .returning({ id: solanaPayoutJobs.id });
+  if (failUpdate.length === 0) {
+    return;
+  }
+
+  Logger.error("PayoutKeeper", "Job permanently failed", null, {
+    jobId,
+    error,
+  });
+}
+
+/** @internal Transactional helpers exposed for payout keeper regression tests. */
+export const __payoutKeeperTestInternals = {
+  processOneJob,
+};

--- a/packages/server/src/systems/DuelScheduler/SolanaArenaOperator.ts
+++ b/packages/server/src/systems/DuelScheduler/SolanaArenaOperator.ts
@@ -1,0 +1,596 @@
+/**
+ * SolanaArenaOperator — Implements SolanaArenaOperatorInterface for DuelBettingBridge
+ *
+ * Sends raw Solana transactions to the deployed Fight Oracle program.
+ * Uses @solana/web3.js directly (no Anchor dependency).
+ *
+ * Env vars:
+ *   SOLANA_RPC_URL              — Solana RPC endpoint (required)
+ *   SOLANA_REPORTER_PRIVATE_KEY — Reporter keypair as base58 or JSON byte array (required)
+ *   SOLANA_FIGHT_ORACLE_PROGRAM_ID — Override program ID (optional)
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import bs58 from "bs58";
+import { createHash } from "node:crypto";
+import { Logger } from "../ServerNetwork/services";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_PROGRAM_ID = "6Tx7s2UG4maFWakRFVi4GeecXJYyBXQF8f2vJdQShSpV";
+
+/** PDA seeds matching the Anchor program */
+const ORACLE_CONFIG_SEED = new TextEncoder().encode("oracle_config");
+const DUEL_STATE_SEED = new TextEncoder().encode("duel");
+
+/** Anchor instruction discriminators (from IDL) */
+const UPSERT_DUEL_DISCRIMINATOR = Buffer.from([
+  174, 7, 139, 223, 70, 128, 251, 128,
+]);
+const REPORT_RESULT_DISCRIMINATOR = Buffer.from([
+  195, 187, 161, 107, 75, 154, 102, 183,
+]);
+
+/** DuelStatus enum indices (Borsh u8) */
+const DUEL_STATUS = {
+  Scheduled: 0,
+  BettingOpen: 1,
+  Locked: 2,
+  Resolved: 3,
+  Cancelled: 4,
+} as const;
+
+/** MarketSide enum indices (Borsh u8) */
+const MARKET_SIDE = {
+  None: 0,
+  A: 1,
+  B: 2,
+} as const;
+
+const TX_CONFIRM_TIMEOUT_MS = 30_000;
+
+// ============================================================================
+// Borsh serialization helpers
+// ============================================================================
+
+function writeU8(buf: Buffer, offset: number, val: number): number {
+  buf.writeUInt8(val, offset);
+  return offset + 1;
+}
+
+function writeI64(buf: Buffer, offset: number, val: bigint): number {
+  buf.writeBigInt64LE(val, offset);
+  return offset + 8;
+}
+
+function writeU64(buf: Buffer, offset: number, val: bigint): number {
+  buf.writeBigUInt64LE(val, offset);
+  return offset + 8;
+}
+
+function writeBytes32(buf: Buffer, offset: number, bytes: Uint8Array): number {
+  Buffer.from(bytes).copy(buf, offset);
+  return offset + 32;
+}
+
+function writeBorshString(buf: Buffer, offset: number, str: string): number {
+  const strBytes = Buffer.from(str, "utf-8");
+  buf.writeUInt32LE(strBytes.length, offset);
+  offset += 4;
+  strBytes.copy(buf, offset);
+  return offset + strBytes.length;
+}
+
+// ============================================================================
+// PDA derivation
+// ============================================================================
+
+function findOracleConfigPda(programId: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([ORACLE_CONFIG_SEED], programId);
+}
+
+function findDuelStatePda(
+  duelKeyBytes: Uint8Array,
+  programId: PublicKey,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [DUEL_STATE_SEED, duelKeyBytes],
+    programId,
+  );
+}
+
+function hexToBytes32(hex: string): Uint8Array {
+  const normalized = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (normalized.length !== 64) {
+    throw new Error(
+      `Expected 32-byte hex string, got ${normalized.length / 2} bytes`,
+    );
+  }
+  if (!/^[0-9a-fA-F]{64}$/.test(normalized)) {
+    throw new Error("Expected 32-byte hex string");
+  }
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function hashParticipant(id: string): Uint8Array {
+  return createHash("sha256").update(id).digest();
+}
+
+// ============================================================================
+// Instruction builders
+// ============================================================================
+
+function buildUpsertDuelInstruction(params: {
+  reporter: PublicKey;
+  oracleConfig: PublicKey;
+  duelState: PublicKey;
+  programId: PublicKey;
+  duelKeyBytes: Uint8Array;
+  participantAHash: Uint8Array;
+  participantBHash: Uint8Array;
+  betOpenTs: bigint;
+  betCloseTs: bigint;
+  duelStartTs: bigint;
+  metadataUri: string;
+  status: number;
+}): TransactionInstruction {
+  const uriBytes = Buffer.from(params.metadataUri, "utf-8");
+  // 8 (disc) + 32 (duelKey) + 32 (partA) + 32 (partB) + 8*3 (timestamps) + 4+len (uri) + 1 (status)
+  const dataLen = 8 + 32 + 32 + 32 + 24 + 4 + uriBytes.length + 1;
+  const data = Buffer.alloc(dataLen);
+
+  let offset = 0;
+  UPSERT_DUEL_DISCRIMINATOR.copy(data, offset);
+  offset += 8;
+  offset = writeBytes32(data, offset, params.duelKeyBytes);
+  offset = writeBytes32(data, offset, params.participantAHash);
+  offset = writeBytes32(data, offset, params.participantBHash);
+  offset = writeI64(data, offset, params.betOpenTs);
+  offset = writeI64(data, offset, params.betCloseTs);
+  offset = writeI64(data, offset, params.duelStartTs);
+  offset = writeBorshString(data, offset, params.metadataUri);
+  writeU8(data, offset, params.status);
+
+  return new TransactionInstruction({
+    keys: [
+      { pubkey: params.reporter, isSigner: true, isWritable: true },
+      { pubkey: params.oracleConfig, isSigner: false, isWritable: false },
+      { pubkey: params.duelState, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    programId: params.programId,
+    data,
+  });
+}
+
+function buildReportResultInstruction(params: {
+  reporter: PublicKey;
+  oracleConfig: PublicKey;
+  duelState: PublicKey;
+  programId: PublicKey;
+  duelKeyBytes: Uint8Array;
+  winner: number;
+  seed: bigint;
+  replayHash: Uint8Array;
+  resultHash: Uint8Array;
+  duelEndTs: bigint;
+  metadataUri: string;
+}): TransactionInstruction {
+  const uriBytes = Buffer.from(params.metadataUri, "utf-8");
+  // 8 (disc) + 32 (duelKey) + 1 (winner) + 8 (seed) + 32 (replayHash) + 32 (resultHash) + 8 (duelEndTs) + 4+len (uri)
+  const dataLen = 8 + 32 + 1 + 8 + 32 + 32 + 8 + 4 + uriBytes.length;
+  const data = Buffer.alloc(dataLen);
+
+  let offset = 0;
+  REPORT_RESULT_DISCRIMINATOR.copy(data, offset);
+  offset += 8;
+  offset = writeBytes32(data, offset, params.duelKeyBytes);
+  offset = writeU8(data, offset, params.winner);
+  offset = writeU64(data, offset, params.seed);
+  offset = writeBytes32(data, offset, params.replayHash);
+  offset = writeBytes32(data, offset, params.resultHash);
+  offset = writeI64(data, offset, params.duelEndTs);
+  writeBorshString(data, offset, params.metadataUri);
+
+  return new TransactionInstruction({
+    keys: [
+      { pubkey: params.reporter, isSigner: true, isWritable: true },
+      { pubkey: params.oracleConfig, isSigner: false, isWritable: false },
+      { pubkey: params.duelState, isSigner: false, isWritable: true },
+    ],
+    programId: params.programId,
+    data,
+  });
+}
+
+// ============================================================================
+// SolanaArenaOperator
+// ============================================================================
+
+export class SolanaArenaOperator {
+  private readonly connection: Connection | null;
+  private readonly reporter: Keypair | null;
+  private readonly programId: PublicKey;
+  private readonly oracleConfigPda: PublicKey;
+  private readonly _enabled: boolean;
+
+  constructor() {
+    const rpcUrl = process.env.SOLANA_RPC_URL;
+    const reporterKey = process.env.SOLANA_REPORTER_PRIVATE_KEY;
+    const programIdStr =
+      process.env.SOLANA_FIGHT_ORACLE_PROGRAM_ID || DEFAULT_PROGRAM_ID;
+
+    if (!rpcUrl || !reporterKey) {
+      this._enabled = false;
+      this.connection = null;
+      this.reporter = null;
+      this.programId = new PublicKey(programIdStr);
+      this.oracleConfigPda = PublicKey.default;
+      Logger.info(
+        "SolanaArenaOperator",
+        "Disabled — missing SOLANA_RPC_URL or SOLANA_REPORTER_PRIVATE_KEY",
+      );
+      return;
+    }
+
+    this.connection = new Connection(rpcUrl, "confirmed");
+    this.reporter = parseKeypair(reporterKey);
+    this.programId = new PublicKey(programIdStr);
+    [this.oracleConfigPda] = findOracleConfigPda(this.programId);
+    this._enabled = true;
+
+    Logger.info("SolanaArenaOperator", "Initialized", {
+      rpcUrl: rpcUrl.replace(/\/\/.*@/, "//***@"), // redact credentials
+      reporter: this.reporter.publicKey.toBase58(),
+      programId: this.programId.toBase58(),
+    });
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  private requireEnabledResources(): {
+    connection: Connection;
+    reporter: Keypair;
+  } {
+    if (!this._enabled || this.connection === null || this.reporter === null) {
+      throw new Error("SolanaArenaOperator is disabled");
+    }
+    return {
+      connection: this.connection,
+      reporter: this.reporter,
+    };
+  }
+
+  /**
+   * Initialize a round on-chain by calling upsert_duel with BettingOpen status
+   */
+  async initRound(
+    roundSeedHex: string,
+    bettingClosesAtMs: number,
+  ): Promise<{
+    closeSlot: number;
+    initOracleSignature: string | null;
+    initMarketSignature: string | null;
+  } | null> {
+    if (!this._enabled) return null;
+
+    try {
+      const { connection, reporter } = this.requireEnabledResources();
+      const duelKeyBytes = hexToBytes32(roundSeedHex);
+      const [duelStatePda] = findDuelStatePda(duelKeyBytes, this.programId);
+
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+      const closeSec = BigInt(Math.floor(bettingClosesAtMs / 1000));
+
+      // Use roundSeedHex to derive participant hashes for init
+      // Actual participant hashes are updated by subsequent upsert calls from the bridge
+      const participantAHash = hashParticipant(`${roundSeedHex}:A`);
+      const participantBHash = hashParticipant(`${roundSeedHex}:B`);
+
+      const metadataUri = `${process.env.DUEL_METADATA_BASE_URL || "https://hyperscape.game/api/duels"}/${roundSeedHex}`;
+
+      const ix = buildUpsertDuelInstruction({
+        reporter: reporter.publicKey,
+        oracleConfig: this.oracleConfigPda,
+        duelState: duelStatePda,
+        programId: this.programId,
+        duelKeyBytes,
+        participantAHash,
+        participantBHash,
+        betOpenTs: nowSec,
+        betCloseTs: closeSec,
+        duelStartTs: closeSec,
+        metadataUri,
+        status: DUEL_STATUS.BettingOpen,
+      });
+
+      const sig = await this.sendAndConfirm([ix]);
+
+      Logger.info("SolanaArenaOperator", "initRound succeeded", {
+        roundSeedHex,
+        signature: sig,
+      });
+
+      // Approximate close slot (assuming 400ms slot time)
+      const slotsUntilClose = Math.ceil((bettingClosesAtMs - Date.now()) / 400);
+      const currentSlot = await connection.getSlot();
+
+      return {
+        closeSlot: currentSlot + Math.max(slotsUntilClose, 1),
+        initOracleSignature: sig,
+        initMarketSignature: null,
+      };
+    } catch (error) {
+      Logger.error(
+        "SolanaArenaOperator",
+        "initRound failed",
+        error instanceof Error ? error : null,
+        { roundSeedHex },
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Lock the market by calling upsert_duel with Locked status
+   */
+  async lockMarket(roundSeedHex: string): Promise<string | null> {
+    if (!this._enabled) return null;
+
+    try {
+      const { reporter } = this.requireEnabledResources();
+      const duelKeyBytes = hexToBytes32(roundSeedHex);
+      const [duelStatePda] = findDuelStatePda(duelKeyBytes, this.programId);
+
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+      const participantAHash = hashParticipant(`${roundSeedHex}:A`);
+      const participantBHash = hashParticipant(`${roundSeedHex}:B`);
+      const metadataUri = `${process.env.DUEL_METADATA_BASE_URL || "https://hyperscape.game/api/duels"}/${roundSeedHex}`;
+
+      const ix = buildUpsertDuelInstruction({
+        reporter: reporter.publicKey,
+        oracleConfig: this.oracleConfigPda,
+        duelState: duelStatePda,
+        programId: this.programId,
+        duelKeyBytes,
+        participantAHash,
+        participantBHash,
+        betOpenTs: nowSec - 60n, // keep original open time approximate
+        betCloseTs: nowSec,
+        duelStartTs: nowSec,
+        metadataUri,
+        status: DUEL_STATUS.Locked,
+      });
+
+      const sig = await this.sendAndConfirm([ix]);
+
+      Logger.info("SolanaArenaOperator", "lockMarket succeeded", {
+        roundSeedHex,
+        signature: sig,
+      });
+
+      return sig;
+    } catch (error) {
+      Logger.error(
+        "SolanaArenaOperator",
+        "lockMarket failed",
+        error instanceof Error ? error : null,
+        { roundSeedHex },
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Report duel result and resolve the market on-chain
+   */
+  async reportAndResolve(params: {
+    roundSeedHex: string;
+    winnerSide: "A" | "B";
+    resultHashHex: string;
+    metadataUri: string;
+  }): Promise<{
+    reportSignature: string | null;
+    resolveSignature: string | null;
+  } | null> {
+    if (!this._enabled) return null;
+
+    try {
+      const { reporter } = this.requireEnabledResources();
+      const duelKeyBytes = hexToBytes32(params.roundSeedHex);
+      const [duelStatePda] = findDuelStatePda(duelKeyBytes, this.programId);
+
+      const winner = params.winnerSide === "A" ? MARKET_SIDE.A : MARKET_SIDE.B;
+
+      const resultHashBytes = hexToBytes32(params.resultHashHex);
+      const replayHash = createHash("sha256")
+        .update(`replay:${params.roundSeedHex}`)
+        .digest();
+
+      // This is deterministic proof material derived from the round seed,
+      // not fresh entropy. Reporter authorization on the Solana instruction
+      // remains the security boundary; these values let the keeper
+      // reconstruct the same report payload if it misses a live event.
+      const seedBuf = createHash("sha256")
+        .update(`seed:${params.roundSeedHex}`)
+        .digest();
+      const seed = seedBuf.readBigUInt64LE(0);
+
+      const nowSec = BigInt(Math.floor(Date.now() / 1000));
+
+      const ix = buildReportResultInstruction({
+        reporter: reporter.publicKey,
+        oracleConfig: this.oracleConfigPda,
+        duelState: duelStatePda,
+        programId: this.programId,
+        duelKeyBytes,
+        winner,
+        seed,
+        replayHash,
+        resultHash: resultHashBytes,
+        duelEndTs: nowSec,
+        metadataUri: params.metadataUri,
+      });
+
+      const sig = await this.sendAndConfirm([ix]);
+
+      Logger.info("SolanaArenaOperator", "reportAndResolve succeeded", {
+        roundSeedHex: params.roundSeedHex,
+        winnerSide: params.winnerSide,
+        signature: sig,
+      });
+
+      return {
+        reportSignature: sig,
+        resolveSignature: sig,
+      };
+    } catch (error) {
+      Logger.error(
+        "SolanaArenaOperator",
+        "reportAndResolve failed",
+        error instanceof Error ? error : null,
+        { roundSeedHex: params.roundSeedHex },
+      );
+      return null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Transaction helpers
+  // --------------------------------------------------------------------------
+
+  private async sendAndConfirm(
+    instructions: TransactionInstruction[],
+  ): Promise<string> {
+    const { connection, reporter } = this.requireEnabledResources();
+    const { blockhash, lastValidBlockHeight } =
+      await connection.getLatestBlockhash("confirmed");
+
+    const message = new TransactionMessage({
+      payerKey: reporter.publicKey,
+      recentBlockhash: blockhash,
+      instructions,
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(message);
+    tx.sign([reporter]);
+
+    const sig = await connection.sendTransaction(tx, {
+      skipPreflight: false,
+      maxRetries: 3,
+    });
+
+    // confirmTransaction can block indefinitely on RPC stalls or a partitioned
+    // network. Cap with an explicit timeout so the caller surfaces a clean
+    // error instead of a stuck transaction that ties up the reporter wallet.
+    let confirmTimer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        connection.confirmTransaction(
+          { signature: sig, blockhash, lastValidBlockHeight },
+          "confirmed",
+        ),
+        new Promise<never>((_, reject) => {
+          confirmTimer = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `confirmTransaction timed out after ${TX_CONFIRM_TIMEOUT_MS}ms (signature=${sig})`,
+                ),
+              ),
+            TX_CONFIRM_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (confirmTimer !== null) clearTimeout(confirmTimer);
+    }
+
+    return sig;
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function parseKeypair(raw: string): Keypair {
+  const assertSecretKeyLength = (bytes: Uint8Array): Uint8Array => {
+    if (bytes.length !== 64) {
+      throw new Error(
+        `Reporter private key must decode to 64 bytes; received ${bytes.length}`,
+      );
+    }
+    return bytes;
+  };
+
+  const trimmed = raw.trim();
+  if (trimmed.length > 1024) {
+    throw new Error("Reporter private key input is unexpectedly large");
+  }
+
+  // JSON byte array: [1,2,3,...]
+  if (trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      throw new Error(
+        `Reporter private key JSON is malformed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("Reporter private key JSON must be a number array");
+    }
+    // Uint8Array.from silently coerces out-of-range or non-integer values
+    // (e.g. 256 → 0, -1 → 255, "1" → 1). Validate each byte explicitly so a
+    // corrupted key fails loud instead of producing an attacker-controlled
+    // reporter identity.
+    for (const byte of parsed) {
+      if (
+        typeof byte !== "number" ||
+        !Number.isInteger(byte) ||
+        byte < 0 ||
+        byte > 255
+      ) {
+        throw new Error(
+          "Reporter private key JSON must contain only integers in [0, 255]",
+        );
+      }
+    }
+    return Keypair.fromSecretKey(
+      assertSecretKeyLength(Uint8Array.from(parsed as number[])),
+    );
+  }
+
+  return Keypair.fromSecretKey(assertSecretKeyLength(bs58.decode(trimmed)));
+}
+
+/** @internal Pure helpers exposed for byte-layout regression tests. */
+export const __solanaArenaOperatorTestInternals = {
+  DUEL_STATUS,
+  MARKET_SIDE,
+  REPORT_RESULT_DISCRIMINATOR,
+  UPSERT_DUEL_DISCRIMINATOR,
+  buildReportResultInstruction,
+  buildUpsertDuelInstruction,
+  hashParticipant,
+  hexToBytes32,
+  parseKeypair,
+};

--- a/packages/server/src/systems/ServerNetwork/index.ts
+++ b/packages/server/src/systems/ServerNetwork/index.ts
@@ -258,6 +258,11 @@ import {
 import { TradingSystem } from "../TradingSystem";
 import { DuelSystem } from "../DuelSystem";
 import { DuelScheduler, DuelBettingBridge } from "../DuelScheduler";
+import { SolanaArenaOperator } from "../DuelScheduler/SolanaArenaOperator.js";
+import {
+  startPayoutKeeper,
+  stopPayoutKeeper,
+} from "../DuelScheduler/PayoutKeeper.js";
 import {
   handleDuelChallenge,
   handleDuelChallengeRespond,
@@ -405,6 +410,26 @@ export class ServerNetwork extends System implements NetworkWithSocket {
   static agentDesireScores: Map<
     string,
     Array<{ goalType: string; score: number; breakdown: string }>
+  > = new Map();
+
+  /** Agent activity storage (characterId -> recent actions and session stats). */
+  static agentActivity: Map<
+    string,
+    {
+      recentActions: Array<{
+        type: string;
+        description: string;
+        xpGained?: number;
+        timestamp: number;
+      }>;
+      sessionStats: {
+        kills: number;
+        deaths: number;
+        totalXpGained: number;
+        goldEarned: number;
+        resourcesGathered: Record<string, number>;
+      };
+    }
   > = new Map();
 
   /** Agent thought storage (characterId -> recent thoughts) for dashboard display */
@@ -1135,6 +1160,14 @@ export class ServerNetwork extends System implements NetworkWithSocket {
         this.duelScheduler;
     }
 
+    // SolanaArenaOperator — bridge between DuelBettingBridge and the on-chain oracle
+    const solanaOperator = new SolanaArenaOperator();
+    if (solanaOperator.isEnabled()) {
+      (
+        this.world as World & { solanaArenaOperator?: SolanaArenaOperator }
+      ).solanaArenaOperator = solanaOperator;
+    }
+
     // DuelBettingBridge - connects duel results to Solana prediction markets
     // Creates betting markets when duels are scheduled and resolves them when complete
     // Enable via DUEL_BETTING_ENABLED=true environment variable
@@ -1145,6 +1178,11 @@ export class ServerNetwork extends System implements NetworkWithSocket {
     (
       this.world as { duelBettingBridge?: DuelBettingBridge }
     ).duelBettingBridge = this.duelBettingBridge;
+
+    // Start payout keeper for processing bet claims
+    if (process.env.DUEL_BETTING_ENABLED === "true") {
+      startPayoutKeeper();
+    }
 
     // Listen for player teleport events (used by duel system)
     this.onWorld("player:teleport", (event) => {
@@ -3262,9 +3300,11 @@ export class ServerNetwork extends System implements NetworkWithSocket {
     ServerNetwork.agentGoals.clear();
     ServerNetwork.agentAvailableGoals.clear();
     ServerNetwork.agentGoalsPaused.clear();
+    ServerNetwork.agentActivity.clear();
     ServerNetwork.agentThoughts.clear();
     ServerNetwork.agentPersonality.clear();
     ServerNetwork.agentDesireScores.clear();
+    stopPayoutKeeper();
 
     // Clean up duel event listeners to prevent memory leak
     if (this.cleanupDuelEventListeners) {

--- a/packages/server/src/systems/StreamingDuelScheduler/__tests__/DuelOrchestrator.test.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/__tests__/DuelOrchestrator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  type DuelArenaConfig,
+  getDuelArenaConfig,
+  isPositionInsideCombatArena,
+  tileChebyshevDistance,
+  worldToTile,
+} from "@hyperscape/shared";
+import { computeStreamingArenaEngagementSpawnPoints } from "../managers/DuelOrchestrator";
+
+function expectAdjacent(spawns: {
+  agent1: { x: number; z: number };
+  agent2: { x: number; z: number };
+}) {
+  expect(
+    tileChebyshevDistance(
+      worldToTile(spawns.agent1.x, spawns.agent1.z),
+      worldToTile(spawns.agent2.x, spawns.agent2.z),
+    ),
+  ).toBe(1);
+}
+
+describe("DuelOrchestrator streaming arena spawns", () => {
+  it("places streaming contestants on adjacent combat tiles inside the arena", () => {
+    const spawns =
+      computeStreamingArenaEngagementSpawnPoints(getDuelArenaConfig());
+
+    expectAdjacent(spawns);
+    expect(isPositionInsideCombatArena(spawns.agent1.x, spawns.agent1.z)).toBe(
+      true,
+    );
+    expect(isPositionInsideCombatArena(spawns.agent2.x, spawns.agent2.z)).toBe(
+      true,
+    );
+  });
+
+  it("keeps adjacent combat spacing for width-oriented arena layouts", () => {
+    const config: DuelArenaConfig = {
+      ...getDuelArenaConfig(),
+      spawnLayout: "alongWidth",
+    };
+
+    expectAdjacent(computeStreamingArenaEngagementSpawnPoints(config));
+  });
+});

--- a/packages/server/src/systems/StreamingDuelScheduler/__tests__/StreamingDuelScheduler.test.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/__tests__/StreamingDuelScheduler.test.ts
@@ -379,6 +379,47 @@ function createMockWorld(options?: {
   };
 }
 
+describe("StreamingDuelScheduler endCycle guard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resets the end-cycle guard when a synchronous transition throws", async () => {
+    const ctx = createMockWorld();
+    const scheduler = new StreamingDuelScheduler(ctx.world as never);
+    (scheduler as any).currentCycle = {
+      cycleId: "cycle-sync-throw",
+      duelId: "duel-sync-throw",
+      duelKeyHex: "0xcycle",
+      winnerId: "agent-alpha",
+      loserId: "agent-beta",
+      agent1: { characterId: "agent-alpha" },
+      agent2: { characterId: "agent-beta" },
+    };
+    (scheduler as any).schedulerState = "ACTIVE";
+
+    const originalEmit = ctx.world.emit;
+    ctx.world.emit = ((event: string, payload: unknown) => {
+      if (event === "streaming:resolution:end") {
+        throw new Error("resolution end emit failed");
+      }
+      originalEmit(event, payload);
+    }) as typeof ctx.world.emit;
+
+    expect(() => (scheduler as any).endCycle()).not.toThrow();
+    expect((scheduler as any)._endCycleInProgress).toBe(false);
+    expect((scheduler as any).schedulerState).toBe("IDLE");
+    expect(scheduler.getCurrentCycle()).toBeNull();
+
+    scheduler.destroy();
+  });
+});
+
 // TODO: These tests need refactoring - they call internal methods via `(scheduler as any)`
 // that have been moved to the orchestrator pattern. Many pass but 23 fail.
 describe.skip("StreamingDuelScheduler", () => {
@@ -426,7 +467,14 @@ describe.skip("StreamingDuelScheduler", () => {
 
     expect(ctx.world.network.send).toHaveBeenCalledWith(
       "streamingState",
-      expect.any(Object),
+      expect.objectContaining({
+        cycle: expect.objectContaining({
+          duelKeyHex: null,
+          duelEndTime: null,
+          seed: null,
+          replayHash: null,
+        }),
+      }),
     );
 
     scheduler.destroy();
@@ -1380,6 +1428,10 @@ describe.skip("StreamingDuelScheduler", () => {
       winReason: "kill",
       damageWinner: 50,
       damageLoser: 30,
+      duelKeyHex: null,
+      duelEndTime: null,
+      seed: null,
+      replayHash: null,
     });
 
     const duels1 = scheduler.getRecentDuels(10);

--- a/packages/server/src/systems/StreamingDuelScheduler/index.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/index.ts
@@ -22,6 +22,22 @@ interface NetworkWithSend {
   send: <T>(name: string, data: T, ignoreSocketId?: string) => void;
   sendToSpectators?: <T>(name: string, data: T) => void;
 }
+
+function redactOracleProofFromStreamingState(
+  state: StreamingStateUpdate,
+): StreamingStateUpdate {
+  return {
+    ...state,
+    cycle: {
+      ...state.cycle,
+      duelKeyHex: null,
+      duelEndTime: null,
+      seed: null,
+      replayHash: null,
+    },
+  };
+}
+
 import { Logger } from "../ServerNetwork/services";
 import { v4 as uuidv4 } from "uuid";
 import { errMsg } from "../../shared/errMsg.js";
@@ -1360,8 +1376,25 @@ export class StreamingDuelScheduler {
       this.orchestrator.endFightByTimeout();
     }
 
-    // Update HP from entities
-    this.orchestrator.updateContestantHp();
+    // Update HP from entities and feed damage hits to camera director
+    const hpDeltas = this.orchestrator.updateContestantHp();
+    if (hpDeltas && this.currentCycle) {
+      const { hpLost1, hpLost2, maxHp1, maxHp2 } = hpDeltas;
+      if (hpLost1 > 0 && this.currentCycle.agent1) {
+        this.camera.onCombatHit(
+          this.currentCycle.agent1.characterId,
+          hpLost1 / Math.max(1, maxHp1),
+          now,
+        );
+      }
+      if (hpLost2 > 0 && this.currentCycle.agent2) {
+        this.camera.onCombatHit(
+          this.currentCycle.agent2.characterId,
+          hpLost2 / Math.max(1, maxHp2),
+          now,
+        );
+      }
+    }
 
     // Fallback: nudge stalled fights so the stream cycle still progresses even
     // when combat start hooks fail in this tick window.
@@ -1391,7 +1424,7 @@ export class StreamingDuelScheduler {
     loserId: string,
     winReason: "kill" | "hp_advantage" | "damage_advantage" | "draw",
     finishedAt: number,
-  ): { seed: string; replayHash: string } {
+  ): { duelKeyHex: string | null; seed: string; replayHash: string } {
     const duelId = cycle.duelId ?? `streaming-${cycle.cycleId}`;
     const fightStartedAt = cycle.fightStartTime ?? cycle.cycleStartTime;
     const duelSeedHex = crypto
@@ -1422,7 +1455,11 @@ export class StreamingDuelScheduler {
         }),
       )
       .digest("hex");
-    return { seed, replayHash };
+    // Return the duel key alongside seed + replayHash so the proof is
+    // self-contained. Callers that persist the proof must not rely on
+    // cycle.duelKeyHex still being populated at write time — the cycle can
+    // be cleared by shutdown or phase-reset before persistence completes.
+    return { duelKeyHex: cycle.duelKeyHex ?? null, seed, replayHash };
   }
 
   /**
@@ -1471,6 +1508,11 @@ export class StreamingDuelScheduler {
     );
     this.currentCycle.seed = oracleProof.seed;
     this.currentCycle.replayHash = oracleProof.replayHash;
+    // If the cycle's duelKeyHex was somehow cleared, recover it from the
+    // self-contained proof so persistence below is consistent.
+    if (!this.currentCycle.duelKeyHex && oracleProof.duelKeyHex) {
+      this.currentCycle.duelKeyHex = oracleProof.duelKeyHex;
+    }
 
     // Update stats — draws don't affect win/loss/streaks (#24)
     if (winReason === "draw") {
@@ -1505,6 +1547,12 @@ export class StreamingDuelScheduler {
         this.currentCycle.agent1?.characterId === loserId
           ? this.currentCycle.agent1.damageDealtThisFight
           : (this.currentCycle.agent2?.damageDealtThisFight ?? 0),
+      // Oracle proof — needed by the keeper result-catch-up endpoint so a
+      // missed onDuelEnd event can still be replayed to resolve the bundle.
+      duelKeyHex: this.currentCycle.duelKeyHex ?? null,
+      duelEndTime: this.currentCycle.duelEndTime ?? null,
+      seed: this.currentCycle.seed ?? null,
+      replayHash: this.currentCycle.replayHash ?? null,
     });
 
     // Pull per-fight AI stats (attacksLanded, healsUsed) captured in stopCombatAIs
@@ -1594,104 +1642,139 @@ export class StreamingDuelScheduler {
 
     // Fix M — guard against re-entry
     if (this._endCycleInProgress) return;
+    const cycleSnapshot = this.currentCycle;
     this._endCycleInProgress = true;
 
-    const cycleSnapshot = this.currentCycle;
-    const now = Date.now();
-    const winnerId = cycleSnapshot.winnerId;
-    const loserId = cycleSnapshot.loserId;
-    const cycleAgent1Id = cycleSnapshot.agent1?.characterId ?? null;
-    const cycleAgent2Id = cycleSnapshot.agent2?.characterId ?? null;
+    try {
+      const now = Date.now();
+      const winnerId = cycleSnapshot.winnerId;
+      const loserId = cycleSnapshot.loserId;
+      const cycleAgent1Id = cycleSnapshot.agent1?.characterId ?? null;
+      const cycleAgent2Id = cycleSnapshot.agent2?.characterId ?? null;
 
-    // Snapshot duel food slots before clearing
-    const duelFoodSlotsMap = this.orchestrator.getDuelFoodSlotsByAgent();
-    const duelFoodSlotsSnapshotByAgent = new Map<
-      string,
-      Array<{ slot: number; itemId: string }>
-    >();
-    if (cycleAgent1Id) {
-      duelFoodSlotsSnapshotByAgent.set(cycleAgent1Id, [
-        ...(duelFoodSlotsMap.get(cycleAgent1Id) ?? []),
-      ]);
-      duelFoodSlotsMap.delete(cycleAgent1Id);
-    }
-    if (cycleAgent2Id) {
-      duelFoodSlotsSnapshotByAgent.set(cycleAgent2Id, [
-        ...(duelFoodSlotsMap.get(cycleAgent2Id) ?? []),
-      ]);
-      duelFoodSlotsMap.delete(cycleAgent2Id);
-    }
+      // Snapshot duel food slots before clearing
+      const duelFoodSlotsMap = this.orchestrator.getDuelFoodSlotsByAgent();
+      const duelFoodSlotsSnapshotByAgent = new Map<
+        string,
+        Array<{ slot: number; itemId: string }>
+      >();
+      if (cycleAgent1Id) {
+        duelFoodSlotsSnapshotByAgent.set(cycleAgent1Id, [
+          ...(duelFoodSlotsMap.get(cycleAgent1Id) ?? []),
+        ]);
+        duelFoodSlotsMap.delete(cycleAgent1Id);
+      }
+      if (cycleAgent2Id) {
+        duelFoodSlotsSnapshotByAgent.set(cycleAgent2Id, [
+          ...(duelFoodSlotsMap.get(cycleAgent2Id) ?? []),
+        ]);
+        duelFoodSlotsMap.delete(cycleAgent2Id);
+      }
 
-    Logger.info(
-      "StreamingDuelScheduler",
-      `Cycle ${cycleSnapshot.cycleId} ended. Winner: ${winnerId || "none"}`,
-    );
+      Logger.info(
+        "StreamingDuelScheduler",
+        `Cycle ${cycleSnapshot.cycleId} ended. Winner: ${winnerId || "none"}`,
+      );
 
-    // Emit cycle end
-    this.world.emit("streaming:resolution:end", {
-      cycleId: cycleSnapshot.cycleId,
-      duelId: cycleSnapshot.duelId,
-      duelKeyHex: cycleSnapshot.duelKeyHex,
-      winnerId,
-      loserId,
-    });
-    this.camera.finishFightCutawayTracking(now);
+      // Emit cycle end
+      this.world.emit("streaming:resolution:end", {
+        cycleId: cycleSnapshot.cycleId,
+        duelId: cycleSnapshot.duelId,
+        duelKeyHex: cycleSnapshot.duelKeyHex,
+        winnerId,
+        loserId,
+      });
+      this.camera.finishFightCutawayTracking(now);
 
-    // NOTE: Duel flags (inStreamingDuel, preventRespawn) are intentionally NOT
-    // cleared here. They stay `true` until cleanupAfterDuel() teleports both
-    // agents out of the arena and then clears them via microtask. Clearing
-    // flags before the cleanup teleport creates a race condition where
-    // DuelSystem.ejectNonDuelingPlayersFromCombatArenas() sees the agents
-    // still in the arena with inStreamingDuel=false and emits a spurious
-    // extra teleport (causing duplicate teleport VFX).
+      // NOTE: Duel flags (inStreamingDuel, preventRespawn) are intentionally NOT
+      // cleared here. They stay `true` until cleanupAfterDuel() teleports both
+      // agents out of the arena and then clears them via microtask. Clearing
+      // flags before the cleanup teleport creates a race condition where
+      // DuelSystem.ejectNonDuelingPlayersFromCombatArenas() sees the agents
+      // still in the arena with inStreamingDuel=false and emits a spurious
+      // extra teleport (causing duplicate teleport VFX).
 
-    // Clear current cycle
-    this.currentCycle = null;
+      // Clear current cycle
+      this.currentCycle = null;
 
-    // Transition phase state machine back to IDLE
-    this.phaseStateMachine.forceIdle();
-    this.schedulerState = "IDLE";
+      // Transition phase state machine back to IDLE
+      this.phaseStateMachine.forceIdle();
+      this.schedulerState = "IDLE";
 
-    // Await cleanup, then start next cycle after an inter-cycle delay.
-    // This prevents stale avatars from lingering in the arena — cleanup
-    // must complete before re-selecting agents for the next duel.
-    this.orchestrator
-      .cleanupAfterDuel(cycleSnapshot, duelFoodSlotsSnapshotByAgent)
-      .catch((err) => {
+      // Await cleanup, then start next cycle after an inter-cycle delay.
+      // This prevents stale avatars from lingering in the arena — cleanup
+      // must complete before re-selecting agents for the next duel.
+      this.orchestrator
+        .cleanupAfterDuel(cycleSnapshot, duelFoodSlotsSnapshotByAgent)
+        .catch((err) => {
+          Logger.warn(
+            "StreamingDuelScheduler",
+            `cleanupAfterDuel failed: ${err instanceof Error ? err.message : String(err)}. Clearing duel food tracking and flags as fallback.`,
+          );
+          this.orchestrator.clearDuelFlagsForCycleIfInactive(cycleSnapshot);
+        })
+        .finally(() => {
+          // Wait for inter-cycle delay so spectators see a clean arena reset
+          setTimeout(() => {
+            this._endCycleInProgress = false;
+
+            // Check for pending graceful restart
+            if (this._pendingGracefulRestart) {
+              Logger.info(
+                "StreamingDuelScheduler",
+                "Duel cycle complete, triggering pending graceful restart",
+              );
+              this.triggerGracefulRestart();
+              return;
+            }
+
+            // Start new cycle if enough agents are available
+            if (this.matchmaking.availableAgents.size >= config.minAgents) {
+              this.schedulerState = "ACTIVE";
+              this.startNewCycle();
+            } else {
+              this.schedulerState = "WAITING_FOR_AGENTS";
+              Logger.info(
+                "StreamingDuelScheduler",
+                `Waiting for agents after cycle end: ${this.matchmaking.availableAgents.size}/${config.minAgents}`,
+              );
+            }
+          }, STREAMING_TIMING.INTER_CYCLE_DELAY_MS);
+        });
+    } catch (err) {
+      Logger.error(
+        "StreamingDuelScheduler",
+        "endCycle failed during synchronous transition",
+        err instanceof Error ? err : null,
+        {
+          cycleId: cycleSnapshot.cycleId,
+          duelId: cycleSnapshot.duelId,
+        },
+      );
+
+      try {
+        this.orchestrator.clearDuelFlagsForCycleIfInactive(cycleSnapshot);
+      } catch (cleanupErr) {
         Logger.warn(
           "StreamingDuelScheduler",
-          `cleanupAfterDuel failed: ${err instanceof Error ? err.message : String(err)}. Clearing duel food tracking and flags as fallback.`,
+          `endCycle fallback flag cleanup failed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
         );
-        this.orchestrator.clearDuelFlagsForCycleIfInactive(cycleSnapshot);
-      })
-      .finally(() => {
-        // Wait for inter-cycle delay so spectators see a clean arena reset
-        setTimeout(() => {
-          this._endCycleInProgress = false;
+      }
 
-          // Check for pending graceful restart
-          if (this._pendingGracefulRestart) {
-            Logger.info(
-              "StreamingDuelScheduler",
-              "Duel cycle complete, triggering pending graceful restart",
-            );
-            this.triggerGracefulRestart();
-            return;
-          }
-
-          // Start new cycle if enough agents are available
-          if (this.matchmaking.availableAgents.size >= config.minAgents) {
-            this.schedulerState = "ACTIVE";
-            this.startNewCycle();
-          } else {
-            this.schedulerState = "WAITING_FOR_AGENTS";
-            Logger.info(
-              "StreamingDuelScheduler",
-              `Waiting for agents after cycle end: ${this.matchmaking.availableAgents.size}/${config.minAgents}`,
-            );
-          }
-        }, STREAMING_TIMING.INTER_CYCLE_DELAY_MS);
-      });
+      if (this.currentCycle === cycleSnapshot) {
+        this.currentCycle = null;
+      }
+      try {
+        this.phaseStateMachine.forceIdle();
+      } catch (phaseErr) {
+        Logger.warn(
+          "StreamingDuelScheduler",
+          `endCycle fallback phase reset failed: ${phaseErr instanceof Error ? phaseErr.message : String(phaseErr)}`,
+        );
+      }
+      this.schedulerState = "IDLE";
+      this._endCycleInProgress = false;
+    }
   }
 
   /**
@@ -1971,7 +2054,7 @@ export class StreamingDuelScheduler {
   }
 
   private broadcastState(): void {
-    const state = this.getStreamingState();
+    const state = redactOracleProofFromStreamingState(this.getStreamingState());
     // Broadcast streaming state only to spectator sockets (interest management).
     // Regular gameplay clients don't need streaming duel updates every second.
     const network = this.world.network as NetworkWithSend | undefined;
@@ -1984,7 +2067,13 @@ export class StreamingDuelScheduler {
   }
 
   /**
-   * Get current streaming state for broadcast.
+   * Get current raw streaming state.
+   *
+   * This object may contain oracle-proof material (`duelKeyHex`, `seed`,
+   * `replayHash`, `duelEndTime`) while a duel is active or freshly resolved.
+   * Any public HTTP, SSE, or spectator-socket emission must redact those
+   * fields first.
+   *
    * MEMORY OPTIMIZATION: Reuses pre-allocated objects to avoid GC pressure.
    * Only creates new contestant objects when agents change.
    */
@@ -2379,6 +2468,25 @@ export class StreamingDuelScheduler {
       if (this.camera.isAgentValidCameraCandidate(agentId)) {
         return agentId;
       }
+    }
+
+    // Final fallback: during an active cycle, prefer to point at a contestant
+    // that still has a live world entity, even if they are no longer in the
+    // matchmaking `availableAgents` pool. This covers the case where a
+    // contestant disconnects mid-fight (PLAYER_LEFT → unregisterAgent) and
+    // is therefore no longer a "valid camera candidate" by the matchmaking
+    // rule, but their entity is still in the arena and is the thing the
+    // viewer actually wants to see. Observed on 2026-04-15 where the state
+    // endpoint returned `phase: FIGHTING` with `cameraTarget: null` because
+    // both contestants had been unregistered from matchmaking but were still
+    // alive in the world.
+    const cycleAgent1Id = this.currentCycle.agent1?.characterId;
+    if (cycleAgent1Id && this.world.entities.get(cycleAgent1Id)) {
+      return cycleAgent1Id;
+    }
+    const cycleAgent2Id = this.currentCycle.agent2?.characterId;
+    if (cycleAgent2Id && this.world.entities.get(cycleAgent2Id)) {
+      return cycleAgent2Id;
     }
 
     return null;

--- a/packages/server/src/systems/StreamingDuelScheduler/managers/CameraDirector.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/managers/CameraDirector.ts
@@ -37,6 +37,7 @@ type CameraSwitchTiming = {
   minHoldMs: number;
   maxHoldMs: number;
   idleThresholdMs: number;
+  reverseAngleCooldownMs: number;
 };
 
 type CameraCandidateWeight = {
@@ -75,19 +76,36 @@ const clampNumber = (value: number, min: number, max: number): number => {
 
 const CAMERA_DIRECTOR = {
   switchTiming: {
-    IDLE: { minHoldMs: 30_000, maxHoldMs: 90_000, idleThresholdMs: 15_000 },
+    IDLE: {
+      minHoldMs: 30_000,
+      maxHoldMs: 90_000,
+      idleThresholdMs: 15_000,
+      reverseAngleCooldownMs: 20_000,
+    },
     ANNOUNCEMENT: {
       minHoldMs: 22_000,
       maxHoldMs: 95_000,
       idleThresholdMs: 12_000,
+      reverseAngleCooldownMs: 20_000,
     },
-    COUNTDOWN: { minHoldMs: 6_000, maxHoldMs: 24_000, idleThresholdMs: 6_000 },
+    COUNTDOWN: {
+      minHoldMs: 6_000,
+      maxHoldMs: 24_000,
+      idleThresholdMs: 6_000,
+      reverseAngleCooldownMs: 20_000,
+    },
     FIGHTING: {
       minHoldMs: 28_000,
       maxHoldMs: 90_000,
       idleThresholdMs: 20_000,
+      reverseAngleCooldownMs: 14_000,
     },
-    RESOLUTION: { minHoldMs: 8_000, maxHoldMs: 45_000, idleThresholdMs: 8_000 },
+    RESOLUTION: {
+      minHoldMs: 8_000,
+      maxHoldMs: 45_000,
+      idleThresholdMs: 8_000,
+      reverseAngleCooldownMs: 20_000,
+    },
   } as Record<StreamingPhase, CameraSwitchTiming>,
   baseWeights: {
     IDLE: { contestant: 1.3, nonContestant: 1.3 },
@@ -105,9 +123,12 @@ const CAMERA_DIRECTOR = {
     currentTargetBias: 1.45,
     recentFocusPenaltyShort: 0.45,
     recentFocusPenaltyLong: 0.78,
-    switchRandomChance: 0.12,
+    switchRandomChancePerSec: 0.06,
     strongerThresholdActive: 1.55,
     strongerThresholdIdle: 1.1,
+    focusFatigueCooldownMs: 10_000,
+    returnPenaltyThreshold: 1.8,
+    returnPenaltyCooldownMs: 20_000,
   },
   idlePenalty: {
     softThresholdMs: 12_000,
@@ -157,8 +178,8 @@ const CAMERA_DIRECTOR = {
     currentTargetBias: 1.15,
     /** Threshold: new candidate must be this much stronger to trigger early switch */
     strongerThreshold: 1.2,
-    /** Small random chance to switch for variety (per eligible check) */
-    switchRandomChance: 0.18,
+    /** Per-second probability of random switch for variety */
+    switchRandomChancePerSec: 0.1,
   },
   /** Known skilling emotes from PendingGatherManager / PendingCookManager */
   skillingEmotes: new Set([
@@ -184,6 +205,8 @@ export class CameraDirector {
 
   private _cameraTarget: string | null = null;
   private lastCameraSwitchTime: number = 0;
+  private lastSwitchedAwayFrom: string | null = null;
+  private lastSwitchedAwayTime: number = 0;
   private agentActivity: Map<string, AgentActivitySample> = new Map();
   private fightCutawayStartedAt: number | null = null;
   private fightCutawayTotalMs: number = 0;
@@ -211,6 +234,8 @@ export class CameraDirector {
   reset(): void {
     this._cameraTarget = null;
     this.lastCameraSwitchTime = 0;
+    this.lastSwitchedAwayFrom = null;
+    this.lastSwitchedAwayTime = 0;
     this.agentActivity.clear();
     this.fightCutawayStartedAt = null;
     this.fightCutawayTotalMs = 0;
@@ -564,6 +589,10 @@ export class CameraDirector {
 
     const previous = this._cameraTarget;
     if (previous !== agentId) {
+      if (previous) {
+        this.lastSwitchedAwayFrom = previous;
+        this.lastSwitchedAwayTime = now;
+      }
       this._cameraTarget = agentId;
       this.lastCameraSwitchTime = now;
     }
@@ -620,6 +649,26 @@ export class CameraDirector {
     for (const agentId of availableAgents) {
       if (this.isAgentValidCameraCandidate(agentId)) {
         return agentId;
+      }
+    }
+
+    // Final fallback: if we have an active cycle, prefer to point at a
+    // contestant whose entity is still alive in the world even if they are
+    // no longer in the matchmaking `availableAgents` pool (e.g. mid-fight
+    // disconnect). The matchmaking pool is the set of agents eligible to
+    // start a NEW duel; a fighter who has dropped out of that pool is still
+    // physically in the arena and is what the viewer should see. Without
+    // this fallback `resolveCycleCameraTarget` returns null during FIGHTING
+    // when both contestants have been unregistered mid-fight, leaving the
+    // camera untargeted. Observed on 2026-04-15.
+    if (cycle) {
+      const cycleAgent1 = cycle.agent1?.characterId;
+      if (cycleAgent1 && this.world.entities.get(cycleAgent1)) {
+        return cycleAgent1;
+      }
+      const cycleAgent2 = cycle.agent2?.characterId;
+      if (cycleAgent2 && this.world.entities.get(cycleAgent2)) {
+        return cycleAgent2;
       }
     }
 
@@ -1013,20 +1062,38 @@ export class CameraDirector {
       currentIdleDurationMs >= timing.idleThresholdMs &&
       !currentCandidate.isInCombat;
 
+    const isReturningToRecent =
+      selected.agentId === this.lastSwitchedAwayFrom &&
+      now - this.lastSwitchedAwayTime <
+        CAMERA_DIRECTOR.multipliers.returnPenaltyCooldownMs;
+    const strongerThreshold = currentIsIdle
+      ? CAMERA_DIRECTOR.multipliers.strongerThresholdIdle
+      : isReturningToRecent
+        ? CAMERA_DIRECTOR.multipliers.returnPenaltyThreshold
+        : CAMERA_DIRECTOR.multipliers.strongerThresholdActive;
     const selectedIsStronger =
-      selected.weight >
-      currentCandidate.weight *
-        (currentIsIdle
-          ? CAMERA_DIRECTOR.multipliers.strongerThresholdIdle
-          : CAMERA_DIRECTOR.multipliers.strongerThresholdActive);
+      selected.weight > currentCandidate.weight * strongerThreshold;
+
+    const elapsedSec = msSinceSwitch / 1000;
+    const randomSwitchProb =
+      1 -
+      Math.exp(
+        -CAMERA_DIRECTOR.multipliers.switchRandomChancePerSec * elapsedSec,
+      );
+    const selectedSample = this.ensureAgentActivity(selected.agentId, now);
+    const hasFocusFatigue =
+      selectedSample.lastFocusedTime > 0 &&
+      now - selectedSample.lastFocusedTime <
+        CAMERA_DIRECTOR.multipliers.focusFatigueCooldownMs;
 
     const shouldSwitch =
       forceSwitch ||
       (selected.agentId !== currentTarget &&
+        !hasFocusFatigue &&
         (selectedIsStronger ||
           (currentIsIdle &&
             selected.activityScore >= currentCandidate.activityScore) ||
-          Math.random() < CAMERA_DIRECTOR.multipliers.switchRandomChance));
+          Math.random() < randomSwitchProb));
 
     if (shouldSwitch && selected.agentId !== currentTarget) {
       this.setCameraTarget(selected.agentId, now);
@@ -1225,16 +1292,26 @@ export class CameraDirector {
       selected.weight >
       currentCandidate.weight * CAMERA_DIRECTOR.idle.strongerThreshold;
     const currentIsIdle = currentActivity === "idle";
+    const idleElapsedSec = msSinceSwitch / 1000;
+    const idleRandomProb =
+      1 -
+      Math.exp(-CAMERA_DIRECTOR.idle.switchRandomChancePerSec * idleElapsedSec);
 
     const shouldSwitch =
       selectedIsStronger ||
       (currentIsIdle &&
         selected.activityScore >= currentCandidate.activityScore) ||
-      Math.random() < CAMERA_DIRECTOR.idle.switchRandomChance;
+      Math.random() < idleRandomProb;
 
     if (shouldSwitch) {
       this.setCameraTarget(selected.agentId, now);
     }
+  }
+
+  onCombatHit(agentId: string, damageFraction: number, now: number): void {
+    if (!this.getAvailableAgents().has(agentId)) return;
+    const intensity = 1.5 + damageFraction * 8;
+    this.markAgentInteresting(agentId, intensity, now);
   }
 
   // ---- Activity map management (for external cleanup) ----

--- a/packages/server/src/systems/StreamingDuelScheduler/managers/DuelOrchestrator.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/managers/DuelOrchestrator.ts
@@ -6,7 +6,7 @@
  * management, HP tracking, fight resolution, and post-duel cleanup.
  */
 
-import type { World } from "@hyperscape/shared";
+import type { DuelArenaConfig, World } from "@hyperscape/shared";
 import {
   AttackType,
   COMBAT_SPELLS,
@@ -20,6 +20,8 @@ import {
   getDuelArenaConfig,
   getItem,
   isPositionInsideCombatArena,
+  tileChebyshevDistance,
+  worldToTile,
 } from "@hyperscape/shared";
 import { DuelCombatAI } from "../../../duel/DuelCombatAI.js";
 import {
@@ -124,6 +126,8 @@ type AgentCombatData = {
 
 /** Reserved regular duel arena for streaming agents (always use a single arena). */
 const STREAMING_AGENT_ARENA_ID = 1;
+/** Streaming agents enter combat immediately, so they must spawn in melee range. */
+const STREAMING_AGENT_ENGAGEMENT_TILE_DISTANCE = 1;
 /** Duel-eligible bronze weapons — only types with new models in swords/ directory. */
 const DUEL_BRONZE_WEAPON_IDS = [
   "bronze_longsword",
@@ -144,6 +148,62 @@ const STALL_NUDGE_MAX_DAMAGE = 5;
 
 /** Combat role types for duel arena agents. */
 type DuelCombatRole = "melee" | "ranged" | "mage" | "prayer";
+
+export function computeStreamingArenaEngagementSpawnPoints(
+  arenaConfig: DuelArenaConfig,
+  requestedArenaId = STREAMING_AGENT_ARENA_ID,
+): {
+  arenaId: number;
+  agent1: { x: number; z: number };
+  agent2: { x: number; z: number };
+} {
+  const arenaId = Math.max(
+    1,
+    Math.min(requestedArenaId, arenaConfig.arenaCount),
+  );
+  const row = Math.floor((arenaId - 1) / arenaConfig.columns);
+  const col = (arenaId - 1) % arenaConfig.columns;
+  const centerX =
+    arenaConfig.baseX +
+    col * (arenaConfig.arenaWidth + arenaConfig.arenaGap) +
+    arenaConfig.arenaWidth / 2;
+  const centerZ =
+    arenaConfig.baseZ +
+    row * (arenaConfig.arenaLength + arenaConfig.arenaGap) +
+    arenaConfig.arenaLength / 2;
+  const centerTileX = Math.floor(centerX);
+  const centerTileZ = Math.floor(centerZ);
+  const tileCenter = (tile: number) => tile + 0.5;
+
+  // Regular player duels use opposite spawn points. Streaming agents skip the
+  // human chase phase and call CombatSystem.startCombat immediately, so they
+  // must begin on adjacent tiles or melee combat deterministically fails.
+  if (arenaConfig.spawnLayout === "alongWidth") {
+    return {
+      arenaId,
+      agent1: {
+        x: tileCenter(centerTileX - STREAMING_AGENT_ENGAGEMENT_TILE_DISTANCE),
+        z: tileCenter(centerTileZ),
+      },
+      agent2: {
+        x: tileCenter(centerTileX),
+        z: tileCenter(centerTileZ),
+      },
+    };
+  }
+
+  return {
+    arenaId,
+    agent1: {
+      x: tileCenter(centerTileX),
+      z: tileCenter(centerTileZ - STREAMING_AGENT_ENGAGEMENT_TILE_DISTANCE),
+    },
+    agent2: {
+      x: tileCenter(centerTileX),
+      z: tileCenter(centerTileZ),
+    },
+  };
+}
 
 /**
  * When skill scores tie, prefer ranged/mage over melee so streaming duels
@@ -183,6 +243,8 @@ export class DuelOrchestrator {
   private combatLoopInterval: ReturnType<typeof setInterval> | null = null;
   private combatLoopTickCount: number = 0;
   private combatRetryTimeout: ReturnType<typeof setTimeout> | null = null;
+  private victoryPresentationTimeout: ReturnType<typeof setTimeout> | null =
+    null;
   private combatRetryCount: number = 0;
   private static readonly MAX_COMBAT_RETRIES = 5;
   private duelFoodSlotsByAgent: Map<string, DuelFoodProvisionedSlot[]> =
@@ -1963,50 +2025,22 @@ export class DuelOrchestrator {
     // Use a single reserved regular duel arena so all agent duels happen in
     // the same standard arena as player duels (no custom arena coordinates).
     const arenaConfig = getDuelArenaConfig();
-    const arenaId = Math.max(
-      1,
-      Math.min(STREAMING_AGENT_ARENA_ID, arenaConfig.arenaCount),
-    );
-    const row = Math.floor((arenaId - 1) / arenaConfig.columns);
-    const col = (arenaId - 1) % arenaConfig.columns;
-    const arenaCenterX =
-      arenaConfig.baseX +
-      col * (arenaConfig.arenaWidth + arenaConfig.arenaGap) +
-      arenaConfig.arenaWidth / 2;
-    const arenaCenterZ =
-      arenaConfig.baseZ +
-      row * (arenaConfig.arenaLength + arenaConfig.arenaGap) +
-      arenaConfig.arenaLength / 2;
-    const cx = arenaCenterX;
-    const cz = arenaCenterZ;
-    const off = arenaConfig.spawnOffset;
-
-    let agent1X: number;
-    let agent1Z: number;
-    let agent2X: number;
-    let agent2Z: number;
-    if (arenaConfig.spawnLayout === "alongWidth") {
-      agent1X = cx - off;
-      agent1Z = cz;
-      agent2X = cx + off;
-      agent2Z = cz;
-    } else {
-      agent1X = cx;
-      agent1Z = cz - off;
-      agent2X = cx;
-      agent2Z = cz + off;
-    }
+    const { arenaId, agent1, agent2 } =
+      computeStreamingArenaEngagementSpawnPoints(
+        arenaConfig,
+        STREAMING_AGENT_ARENA_ID,
+      );
 
     const agent1Pos: [number, number, number] = [
-      agent1X,
-      this.getGroundedY(agent1X, agent1Z, arenaConfig.baseY),
-      agent1Z,
+      agent1.x,
+      this.getGroundedY(agent1.x, agent1.z, arenaConfig.baseY),
+      agent1.z,
     ];
 
     const agent2Pos: [number, number, number] = [
-      agent2X,
-      this.getGroundedY(agent2X, agent2Z, arenaConfig.baseY),
-      agent2Z,
+      agent2.x,
+      this.getGroundedY(agent2.x, agent2.z, arenaConfig.baseY),
+      agent2.z,
     ];
 
     // Teleport both agents, facing each other
@@ -2373,9 +2407,10 @@ export class DuelOrchestrator {
 
     // Start DuelCombatAI for each agent (tick-based heal/buff/attack decisions)
     this.startCombatAIs().catch((err) => {
-      Logger.warn(
+      Logger.error(
         "StreamingDuelScheduler",
         `Failed to start combat AIs: ${errMsg(err)}`,
+        err instanceof Error ? err : null,
       );
     });
   }
@@ -2386,9 +2421,6 @@ export class DuelOrchestrator {
    * potion usage, and combat phase awareness (opening, trading, finishing).
    */
   async startCombatAIs(): Promise<void> {
-    this.stopCombatAIs();
-    this.combatRetryCount = 0;
-
     const cycle = this.getCurrentCycle();
     if (!cycle?.agent1 || !cycle?.agent2) return;
 
@@ -2397,6 +2429,8 @@ export class DuelOrchestrator {
         .toLowerCase()
         .trim() !== "false";
     if (!combatAiEnabled) {
+      this.stopCombatAIs();
+      this.combatRetryCount = 0;
       Logger.info(
         "StreamingDuelScheduler",
         "Combat AI disabled via STREAMING_DUEL_COMBAT_AI_ENABLED=false; relying on combat system re-engagement loop",
@@ -2414,6 +2448,11 @@ export class DuelOrchestrator {
     const { getAgentRuntimeByCharacterId } =
       await import("../../../eliza/ModelAgentSpawner.js");
     const manager = getAgentManager();
+
+    // Stop/relock after async imports so autonomy is not briefly restored while
+    // the module loader yields.
+    this.stopCombatAIs();
+    this.combatRetryCount = 0;
 
     const service1 = manager?.getAgentService(agent1.characterId) ?? null;
     const service2 = manager?.getAgentService(agent2.characterId) ?? null;
@@ -2487,6 +2526,20 @@ export class DuelOrchestrator {
       Logger.info(
         "StreamingDuelScheduler",
         `Combat AI started for ${agent2.name} (role=${role2}, ${llmTacticsEnabled && !!runtime2 ? "LLM strategy" : "scripted"})`,
+      );
+    }
+
+    if (this.combatAIs.size === 0) {
+      Logger.error(
+        "StreamingDuelScheduler",
+        "No combat AIs started; fight will rely only on combat re-engagement loop",
+        null,
+        {
+          agent1Id: agent1.characterId,
+          agent2Id: agent2.characterId,
+          service1Available: !!service1,
+          service2Available: !!service2,
+        },
       );
     }
   }
@@ -2754,6 +2807,13 @@ export class DuelOrchestrator {
     }
   }
 
+  clearVictoryPresentationTimeout(): void {
+    if (this.victoryPresentationTimeout) {
+      clearTimeout(this.victoryPresentationTimeout);
+      this.victoryPresentationTimeout = null;
+    }
+  }
+
   scheduleCombatRetryIfNeeded(agent1Id: string, agent2Id: string): void {
     this.clearCombatRetryTimeout();
     this.combatRetryTimeout = setTimeout(() => {
@@ -2810,19 +2870,7 @@ export class DuelOrchestrator {
       // Re-teleport to fix spacing, then retry combat
       this.ensureDuelProximity(agent1Id, agent2Id);
 
-      if (combatSystem?.startCombat) {
-        combatSystem.startCombat(agent1Id, agent2Id, {
-          attackerType: "player",
-          targetType: "player",
-        });
-        const cycleAfterRetry = this.getCurrentCycle();
-        if (cycleAfterRetry?.phase === "FIGHTING") {
-          combatSystem.startCombat(agent2Id, agent1Id, {
-            attackerType: "player",
-            targetType: "player",
-          });
-        }
-      }
+      this.tryMutualCombat(agent1Id, agent2Id);
 
       this.setAgentCombatTarget(agent1Id, agent2Id);
       this.setAgentCombatTarget(agent2Id, agent1Id);
@@ -2856,11 +2904,7 @@ export class DuelOrchestrator {
     const bx = Array.isArray(posB) ? posB[0] : posB.x;
     const bz = Array.isArray(posB) ? posB[2] : posB.z;
 
-    const tileAx = Math.floor(ax);
-    const tileAz = Math.floor(az);
-    const tileBx = Math.floor(bx);
-    const tileBz = Math.floor(bz);
-    return Math.max(Math.abs(tileAx - tileBx), Math.abs(tileAz - tileBz));
+    return tileChebyshevDistance(worldToTile(ax, az), worldToTile(bx, bz));
   }
 
   // ============================================================================
@@ -3040,7 +3084,9 @@ export class DuelOrchestrator {
   // HP Tracking & Combat Stall Nudge
   // ============================================================================
 
-  updateContestantHp(): void {
+  updateContestantHp():
+    | { hpLost1: number; hpLost2: number; maxHp1: number; maxHp2: number }
+    | undefined {
     const cycle = this.getCurrentCycle();
     if (!cycle?.agent1 || !cycle?.agent2) return;
 
@@ -3083,6 +3129,14 @@ export class DuelOrchestrator {
     if (hpLost2 > 0) {
       cycle.agent1.damageDealtThisFight += hpLost2;
     }
+
+    // Return HP deltas so the scheduler can feed combat hits to the camera director
+    return {
+      hpLost1,
+      hpLost2,
+      maxHp1: cycle.agent1.maxHp,
+      maxHp2: cycle.agent2.maxHp,
+    };
   }
 
   /**
@@ -3239,7 +3293,9 @@ export class DuelOrchestrator {
     // combat state teardown, scheduled animation resets) finishes first.
     // Without this, the "victory" emote gets immediately overwritten by
     // stale "idle" resets from the combat animation system.
-    setTimeout(() => {
+    this.clearVictoryPresentationTimeout();
+    this.victoryPresentationTimeout = setTimeout(() => {
+      this.victoryPresentationTimeout = null;
       this.triggerVictoryEmote(winnerId);
       this.fireVictoryTrashTalk(winnerId);
     }, 600);
@@ -3522,6 +3578,7 @@ export class DuelOrchestrator {
   reset(): void {
     this.stopCombatLoop();
     this.clearCombatRetryTimeout();
+    this.clearVictoryPresentationTimeout();
     this.stopCombatAIs();
     this._lastFightStats.clear();
     this.duelFoodSlotsByAgent.clear();

--- a/packages/server/src/systems/StreamingDuelScheduler/managers/MatchmakingManager.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/managers/MatchmakingManager.ts
@@ -28,6 +28,7 @@ export type AgentStatsEntry = {
   losses: number;
   combatLevel: number;
   currentStreak: number;
+  lossStreak: number;
 };
 
 type MatchmakingConfig = {
@@ -194,6 +195,7 @@ export class MatchmakingManager {
           losses: 0,
           combatLevel,
           currentStreak: 0,
+          lossStreak: 0,
         });
 
         // Load persisted stats from database asynchronously
@@ -432,11 +434,13 @@ export class MatchmakingManager {
     if (winnerStats) {
       winnerStats.wins++;
       winnerStats.currentStreak++;
+      winnerStats.lossStreak = 0;
     }
 
     if (loserStats) {
       loserStats.losses++;
       loserStats.currentStreak = 0;
+      loserStats.lossStreak++;
     }
 
     this.leaderboardDirty = true;
@@ -640,6 +644,10 @@ export class MatchmakingManager {
       winReason: duel.winReason,
       damageWinner: duel.damageWinner,
       damageLoser: duel.damageLoser,
+      duelKeyHex: duel.duelKeyHex,
+      duelEndTime: duel.duelEndTime,
+      seed: duel.seed,
+      replayHash: duel.replayHash,
     });
   }
 
@@ -673,15 +681,19 @@ export class MatchmakingManager {
         winRate,
         combatLevel: stats.combatLevel,
         currentStreak: stats.currentStreak,
+        lossStreak: stats.lossStreak,
       });
     }
 
-    // Sort by win rate, then by total wins
+    // Sort by win rate, then by total wins, then by fewer losses
     entries.sort((a, b) => {
       if (b.winRate !== a.winRate) {
         return b.winRate - a.winRate;
       }
-      return b.wins - a.wins;
+      if (b.wins !== a.wins) {
+        return b.wins - a.wins;
+      }
+      return a.losses - b.losses;
     });
 
     // Assign ranks

--- a/packages/server/src/systems/StreamingDuelScheduler/types.ts
+++ b/packages/server/src/systems/StreamingDuelScheduler/types.ts
@@ -96,6 +96,7 @@ export interface LeaderboardEntry {
   winRate: number;
   combatLevel: number;
   currentStreak: number;
+  lossStreak: number;
 }
 
 export interface RecentDuelEntry {
@@ -109,6 +110,15 @@ export interface RecentDuelEntry {
   winReason: "kill" | "hp_advantage" | "damage_advantage" | "draw";
   damageWinner: number;
   damageLoser: number;
+  // Oracle proof fields required by the keeper result-catch-up endpoint.
+  // Populated at resolution time from buildOracleProof() on the currentCycle.
+  // Nullable for backwards-compatibility with rows persisted before this
+  // field set was added; legacy rows cannot be used for synthetic onDuelEnd
+  // replay.
+  duelKeyHex: string | null;
+  duelEndTime: number | null;
+  seed: string | null;
+  replayHash: string | null;
 }
 
 export interface StreamingCycleAgent {
@@ -131,6 +141,24 @@ export interface StreamingCycleAgent {
   rank: number;
   headToHeadWins: number;
   headToHeadLosses: number;
+}
+
+/**
+ * Raw source-time timeline emitted alongside the live-scheduler cycle when
+ * the `STREAMING_EMIT_RAW_SOURCE_TIME` flag is enabled. Every timestamp
+ * mirrors the underlying scheduler's wall-clock field without any
+ * presentation-delay projection applied; consumers (bettor-facing clients
+ * doing per-viewer alignment) are expected to key snapshot history off
+ * these fields rather than off `broadcastTimeline` values that the
+ * betting-feed rail pre-projects. See docs/frontier_duel_bet_stream_sync_prd_sow.md.
+ */
+export interface StreamingSourceTimeline {
+  phase: StreamingPhase;
+  betOpenTime: number | null;
+  betCloseTime: number | null;
+  fightStartTime: number | null;
+  duelEndTime: number | null;
+  updatedAt: number;
 }
 
 export interface StreamingStateUpdate {
@@ -163,9 +191,24 @@ export interface StreamingStateUpdate {
     winReason: string | null;
     seed: string | null;
     replayHash: string | null;
+    /**
+     * Optional raw source-time timeline. Present only when
+     * `STREAMING_EMIT_RAW_SOURCE_TIME=true` on the server. Absent on default
+     * deployments to preserve the current wire contract for consumers that
+     * don't participate in viewer-clock alignment.
+     */
+    sourceTimeline?: StreamingSourceTimeline;
   };
   leaderboard: LeaderboardEntry[];
   cameraTarget: string | null;
+  /**
+   * Raw source-emission timestamp of the frame. Present on REST responses
+   * only when `STREAMING_EMIT_RAW_SOURCE_TIME=true`; SSE frames stamp this
+   * independently via their own envelope regardless of the flag. Consumers
+   * doing per-viewer clock alignment use this as the selector key for
+   * historical session snapshots.
+   */
+  emittedAt?: number;
 }
 
 const parseDurationEnv = (

--- a/packages/server/tests/unit/assets/woodcutting-manifest.test.ts
+++ b/packages/server/tests/unit/assets/woodcutting-manifest.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+interface WoodcuttingResource {
+  id: string;
+  modelVariants?: string[];
+  depletedModelPath?: string | null;
+}
+
+const WORLD_ASSETS_DIR = fileURLToPath(
+  new URL("../../../world/assets", import.meta.url),
+);
+const WOODCUTTING_MANIFEST_PATH = resolve(
+  WORLD_ASSETS_DIR,
+  "manifests/gathering/woodcutting.json",
+);
+
+function assetUriExists(assetUri: string): boolean {
+  return existsSync(resolve(WORLD_ASSETS_DIR, assetUri.replace("asset://", "")));
+}
+
+describe("woodcutting manifest", () => {
+  it("only references packaged resource models", () => {
+    const manifest = JSON.parse(
+      readFileSync(WOODCUTTING_MANIFEST_PATH, "utf8"),
+    ) as { resources?: WoodcuttingResource[] };
+
+    for (const resource of manifest.resources ?? []) {
+      for (const modelVariant of resource.modelVariants ?? []) {
+        expect(assetUriExists(modelVariant)).toBe(true);
+      }
+      if (resource.depletedModelPath) {
+        expect(assetUriExists(resource.depletedModelPath)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/server/tests/unit/middleware/csrf.test.ts
+++ b/packages/server/tests/unit/middleware/csrf.test.ts
@@ -1,0 +1,72 @@
+import type { FastifyRequest } from "fastify";
+import { describe, expect, it } from "vitest";
+import { shouldSkipCsrf } from "../../../src/middleware/csrf.js";
+
+function request(headers: Record<string, string | undefined>): FastifyRequest {
+  return {
+    headers,
+    method: "POST",
+    url: "/api/state-changing",
+  } as FastifyRequest;
+}
+
+describe("shouldSkipCsrf", () => {
+  it("does not let forged authorization headers bypass CSRF on cookie requests", () => {
+    expect(
+      shouldSkipCsrf(
+        request({
+          authorization: "Bearer attacker-controlled",
+          cookie: "session=ambient",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("allows structured authorization headers for non-cookie API clients", () => {
+    expect(
+      shouldSkipCsrf(
+        request({
+          authorization: "Bearer service-token",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not let forged admin-code headers bypass CSRF on cookie requests", () => {
+    expect(
+      shouldSkipCsrf(
+        request({
+          "x-admin-code": "operator-secret",
+          cookie: "session=ambient",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not trust non-TLS production origins", () => {
+    expect(
+      shouldSkipCsrf(
+        request({
+          origin: "http://hyperbet.win",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still trusts TLS production origins and local development origins", () => {
+    expect(
+      shouldSkipCsrf(
+        request({
+          origin: "https://hyperbet.win",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldSkipCsrf(
+        request({
+          origin: "http://localhost:5173",
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-betting-auth.test.ts
+++ b/packages/server/tests/unit/routes/streaming-betting-auth.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertSafeBettingFeedAuthConfig,
   extractBettingFeedToken,
   hasValidBettingFeedToken,
   resolveBettingFeedAccessToken,
+  resolveOracleProofAccessToken,
   shouldSkipBettingFeedAuth,
 } from "../../../src/routes/streaming-betting-auth.js";
 
@@ -31,6 +33,19 @@ describe("streaming-betting-auth", () => {
         authorizationHeader: "bearer secret-token",
       }),
     ).toBe("secret-token");
+  });
+
+  it("rejects empty or malformed bearer headers", () => {
+    expect(
+      extractBettingFeedToken({
+        authorizationHeader: "Bearer ",
+      }),
+    ).toBeNull();
+    expect(
+      extractBettingFeedToken({
+        authorizationHeader: "Bearer secret extra",
+      }),
+    ).toBeNull();
   });
 
   it("does not accept query tokens unless the route explicitly allows them", () => {
@@ -81,5 +96,45 @@ describe("streaming-betting-auth", () => {
         BETTING_FEED_SKIP_AUTH: "true",
       }),
     ).toBe(false);
+  });
+
+  it("throws when skip-auth is configured in production", () => {
+    expect(() =>
+      assertSafeBettingFeedAuthConfig({
+        NODE_ENV: "production",
+        BETTING_FEED_SKIP_AUTH: "true",
+      }),
+    ).toThrow("BETTING_FEED_SKIP_AUTH=true is forbidden");
+  });
+
+  it("requires HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN for oracle proof retrieval", () => {
+    expect(
+      resolveOracleProofAccessToken({
+        HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN: "keeper-aligned-secret",
+        BETTING_FEED_ACCESS_TOKEN: "bet-secret",
+      }),
+    ).toEqual({
+      token: "keeper-aligned-secret",
+      source: "oracle-proof",
+    });
+  });
+
+  it("does not fall back to BETTING_FEED_ACCESS_TOKEN for oracle proof retrieval", () => {
+    expect(
+      resolveOracleProofAccessToken({
+        NODE_ENV: "development",
+        BETTING_FEED_ACCESS_TOKEN: "bet-secret",
+      }),
+    ).toEqual({
+      token: null,
+      source: null,
+    });
+  });
+
+  it("reports missing auth when neither oracle-proof nor betting feed token is configured", () => {
+    expect(resolveOracleProofAccessToken({})).toEqual({
+      token: null,
+      source: null,
+    });
   });
 });

--- a/packages/server/tests/unit/routes/streaming-betting-canonical-convergence.test.ts
+++ b/packages/server/tests/unit/routes/streaming-betting-canonical-convergence.test.ts
@@ -1,0 +1,697 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerStreamingBettingRoutes } from "../../../src/routes/streaming-betting-routes.js";
+
+type BettingSyncStatePayload = {
+  rendererHealth?: {
+    ready?: boolean;
+    degradedReason?: string | null;
+  };
+} & Record<string, unknown>;
+
+const stubbedEnv = new Map<string, string | undefined>();
+
+function stubEnv(key: string, value: string): void {
+  if (!stubbedEnv.has(key)) {
+    stubbedEnv.set(key, process.env[key]);
+  }
+  process.env[key] = value;
+}
+
+function restoreStubbedEnvs(): void {
+  for (const [key, value] of stubbedEnv.entries()) {
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+  stubbedEnv.clear();
+}
+
+function createFastifyWithRateLimitDecorator(): FastifyInstance {
+  const fastify = Fastify();
+  fastify.decorate("rateLimit", (() =>
+    async () => {}) as FastifyInstance["rateLimit"]);
+  return fastify;
+}
+
+function createRouteOptions(
+  overrides: Partial<Parameters<typeof registerStreamingBettingRoutes>[0]> = {},
+) {
+  return {
+    fastify: createFastifyWithRateLimitDecorator(),
+    world: {
+      getSystem: () => null,
+    } as never,
+    replayBuffer: 16,
+    replayMaxBytes: 64 * 1024,
+    pushIntervalMs: 250,
+    heartbeatMs: 5000,
+    maxPendingBytes: 64 * 1024,
+    maxClients: 1,
+    bootstrapRateLimit: {
+      max: 10,
+      timeWindow: "1 minute",
+    },
+    eventsRateLimit: {
+      max: 10,
+      timeWindow: "1 minute",
+    },
+    internalAllowedOrigin: null,
+    externalStatusFile: null,
+    externalStatusMaxAgeMs: 15_000,
+    getStreamingDuelScheduler: () => ({
+      getCurrentCycle: () => null,
+    }),
+    getStreamCaptureStats: () => ({
+      clientConnected: true,
+      ffmpegRunning: true,
+    }),
+    ...overrides,
+  };
+}
+
+describe("streaming-betting canonical convergence", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreStubbedEnvs();
+  });
+
+  it("marks canonical playback ready when the probe is healthy even if worker connected is stale false", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-canonical-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+    fs.writeFileSync(
+      externalStatusFile,
+      JSON.stringify({
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "External Delivery",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: false,
+            error: "stale worker error",
+            startedAt: now - 500,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle:
+            "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: now,
+          lastRenderTickAt: now,
+          lastVisualChangeAt: now,
+          lastRecoveryAt: now - 1000,
+          recoveryCount: 1,
+          workerHeartbeatAt: now,
+        },
+      }),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 200 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(fetchSpy).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    const canonicalDestination = payload.channel.destinations.find(
+      (destination: { role?: string }) => destination.role === "canonical",
+    );
+    expect(payload.channel.publicReadiness).toMatchObject({
+      ready: true,
+      reason: null,
+    });
+    expect(canonicalDestination).toMatchObject({
+      id: "canonical-cloudflare",
+      connected: true,
+      transportHealthy: true,
+      playbackReady: true,
+      lastError: null,
+      manifestStatus: "ok",
+    });
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("refreshes bootstrap renderer health when replay exists but external status has advanced", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-bootstrap-refresh-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+
+    const writeStatus = (rendererReady: boolean, updatedAt: number) => {
+      fs.writeFileSync(
+        externalStatusFile,
+        JSON.stringify({
+          active: true,
+          ffmpegRunning: true,
+          clientConnected: true,
+          destinations: [
+            {
+              id: "canonical-cloudflare",
+              role: "canonical",
+              provider: "cloudflare_stream",
+              name: "External Delivery",
+              transport: "srt",
+              playbackUrl: "https://customer.example/live.m3u8",
+              connected: true,
+              startedAt: updatedAt - 500,
+            },
+          ],
+          stats: {
+            healthy: true,
+          },
+          updatedAt,
+          rendererHealth: {
+            ready: rendererReady,
+            degradedReason: rendererReady ? null : "render_tick_stale",
+            updatedAt,
+          },
+          metrics: {
+            captureFps: 60,
+            encodeFps: 60,
+            latestFrameAt: updatedAt,
+            latestRenderTickAt: updatedAt,
+            latestVisualChangeAt: updatedAt,
+            visualChangeAgeMs: 0,
+          },
+          sourceRuntime: {
+            ready: true,
+            statusSource: "external_worker",
+            captureMode: "cdp",
+            degradedReason: null,
+            currentSceneUrl: "https://staging.example/stream",
+            activeBundle:
+              "https://staging.example/assets/StreamingMode-abc123.js",
+            lastFrameAt: updatedAt,
+            lastRenderTickAt: updatedAt,
+            lastVisualChangeAt: updatedAt,
+            lastRecoveryAt: updatedAt - 1000,
+            recoveryCount: 1,
+            workerHeartbeatAt: updatedAt,
+          },
+        }),
+      );
+    };
+
+    writeStatus(false, now);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 200 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(fetchSpy).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const initialResponse = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(initialResponse.statusCode).toBe(200);
+    expect(initialResponse.json().rendererHealth).toMatchObject({
+      ready: false,
+      degradedReason: "render_tick_stale",
+    });
+
+    writeStatus(true, now + 5_000);
+
+    let refreshedPayload: BettingSyncStatePayload | null = null;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const response = await options.fastify.inject({
+        method: "GET",
+        url: "/api/internal/bet-sync/state",
+        headers: {
+          authorization: "Bearer bet-secret",
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const payload = response.json() as BettingSyncStatePayload;
+      if (payload.rendererHealth?.ready === true) {
+        refreshedPayload = payload;
+        break;
+      }
+    }
+
+    expect(refreshedPayload).not.toBeNull();
+    expect(refreshedPayload?.rendererHealth).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps Cloudflare canonical in external mode even when automatic failover prefers self-hls", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("STREAM_ENABLE_AUTOMATIC_FAILOVER", "true");
+    stubEnv("STREAM_CANONICAL_PROVIDER_PRIORITY", "self_hls,cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-priority-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+    fs.writeFileSync(
+      externalStatusFile,
+      JSON.stringify({
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "Cloudflare Stream",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: true,
+            startedAt: now - 500,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: now,
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 123,
+        },
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: null,
+          lastFrameAt: now,
+          lastRenderTickAt: now,
+          lastVisualChangeAt: now,
+          lastRecoveryAt: now - 1000,
+          recoveryCount: 0,
+          workerHeartbeatAt: now,
+        },
+      }),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 200 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.channel.canonicalDestinationId).toBe("canonical-cloudflare");
+    expect(payload.channel.fallbackDestinationId).toBeNull();
+    expect(payload.canonicalDestination).toMatchObject({
+      provider: "cloudflare_stream",
+      playbackReady: true,
+    });
+    expect(payload.fallbackDestination).toBeNull();
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("keeps Cloudflare canonical by default even when provider priority prefers self-hls", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("STREAM_CANONICAL_PROVIDER_PRIORITY", "self_hls,cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-default-cloudflare-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+    fs.writeFileSync(
+      externalStatusFile,
+      JSON.stringify({
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "Cloudflare Stream",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: true,
+            startedAt: now - 500,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: now,
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 321,
+        },
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: null,
+          lastFrameAt: now,
+          lastRenderTickAt: now,
+          lastVisualChangeAt: now,
+          lastRecoveryAt: now - 1000,
+          recoveryCount: 0,
+          workerHeartbeatAt: now,
+        },
+      }),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 200 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.channel.canonicalDestinationId).toBe("canonical-cloudflare");
+    expect(payload.channel.fallbackDestinationId).toBeNull();
+    expect(payload.canonicalDestination).toMatchObject({
+      provider: "cloudflare_stream",
+      playbackReady: true,
+    });
+    expect(payload.fallbackDestination).toBeNull();
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not fail over to self-hls while Cloudflare is disconnected in external mode", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("STREAM_ENABLE_AUTOMATIC_FAILOVER", "true");
+    stubEnv("STREAM_CANONICAL_PROVIDER_PRIORITY", "cloudflare_stream,self_hls");
+    stubEnv("STREAM_FAILBACK_SOAK_MS", "150");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-failback-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+
+    const writeStatus = (connected: boolean, updatedAt: number) => {
+      fs.writeFileSync(
+        externalStatusFile,
+        JSON.stringify({
+          active: true,
+          ffmpegRunning: true,
+          clientConnected: true,
+          destinations: [
+            {
+              id: "canonical-cloudflare",
+              role: "canonical",
+              provider: "cloudflare_stream",
+              name: "Cloudflare Stream",
+              transport: "srt",
+              playbackUrl: "https://customer.example/live.m3u8",
+              connected,
+              error: connected ? null : "delivery_disconnected",
+              startedAt: updatedAt - 500,
+            },
+          ],
+          stats: {
+            healthy: true,
+          },
+          updatedAt,
+          hlsManifest: {
+            updatedAt,
+            mediaSequence: 456,
+          },
+          rendererHealth: {
+            ready: true,
+            degradedReason: null,
+            updatedAt,
+          },
+          sourceRuntime: {
+            ready: true,
+            statusSource: "external_worker",
+            captureMode: "cdp",
+            degradedReason: null,
+            currentSceneUrl: "https://staging.example/stream",
+            activeBundle: null,
+            lastFrameAt: updatedAt,
+            lastRenderTickAt: updatedAt,
+            lastVisualChangeAt: updatedAt,
+            lastRecoveryAt: updatedAt - 1000,
+            recoveryCount: 0,
+            workerHeartbeatAt: updatedAt,
+          },
+        }),
+      );
+    };
+
+    let probeStatus = 204;
+    writeStatus(false, now);
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async () => new Response("", { status: probeStatus }),
+      );
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    let response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+    expect(response.json().canonicalDestination).toMatchObject({
+      provider: "cloudflare_stream",
+      playbackReady: false,
+    });
+    expect(response.json().fallbackDestination).toBeNull();
+
+    probeStatus = 200;
+    writeStatus(true, now + 50);
+    await new Promise((resolve) => setTimeout(resolve, 2_100));
+
+    response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+    expect(response.json().canonicalDestination).toMatchObject({
+      provider: "cloudflare_stream",
+      playbackReady: true,
+    });
+    expect(response.json().fallbackDestination).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+    expect(response.json().canonicalDestination).toMatchObject({
+      provider: "cloudflare_stream",
+      playbackReady: true,
+    });
+    expect(response.json().fallbackDestination).toBeNull();
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-betting-feed.test.ts
+++ b/packages/server/tests/unit/routes/streaming-betting-feed.test.ts
@@ -99,6 +99,57 @@ function createFrame(seq: number): BettingFeedFrame {
   };
 }
 
+function createChannel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "hyperscapes-broadcast-channel",
+    mode: "always_on",
+    presentationDelayMs: 4_000,
+    activeDuelId: "duel-1",
+    activeDuelKey: null,
+    canonicalDestinationId: "canonical-cloudflare",
+    fallbackDestinationId: "fallback-self-hls",
+    publicPlaybackUrl: "https://video.example/live.m3u8?protocol=llhls",
+    publicReadiness: {
+      ready: false,
+      reason: "delivery_disconnected",
+      updatedAt: 123_501,
+    },
+    destinations: [
+      {
+        id: "canonical-cloudflare",
+        name: "External Delivery",
+        role: "canonical",
+        provider: "cloudflare_stream",
+        transport: "llhls",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        ingestUrl: "rtmps://live.cloudflare.example/input",
+        connected: false,
+        transportHealthy: false,
+        playbackReady: false,
+        manifestStatus: "missing",
+        lastError: "delivery_disconnected",
+        updatedAt: 123_501,
+      },
+      {
+        id: "fallback-self-hls",
+        name: "Self-HLS",
+        role: "fallback",
+        provider: "self_hls",
+        transport: "hls",
+        playbackUrl: "/live/stream.m3u8",
+        ingestUrl: null,
+        connected: true,
+        transportHealthy: true,
+        playbackReady: true,
+        manifestStatus: "ok",
+        lastError: null,
+        updatedAt: 123_500,
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe("streaming-betting-feed", () => {
   it("builds betting payloads with stable schema and phase version data", () => {
     const payload = buildBettingFeedPayload({
@@ -110,30 +161,96 @@ describe("streaming-betting-feed", () => {
         degradedReason: "loading_overlay_active",
         updatedAt: 123_500,
       },
+      deliveryHealth: {
+        ready: false,
+        degradedReason: "delivery_disconnected",
+        updatedAt: 123_501,
+      },
+      rendererMetrics: {
+        captureFps: 29,
+        encodeFps: 28,
+        droppedFrames: 1,
+        renderTick: 77,
+        duelStateTick: 66,
+        latestFrameAt: 123_450,
+        latestRenderTickAt: 123_451,
+        latestDuelStateTickAt: 123_452,
+        latestVisualChangeAt: 123_453,
+        visualChangeAgeMs: 250,
+        hlsManifest: {
+          updatedAt: 123_454,
+          mediaSequence: 812,
+        },
+      },
+      channel: createChannel(),
+      sourceRuntime: {
+        ready: true,
+        statusSource: "external_worker",
+        captureMode: "cdp",
+        degradedReason: null,
+        currentSceneUrl: "https://staging.example/stream",
+        activeBundle: "bundle-a",
+        lastFrameAt: 123_455,
+        lastRenderTickAt: 123_456,
+        lastVisualChangeAt: 123_457,
+        lastRecoveryAt: 123_400,
+        recoveryCount: 1,
+        workerHeartbeatAt: 123_502,
+      },
+      canonicalAuthority: {
+        providerLive: false,
+        playbackProbeReady: false,
+        decision: "blocked",
+        reason: "provider_not_live",
+        revision: 4,
+        updatedAt: 123_503,
+        liveInputId: "live-input-123",
+        videoUid: "video-456",
+        lifecycleStatus: "disconnected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        playbackProbeStatusCode: 204,
+        playbackManifestStatus: "missing",
+      },
       cycle: createCycle({
         phase: "FIGHTING",
         phaseVersion: 9,
+        fightStartTime: 3_000,
         winnerId: "agent-b",
         winReason: "damage_advantage",
       }),
     });
 
     expect(payload).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 3,
       sourceEpoch: 42,
       seq: 7,
       emittedAt: 123_456,
+      cycle: {
+        phase: "FIGHTING",
+        fightStartTime: 3_000,
+        winnerId: null,
+        winReason: null,
+      },
       duelId: "duel-1",
-      duelKey: "0xabcdef",
+      duelKey: null,
       phase: "FIGHTING",
       phaseVersion: 9,
-      betOpenTime: 1_000,
-      betCloseTime: 2_000,
-      fightStartTime: null,
+      broadcastTimeline: {
+        phase: "FIGHTING",
+        betOpenTime: 5_000,
+        betCloseTime: 6_000,
+        fightStartTime: 7_000,
+        duelEndTime: null,
+        presentationDelayMs: 4_000,
+        updatedAt: 123_456,
+      },
+      betOpenTime: 5_000,
+      betCloseTime: 6_000,
+      fightStartTime: 7_000,
       duelEndTime: null,
-      winnerId: "agent-b",
-      winnerName: "Agent B",
-      winReason: "damage_advantage",
+      winnerId: null,
+      winnerName: null,
+      winReason: null,
       arenaPositions: {
         agent1: [10, 11, 12],
         agent2: [20, 21, 22],
@@ -143,10 +260,200 @@ describe("streaming-betting-feed", () => {
         degradedReason: "loading_overlay_active",
         updatedAt: 123_500,
       },
+      deliveryHealth: {
+        ready: false,
+        degradedReason: "delivery_disconnected",
+        updatedAt: 123_501,
+      },
+      publicReadiness: {
+        ready: false,
+        reason: "delivery_disconnected",
+        updatedAt: 123_501,
+      },
+      canonicalDestination: {
+        id: "canonical-cloudflare",
+        role: "canonical",
+        provider: "cloudflare_stream",
+        playbackReady: false,
+      },
+      fallbackDestination: {
+        id: "fallback-self-hls",
+        role: "fallback",
+        provider: "self_hls",
+        playbackReady: true,
+      },
+      sourceRuntime: {
+        ready: true,
+        statusSource: "external_worker",
+        captureMode: "cdp",
+        degradedReason: null,
+        currentSceneUrl: "https://staging.example/stream",
+        activeBundle: "bundle-a",
+        lastFrameAt: 123_455,
+        lastRenderTickAt: 123_456,
+        lastVisualChangeAt: 123_457,
+        lastRecoveryAt: 123_400,
+        recoveryCount: 1,
+        workerHeartbeatAt: 123_502,
+      },
+      canonicalAuthority: {
+        providerLive: false,
+        playbackProbeReady: false,
+        decision: "blocked",
+        reason: "provider_not_live",
+        revision: 4,
+        updatedAt: 123_503,
+        liveInputId: "live-input-123",
+        videoUid: "video-456",
+        lifecycleStatus: "disconnected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        playbackProbeStatusCode: 204,
+        playbackManifestStatus: "missing",
+      },
+      captureFps: 29,
+      encodeFps: 28,
+      droppedFrames: 1,
+      renderTick: 77,
+      duelStateTick: 66,
+      latestFrameAt: 123_450,
+      latestRenderTickAt: 123_451,
+      latestDuelStateTickAt: 123_452,
+      latestVisualChangeAt: 123_453,
+      visualChangeAgeMs: 250,
+      hlsManifestUpdatedAt: 123_454,
+      hlsMediaSequence: 812,
+      deliveryMode: "external_hls",
+      deliveryProvider: "cloudflare_stream",
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
     });
 
     expect(payload.agent1?.id).toBe("agent-a");
     expect(payload.agent2?.hp).toBe(20);
+    expect(payload.rendererMetrics?.hlsManifest?.mediaSequence).toBe(812);
+    expect(payload.channel?.canonicalDestinationId).toBe(
+      "canonical-cloudflare",
+    );
+    expect(payload.delivery?.llhlsUrl).toContain("protocol=llhls");
+    expect(payload.deliveryHealth?.degradedReason).toBe(
+      "delivery_disconnected",
+    );
+    expect(payload.canonicalAuthority).toMatchObject({
+      decision: "blocked",
+      reason: "provider_not_live",
+      revision: 4,
+      providerLive: false,
+      playbackProbeReady: false,
+    });
+  });
+
+  it("promotes broadcast timeline phase to the top-level payload phase", () => {
+    const payload = buildBettingFeedPayload({
+      sourceEpoch: 7,
+      seq: 3,
+      emittedAt: 9_000,
+      channel: createChannel(),
+      cycle: createCycle({
+        phase: "FIGHTING",
+        phaseVersion: 5,
+        betOpenTime: 1_000,
+        betCloseTime: 2_000,
+        fightStartTime: 10_000,
+      }),
+    });
+
+    expect(payload.phase).toBe("COUNTDOWN");
+    expect(payload.broadcastTimeline.phase).toBe("COUNTDOWN");
+    expect(payload.phaseVersion).toBe(5);
+  });
+
+  it("projects a bettor-facing timeline against the active canonical delay", () => {
+    const payload = buildBettingFeedPayload({
+      sourceEpoch: 7,
+      seq: 11,
+      emittedAt: 6_500,
+      channel: createChannel({
+        presentationDelayMs: 4_000,
+      }),
+      cycle: createCycle({
+        phase: "FIGHTING",
+        betOpenTime: 1_000,
+        betCloseTime: 2_000,
+        fightStartTime: 3_000,
+        duelEndTime: 9_000,
+      }),
+    });
+
+    expect(payload.phase).toBe("COUNTDOWN");
+    expect(payload.broadcastTimeline).toEqual({
+      phase: "COUNTDOWN",
+      betOpenTime: 5_000,
+      betCloseTime: 6_000,
+      fightStartTime: 7_000,
+      duelEndTime: 13_000,
+      presentationDelayMs: 4_000,
+      updatedAt: 6_500,
+    });
+    expect(payload.betOpenTime).toBe(5_000);
+    expect(payload.betCloseTime).toBe(6_000);
+    expect(payload.fightStartTime).toBe(7_000);
+    expect(payload.duelEndTime).toBe(13_000);
+  });
+
+  it("holds the projected phase at idle until the delayed cycle start arrives", () => {
+    const payload = buildBettingFeedPayload({
+      sourceEpoch: 8,
+      seq: 12,
+      emittedAt: 4_500,
+      channel: createChannel({
+        presentationDelayMs: 4_000,
+      }),
+      cycle: createCycle({
+        phase: "ANNOUNCEMENT",
+        betOpenTime: 1_000,
+        betCloseTime: 2_000,
+        fightStartTime: 3_000,
+        duelEndTime: 9_000,
+      }),
+    });
+
+    expect(payload.phase).toBe("IDLE");
+    expect(payload.broadcastTimeline).toEqual({
+      phase: "IDLE",
+      betOpenTime: 5_000,
+      betCloseTime: 6_000,
+      fightStartTime: 7_000,
+      duelEndTime: 13_000,
+      presentationDelayMs: 4_000,
+      updatedAt: 4_500,
+    });
+  });
+
+  it("hides winner metadata until the delayed public phase reaches resolution", () => {
+    const payload = buildBettingFeedPayload({
+      sourceEpoch: 9,
+      seq: 13,
+      emittedAt: 6_500,
+      channel: createChannel({
+        presentationDelayMs: 4_000,
+      }),
+      cycle: createCycle({
+        phase: "RESOLUTION",
+        fightStartTime: 3_000,
+        duelEndTime: 9_000,
+        winnerId: "agent-a",
+        winReason: "knockout",
+      }),
+    });
+
+    expect(payload.phase).toBe("COUNTDOWN");
+    expect(payload.winnerId).toBeNull();
+    expect(payload.winnerName).toBeNull();
+    expect(payload.winReason).toBeNull();
+    expect(payload.cycle).toMatchObject({
+      phase: "RESOLUTION",
+      winnerId: null,
+      winReason: null,
+    });
   });
 
   it("selects replay, bootstrap, and reset delivery modes deterministically", () => {
@@ -194,19 +501,98 @@ describe("streaming-betting-feed", () => {
       seq: 7,
       emittedAt: 123_456,
       cycle: createCycle(),
+      channel: createChannel({
+        publicReadiness: {
+          ready: true,
+          reason: null,
+          updatedAt: 123_401,
+        },
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            name: "External Delivery",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            transport: "llhls",
+            playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+            ingestUrl: "rtmps://live.cloudflare.example/input",
+            connected: true,
+            transportHealthy: true,
+            playbackReady: true,
+            manifestStatus: "ok",
+            lastError: null,
+            updatedAt: 123_401,
+          },
+        ],
+      }),
       rendererHealth: {
         ready: true,
         degradedReason: null,
         updatedAt: 123_400,
       },
+      sourceRuntime: {
+        ready: true,
+        statusSource: "external_worker",
+        captureMode: "cdp",
+        degradedReason: null,
+        currentSceneUrl: "https://staging.example/stream",
+        activeBundle: "bundle-a",
+        lastFrameAt: 123_390,
+        lastRenderTickAt: 123_391,
+        lastVisualChangeAt: 123_392,
+        lastRecoveryAt: 123_300,
+        recoveryCount: 1,
+        workerHeartbeatAt: 123_401,
+      },
     });
     const laterPayload = {
       ...basePayload,
       emittedAt: 999_999,
+      broadcastTimeline: {
+        ...basePayload.broadcastTimeline,
+        updatedAt: 555_554,
+      },
       rendererHealth: basePayload.rendererHealth
         ? {
             ...basePayload.rendererHealth,
             updatedAt: 555_555,
+          }
+        : null,
+      deliveryHealth: basePayload.deliveryHealth
+        ? {
+            ...basePayload.deliveryHealth,
+            updatedAt: 777_777,
+          }
+        : null,
+      channel: basePayload.channel
+        ? {
+            ...basePayload.channel,
+            publicReadiness: {
+              ...basePayload.channel.publicReadiness,
+              updatedAt: 888_888,
+            },
+            destinations: basePayload.channel.destinations.map(
+              (destination) => ({
+                ...destination,
+                updatedAt: 999_999,
+              }),
+            ),
+          }
+        : null,
+      sourceRuntime: basePayload.sourceRuntime
+        ? {
+            ...basePayload.sourceRuntime,
+            lastFrameAt: 888_887,
+            lastRenderTickAt: 888_886,
+            lastVisualChangeAt: 888_885,
+            lastRecoveryAt: 888_884,
+            workerHeartbeatAt: 888_883,
+          }
+        : null,
+      canonicalAuthority: basePayload.canonicalAuthority
+        ? {
+            ...basePayload.canonicalAuthority,
+            updatedAt: 666_666,
           }
         : null,
     };
@@ -214,6 +600,124 @@ describe("streaming-betting-feed", () => {
     expect(buildBettingFeedDedupKey(basePayload)).toBe(
       buildBettingFeedDedupKey(laterPayload),
     );
+  });
+
+  it("changes the dedup key when canonical authority semantics change", () => {
+    const basePayload = buildBettingFeedPayload({
+      sourceEpoch: 42,
+      seq: 7,
+      emittedAt: 123_456,
+      cycle: createCycle(),
+      channel: createChannel(),
+      canonicalAuthority: {
+        providerLive: true,
+        playbackProbeReady: true,
+        decision: "ready",
+        reason: null,
+        revision: 7,
+        updatedAt: 123_500,
+        liveInputId: "live-input-123",
+        videoUid: "video-456",
+        lifecycleStatus: "connected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        playbackProbeStatusCode: 200,
+        playbackManifestStatus: "ok",
+      },
+    });
+    const changedPayload = {
+      ...basePayload,
+      canonicalAuthority: basePayload.canonicalAuthority
+        ? {
+            ...basePayload.canonicalAuthority,
+            decision: "blocked" as const,
+            reason: "probe_unready",
+            revision: 8,
+          }
+        : null,
+    };
+
+    expect(buildBettingFeedDedupKey(basePayload)).not.toBe(
+      buildBettingFeedDedupKey(changedPayload),
+    );
+  });
+
+  it("emits raw sourceTimeline on the betting feed when enabled", () => {
+    const previous = process.env.STREAMING_EMIT_RAW_SOURCE_TIME;
+    process.env.STREAMING_EMIT_RAW_SOURCE_TIME = "true";
+
+    try {
+      const payload = buildBettingFeedPayload({
+        sourceEpoch: 42,
+        seq: 7,
+        emittedAt: 123_456,
+        cycle: createCycle({
+          phase: "FIGHTING",
+          fightStartTime: 3_000,
+          duelEndTime: 4_000,
+        }),
+      });
+
+      expect(payload.sourceTimeline).toEqual({
+        phase: "FIGHTING",
+        betOpenTime: 1_000,
+        betCloseTime: 2_000,
+        fightStartTime: 3_000,
+        duelEndTime: 4_000,
+        updatedAt: 123_456,
+      });
+      expect(payload.cycle?.sourceTimeline).toEqual(payload.sourceTimeline);
+      expect(payload.broadcastTimeline.presentationDelayMs).toBe(0);
+    } finally {
+      if (previous == null) {
+        delete process.env.STREAMING_EMIT_RAW_SOURCE_TIME;
+      } else {
+        process.env.STREAMING_EMIT_RAW_SOURCE_TIME = previous;
+      }
+    }
+  });
+
+  it("ignores sourceTimeline updatedAt when building dedup keys", () => {
+    const previous = process.env.STREAMING_EMIT_RAW_SOURCE_TIME;
+    process.env.STREAMING_EMIT_RAW_SOURCE_TIME = "true";
+
+    try {
+      const basePayload = buildBettingFeedPayload({
+        sourceEpoch: 42,
+        seq: 7,
+        emittedAt: 123_456,
+        cycle: createCycle(),
+      });
+      const laterPayload = {
+        ...basePayload,
+        sourceTimeline: basePayload.sourceTimeline
+          ? {
+              ...basePayload.sourceTimeline,
+              updatedAt: 999_999,
+            }
+          : null,
+        cycle: basePayload.cycle
+          ? {
+              ...basePayload.cycle,
+              sourceTimeline: basePayload.cycle.sourceTimeline
+                ? {
+                    ...basePayload.cycle.sourceTimeline,
+                    updatedAt: 999_999,
+                  }
+                : undefined,
+            }
+          : null,
+      };
+
+      expect(buildBettingFeedDedupKey(basePayload)).toBe(
+        buildBettingFeedDedupKey(laterPayload),
+      );
+    } finally {
+      if (previous == null) {
+        delete process.env.STREAMING_EMIT_RAW_SOURCE_TIME;
+      } else {
+        process.env.STREAMING_EMIT_RAW_SOURCE_TIME = previous;
+      }
+    }
   });
 
   it("handles empty replay buffers cleanly", () => {

--- a/packages/server/tests/unit/routes/streaming-betting-renderer-health.test.ts
+++ b/packages/server/tests/unit/routes/streaming-betting-renderer-health.test.ts
@@ -156,6 +156,86 @@ describe("deriveBettingRendererHealth", () => {
     });
   });
 
+  it("trusts fresh render metrics during active phases over stale explicit false negatives", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: false,
+          degradedReason: "renderer_health_stale",
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 30,
+          encodeFps: 30,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: false,
+        ffmpegRunning: false,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
+  it("keeps a short grace window before treating missing visual change as stale", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(
+      createCycle({
+        phase: "COUNTDOWN",
+        phaseStartTime: now - 2_000,
+      }),
+      {
+        externalStatusSnapshot: {
+          destinations: [],
+          stats: {},
+          updatedAt: now,
+          rendererHealth: {
+            ready: true,
+            degradedReason: null,
+            updatedAt: now,
+          },
+          metrics: {
+            captureFps: 60,
+            encodeFps: 45,
+            latestRenderTickAt: now,
+            latestVisualChangeAt: now - 10_000,
+            visualChangeAgeMs: 10_000,
+          },
+          hlsManifest: {
+            updatedAt: now,
+            mediaSequence: 42,
+          },
+        },
+        externalStatusMaxAgeMs: 15_000,
+        captureStats: {
+          clientConnected: true,
+          ffmpegRunning: true,
+        },
+      },
+    );
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
   it("degrades stale external RTMP renderer snapshots", () => {
     const health = deriveBettingRendererHealth(createCycle(), {
       externalStatusSnapshot: {
@@ -178,6 +258,44 @@ describe("deriveBettingRendererHealth", () => {
     expect(health).toMatchObject({
       ready: false,
       degradedReason: "renderer_health_stale",
+    });
+  });
+
+  it("uses the outer external snapshot timestamp for freshness", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now - 60_000,
+        },
+        metrics: {
+          captureFps: 60,
+          encodeFps: 45,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now - 4_900,
+          visualChangeAgeMs: 4_900,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+      updatedAt: now,
     });
   });
 
@@ -206,6 +324,299 @@ describe("deriveBettingRendererHealth", () => {
     expect(health).toMatchObject({
       ready: false,
       degradedReason: "capture_pipeline_inactive",
+    });
+  });
+
+  it("treats a fresh local HLS manifest as a healthy self-hosted fallback", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      nowMs: now,
+      localHlsManifest: {
+        updatedAt: now - 500,
+        mediaSequence: 512,
+      },
+      captureStats: {
+        clientConnected: false,
+        ffmpegRunning: false,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
+  it("reports stale render ticks when live metrics stop advancing", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 30,
+          encodeFps: 30,
+          latestRenderTickAt: now - 12_000,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: false,
+      degradedReason: "render_tick_stale",
+    });
+  });
+
+  it("allows CDP capture tick jitter while encoded HLS output is fresh", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 30,
+          encodeFps: 30,
+          latestRenderTickAt: now - 6_000,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
+  it("reports stale visual output during fighting phases", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(
+      createCycle({
+        phaseStartTime: now - 12_000,
+      }),
+      {
+        externalStatusSnapshot: {
+          destinations: [],
+          stats: {},
+          updatedAt: now,
+          rendererHealth: {
+            ready: false,
+            degradedReason: "renderer_health_stale",
+            updatedAt: now,
+          },
+          metrics: {
+            captureFps: 30,
+            encodeFps: 30,
+            latestRenderTickAt: now,
+            latestVisualChangeAt: now - 5_000,
+            visualChangeAgeMs: 5_000,
+          },
+          hlsManifest: {
+            updatedAt: now,
+            mediaSequence: 42,
+          },
+        },
+        externalStatusMaxAgeMs: 15_000,
+        captureStats: {
+          clientConnected: true,
+          ffmpegRunning: true,
+        },
+      },
+    );
+
+    expect(health).toMatchObject({
+      ready: false,
+      degradedReason: "visual_change_stale",
+    });
+  });
+
+  it("keeps renderer health ready when raw capture fps is low but encoded output is fresh", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 12,
+          encodeFps: 30,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
+  it("reports low encoder fps during fighting phases", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 30,
+          encodeFps: 12,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: false,
+      degradedReason: "encoder_fps_low",
+    });
+  });
+
+  it("uses the external source target fps for conservative staging profiles", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 4,
+          encodeFps: 13,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now,
+          mediaSequence: 42,
+        },
+        ingest: {
+          profile: "cloudflare_live",
+          transport: "srt",
+          audioSampleRate: 48000,
+          gopFrames: 30,
+          targetFps: 15,
+          probeOnly: false,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+    });
+  });
+
+  it("keeps renderer health ready when fresh render metrics are present but the local manifest is stale", () => {
+    const now = Date.now();
+    const health = deriveBettingRendererHealth(createCycle(), {
+      externalStatusSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        metrics: {
+          captureFps: 56,
+          encodeFps: 45,
+          latestRenderTickAt: now,
+          latestVisualChangeAt: now,
+          visualChangeAgeMs: 200,
+        },
+        hlsManifest: {
+          updatedAt: now - 60_000,
+          mediaSequence: 0,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+    });
+
+    expect(health).toMatchObject({
+      ready: true,
+      degradedReason: null,
+      updatedAt: now,
     });
   });
 

--- a/packages/server/tests/unit/routes/streaming-betting-routes.test.ts
+++ b/packages/server/tests/unit/routes/streaming-betting-routes.test.ts
@@ -1,4 +1,7 @@
-import Fastify from "fastify";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   allocateNextBettingClientId,
@@ -6,12 +9,40 @@ import {
   parseReplayCursor,
   registerStreamingBettingRoutes,
 } from "../../../src/routes/streaming-betting-routes.js";
+import type { StreamingDuelCycle } from "../../../src/systems/StreamingDuelScheduler/types.js";
+
+const stubbedEnv = new Map<string, string | undefined>();
+
+function stubEnv(key: string, value: string): void {
+  if (!stubbedEnv.has(key)) {
+    stubbedEnv.set(key, process.env[key]);
+  }
+  process.env[key] = value;
+}
+
+function restoreStubbedEnvs(): void {
+  for (const [key, value] of stubbedEnv.entries()) {
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+  stubbedEnv.clear();
+}
+
+function createFastifyWithRateLimitDecorator(): FastifyInstance {
+  const fastify = Fastify();
+  fastify.decorate("rateLimit", (() =>
+    async () => {}) as FastifyInstance["rateLimit"]);
+  return fastify;
+}
 
 function createRouteOptions(
   overrides: Partial<Parameters<typeof registerStreamingBettingRoutes>[0]> = {},
 ) {
   return {
-    fastify: Fastify(),
+    fastify: createFastifyWithRateLimitDecorator(),
     world: {
       getSystem: () => null,
     } as never,
@@ -43,14 +74,119 @@ function createRouteOptions(
   };
 }
 
+function createCycle(
+  overrides: Partial<StreamingDuelCycle> = {},
+): StreamingDuelCycle {
+  return {
+    cycleId: "cycle-1",
+    phase: "FIGHTING",
+    cycleStartTime: 1_000,
+    phaseStartTime: 2_000,
+    phaseVersion: 3,
+    agent1: {
+      characterId: "agent-a",
+      name: "Agent A",
+      provider: "provider-a",
+      model: "model-a",
+      combatLevel: 10,
+      wins: 7,
+      losses: 2,
+      currentHp: 25,
+      maxHp: 30,
+      originalPosition: [1, 2, 3],
+      damageDealtThisFight: 4,
+      equipment: {},
+      inventory: [],
+      rank: 1,
+      headToHeadWins: 3,
+      headToHeadLosses: 1,
+    },
+    agent2: {
+      characterId: "agent-b",
+      name: "Agent B",
+      provider: "provider-b",
+      model: "model-b",
+      combatLevel: 11,
+      wins: 5,
+      losses: 4,
+      currentHp: 20,
+      maxHp: 30,
+      originalPosition: [4, 5, 6],
+      damageDealtThisFight: 2,
+      equipment: {},
+      inventory: [],
+      rank: 2,
+      headToHeadWins: 1,
+      headToHeadLosses: 3,
+    },
+    duelId: "duel-1",
+    duelKeyHex: "0xabcdef",
+    arenaId: null,
+    betOpenTime: 1_000,
+    betCloseTime: 2_000,
+    countdownValue: null,
+    fightStartTime: 3_000,
+    duelEndTime: null,
+    arenaPositions: {
+      agent1: [10, 11, 12],
+      agent2: [20, 21, 22],
+    },
+    winnerId: null,
+    loserId: null,
+    winReason: null,
+    seed: null,
+    replayHash: null,
+    ...overrides,
+  };
+}
+
+function createStorageBackedWorld() {
+  const rows = new Map<
+    string,
+    { key: string; value: string; updatedAt: number }
+  >();
+  return {
+    rows,
+    world: {
+      getSystem: (name: string) => {
+        if (name !== "database") {
+          return null;
+        }
+        return {
+          getDb: () => ({
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  limit: async () => [],
+                }),
+              }),
+            }),
+            insert: () => ({
+              values: (row: {
+                key: string;
+                value: string;
+                updatedAt: number;
+              }) => ({
+                onConflictDoUpdate: async () => {
+                  rows.set(row.key, row);
+                },
+              }),
+            }),
+          }),
+        };
+      },
+    } as never,
+  };
+}
+
 describe("streaming-betting-routes", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllEnvs();
+    restoreStubbedEnvs();
   });
 
   it("returns bootstrap state for valid authenticated requests", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -65,8 +201,23 @@ describe("streaming-betting-routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 3,
       sourceEpoch: expect.any(Number),
+      broadcastTimeline: {
+        phase: null,
+        betOpenTime: null,
+        betCloseTime: null,
+        fightStartTime: null,
+        duelEndTime: null,
+        presentationDelayMs: expect.any(Number),
+        updatedAt: expect.any(Number),
+      },
+      channel: expect.objectContaining({
+        canonicalDestinationId: expect.any(String),
+        publicReadiness: expect.objectContaining({
+          ready: expect.any(Boolean),
+        }),
+      }),
       replay: expect.objectContaining({
         sourceEpoch: expect.any(Number),
       }),
@@ -76,8 +227,286 @@ describe("streaming-betting-routes", () => {
     await options.fastify.close();
   });
 
+  it("serializes a coherent non-null bootstrap cycle from the active scheduler", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+
+    const options = createRouteOptions({
+      getStreamingDuelScheduler: () => ({
+        getCurrentCycle: () =>
+          createCycle({
+            phase: "RESOLUTION",
+            winnerId: "agent-a",
+            winReason: "knockout",
+          }),
+      }),
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    const response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      cycle: {
+        duelId: "duel-1",
+        phase: "RESOLUTION",
+        winnerId: null,
+        winReason: null,
+      },
+      duelId: "duel-1",
+      phase: "FIGHTING",
+      winnerId: null,
+      winnerName: null,
+      winReason: null,
+    });
+
+    routes.close();
+    await options.fastify.close();
+  });
+
+  it("uses a fresh canonical playback probe over stale worker destination flags", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-routes-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+    fs.writeFileSync(
+      externalStatusFile,
+      JSON.stringify({
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "External Delivery",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: false,
+            error: "stale worker error",
+            startedAt: Date.now() - 500,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: Date.now(),
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: Date.now(),
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle:
+            "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: Date.now(),
+          lastRenderTickAt: Date.now(),
+          lastVisualChangeAt: Date.now(),
+          lastRecoveryAt: Date.now() - 1_000,
+          recoveryCount: 1,
+          workerHeartbeatAt: Date.now(),
+        },
+      }),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 200 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(fetchSpy).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const response = await options.fastify.inject({
+      method: "GET",
+      url: "/api/internal/bet-sync/state",
+      headers: {
+        authorization: "Bearer bet-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    const canonicalDestination = payload.channel.destinations.find(
+      (destination: { role?: string }) => destination.role === "canonical",
+    );
+    expect(payload.channel.publicReadiness).toMatchObject({
+      ready: true,
+      reason: null,
+    });
+    expect(canonicalDestination).toMatchObject({
+      id: "canonical-cloudflare",
+      connected: true,
+      transportHealthy: true,
+      playbackReady: true,
+      lastError: null,
+      manifestStatus: "ok",
+    });
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not mark Cloudflare provider live from local ingest when playback probe is not ready", async () => {
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("STREAM_DELIVERY_MODE", "external_hls");
+    stubEnv("STREAM_DELIVERY_PROVIDER", "cloudflare_stream");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES", "true");
+    stubEnv("STREAM_PLAYBACK_HLS_URL", "https://customer.example/live.m3u8");
+    stubEnv(
+      "STREAM_PLAYBACK_LLHLS_URL",
+      "https://customer.example/live.m3u8?protocol=llhls",
+    );
+    stubEnv("STREAM_INGEST_RTMPS_URL", "srt://live.cloudflare.example/input");
+
+    const now = Date.now();
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "streaming-betting-routes-"),
+    );
+    const externalStatusFile = path.join(tempDir, "rtmp-status.json");
+    fs.writeFileSync(
+      externalStatusFile,
+      JSON.stringify({
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "External Delivery",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: true,
+            startedAt: now - 500,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: now,
+        rendererHealth: {
+          ready: true,
+          degradedReason: null,
+          updatedAt: now,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle:
+            "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: now,
+          lastRenderTickAt: now,
+          lastVisualChangeAt: now,
+          lastRecoveryAt: now - 1_000,
+          recoveryCount: 1,
+          workerHeartbeatAt: now,
+        },
+      }),
+    );
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => new Response("", { status: 204 }));
+
+    const options = createRouteOptions({
+      externalStatusFile,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    for (
+      let attempt = 0;
+      attempt < 20 && fetchSpy.mock.calls.length === 0;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(fetchSpy).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    let payload: {
+      canonicalAuthority?: {
+        playbackProbeStatusCode?: unknown;
+      } & Record<string, unknown>;
+      channel?: {
+        publicReadiness?: Record<string, unknown>;
+      };
+    } | null = null;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const response = await options.fastify.inject({
+        method: "GET",
+        url: "/api/internal/bet-sync/state",
+        headers: {
+          authorization: "Bearer bet-secret",
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      payload = response.json();
+      if (payload?.canonicalAuthority?.playbackProbeStatusCode === 204) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(payload).not.toBeNull();
+    expect(payload.canonicalAuthority).toMatchObject({
+      providerLive: false,
+      playbackProbeReady: false,
+      decision: "blocked",
+      reason: "provider_not_live",
+    });
+    expect(payload.channel.publicReadiness).toMatchObject({
+      ready: false,
+      reason: "provider_not_live",
+    });
+
+    routes.close();
+    await options.fastify.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
   it("rejects query-token auth on the bootstrap route", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -93,7 +522,7 @@ describe("streaming-betting-routes", () => {
   });
 
   it("returns 503 once betting SSE capacity is exhausted after auth succeeds", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
 
     const options = createRouteOptions({
       maxClients: 0,
@@ -118,8 +547,8 @@ describe("streaming-betting-routes", () => {
   });
 
   it("fails closed in production when betting-feed auth is not configured", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
+    stubEnv("NODE_ENV", "production");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -138,9 +567,9 @@ describe("streaming-betting-routes", () => {
   });
 
   it("allows explicit skip-auth only in development", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
-    vi.stubEnv("BETTING_FEED_SKIP_AUTH", "true");
+    stubEnv("NODE_ENV", "development");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
+    stubEnv("BETTING_FEED_SKIP_AUTH", "true");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -156,9 +585,9 @@ describe("streaming-betting-routes", () => {
   });
 
   it("ignores skip-auth in test environments", async () => {
-    vi.stubEnv("NODE_ENV", "test");
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
-    vi.stubEnv("BETTING_FEED_SKIP_AUTH", "true");
+    stubEnv("NODE_ENV", "test");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
+    stubEnv("BETTING_FEED_SKIP_AUTH", "true");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -173,27 +602,21 @@ describe("streaming-betting-routes", () => {
     await options.fastify.close();
   });
 
-  it("ignores skip-auth in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
-    vi.stubEnv("BETTING_FEED_SKIP_AUTH", "true");
+  it("rejects skip-auth in production during route registration", async () => {
+    stubEnv("NODE_ENV", "production");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
+    stubEnv("BETTING_FEED_SKIP_AUTH", "true");
 
     const options = createRouteOptions();
-    const routes = registerStreamingBettingRoutes(options);
-
-    const response = await options.fastify.inject({
-      method: "GET",
-      url: "/api/internal/bet-sync/state",
-    });
-
-    expect(response.statusCode).toBe(503);
-    routes.close();
+    expect(() => registerStreamingBettingRoutes(options)).toThrow(
+      "BETTING_FEED_SKIP_AUTH=true is forbidden",
+    );
     await options.fastify.close();
   });
 
   it("does not treat the viewer token as a betting-feed fallback", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
-    vi.stubEnv("STREAMING_VIEWER_ACCESS_TOKEN", "viewer-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "");
+    stubEnv("STREAMING_VIEWER_ACCESS_TOKEN", "viewer-secret");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -212,7 +635,7 @@ describe("streaming-betting-routes", () => {
   });
 
   it("reuses and releases the external status poller across repeated route registration", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 
@@ -238,7 +661,7 @@ describe("streaming-betting-routes", () => {
   });
 
   it("releases the external status poller when Fastify closes even without manual route cleanup", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 
     const options = createRouteOptions({
@@ -281,7 +704,7 @@ describe("streaming-betting-routes", () => {
   });
 
   it("rejects query-token auth on the events route", async () => {
-    vi.stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
+    stubEnv("BETTING_FEED_ACCESS_TOKEN", "bet-secret");
 
     const options = createRouteOptions();
     const routes = registerStreamingBettingRoutes(options);
@@ -292,6 +715,142 @@ describe("streaming-betting-routes", () => {
     });
 
     expect(response.statusCode).toBe(401);
+    routes.close();
+    await options.fastify.close();
+  });
+
+  it("persists Cloudflare webhook lifecycle metadata when the shared secret matches", async () => {
+    stubEnv("STREAM_CLOUDFLARE_WEBHOOK_SECRET", "cf-secret");
+    stubEnv("STREAM_CLOUDFLARE_LIVE_INPUT_ID", "live-input-env");
+
+    const storageBackedWorld = createStorageBackedWorld();
+    const options = createRouteOptions({
+      world: storageBackedWorld.world,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    const response = await options.fastify.inject({
+      method: "POST",
+      url: "/api/streaming/cloudflare/webhook",
+      headers: {
+        "cf-webhook-auth": "cf-secret",
+      },
+      payload: {
+        alert_type: "stream_live_input.connected",
+        name: "Stream Live Input Connected",
+        event: {
+          input_id: "live-input-env",
+          video_id: "video-456",
+          timestamp: "2026-04-09T02:15:00.000Z",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      eventType: "stream_live_input.connected",
+      liveInputId: "live-input-env",
+    });
+    expect(
+      JSON.parse(
+        storageBackedWorld.rows.get("streaming:cloudflare:last-webhook")
+          ?.value ?? "null",
+      ),
+    ).toMatchObject({
+      eventType: "stream_live_input.connected",
+      liveInputId: "live-input-env",
+      videoId: "video-456",
+    });
+    expect(
+      JSON.parse(
+        storageBackedWorld.rows.get("streaming:cloudflare:lifecycle")?.value ??
+          "null",
+      ),
+    ).toMatchObject({
+      eventType: "stream_live_input.connected",
+      liveInputId: "live-input-env",
+      status: "connected",
+    });
+
+    routes.close();
+    await options.fastify.close();
+  });
+
+  it("rejects authenticated Cloudflare webhooks that omit a live input id", async () => {
+    stubEnv("STREAM_CLOUDFLARE_WEBHOOK_SECRET", "cf-secret");
+    stubEnv("STREAM_CLOUDFLARE_LIVE_INPUT_ID", "live-input-env");
+
+    const storageBackedWorld = createStorageBackedWorld();
+    const options = createRouteOptions({
+      world: storageBackedWorld.world,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    const response = await options.fastify.inject({
+      method: "POST",
+      url: "/api/streaming/cloudflare/webhook",
+      headers: {
+        "cf-webhook-auth": "cf-secret",
+      },
+      payload: {
+        alert_type: "stream_live_input.connected",
+        name: "Stream Live Input Connected",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(
+      storageBackedWorld.rows.get("streaming:cloudflare:last-webhook"),
+    ).toBeUndefined();
+    expect(
+      storageBackedWorld.rows.get("streaming:cloudflare:lifecycle"),
+    ).toBeUndefined();
+
+    routes.close();
+    await options.fastify.close();
+  });
+
+  it("ignores authenticated Cloudflare webhooks for a different live input", async () => {
+    stubEnv("STREAM_CLOUDFLARE_WEBHOOK_SECRET", "cf-secret");
+    stubEnv("STREAM_CLOUDFLARE_LIVE_INPUT_ID", "live-input-env");
+
+    const storageBackedWorld = createStorageBackedWorld();
+    const options = createRouteOptions({
+      world: storageBackedWorld.world,
+    });
+    const routes = registerStreamingBettingRoutes(options);
+
+    const response = await options.fastify.inject({
+      method: "POST",
+      url: "/api/streaming/cloudflare/webhook",
+      headers: {
+        "cf-webhook-auth": "cf-secret",
+      },
+      payload: {
+        alert_type: "stream_live_input.connected",
+        name: "Stream Live Input Connected",
+        event: {
+          input_id: "other-live-input",
+          video_id: "video-456",
+          timestamp: "2026-04-09T02:15:00.000Z",
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(202);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      ignored: true,
+      liveInputId: "other-live-input",
+    });
+    expect(
+      storageBackedWorld.rows.get("streaming:cloudflare:last-webhook"),
+    ).toBeUndefined();
+    expect(
+      storageBackedWorld.rows.get("streaming:cloudflare:lifecycle"),
+    ).toBeUndefined();
+
     routes.close();
     await options.fastify.close();
   });
@@ -311,6 +870,17 @@ describe("streaming-betting-routes", () => {
     expect(wrapped).toEqual({
       clientId: 3,
       nextCursor: 4,
+    });
+  });
+
+  it("normalizes invalid betting client id cursors before allocation", () => {
+    expect(allocateNextBettingClientId(Number.NaN, [1, 2])).toEqual({
+      clientId: 3,
+      nextCursor: 4,
+    });
+    expect(allocateNextBettingClientId(-1, [])).toEqual({
+      clientId: 1,
+      nextCursor: 2,
     });
   });
 });

--- a/packages/server/tests/unit/routes/streaming-external-status.test.ts
+++ b/packages/server/tests/unit/routes/streaming-external-status.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+import { parseExternalRtmpStatusSnapshot } from "../../../src/routes/streaming-external-status.js";
+
+describe("parseExternalRtmpStatusSnapshot", () => {
+  it("allowlists the additive smoke summary fields", () => {
+    const parsed = parseExternalRtmpStatusSnapshot(
+      JSON.stringify({
+        destinations: [],
+        stats: {},
+        updatedAt: Date.now(),
+        captureMode: "cdp",
+        smoke: {
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle:
+            "https://staging.example/assets/StreamingMode-abc123.js",
+          deliveryMode: "external_hls",
+          captureFpsP50: 29.5,
+          captureFpsP95: 30,
+          encodeFpsP50: 28.5,
+          encodeFpsP95: 29,
+          updatedAt: 1234,
+          ingest: {
+            profile: "cloudflare_live",
+            transport: "rtmps",
+            audioSampleRate: 48_000,
+            gopFrames: 60,
+            probeOnly: true,
+          },
+        },
+        ingest: {
+          profile: "cloudflare_live",
+          transport: "rtmps",
+          audioSampleRate: 48_000,
+          gopFrames: 60,
+          probeOnly: true,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle:
+            "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: 1230,
+          lastRenderTickAt: 1231,
+          lastVisualChangeAt: 1232,
+          lastRecoveryAt: 1000,
+          recoveryCount: 2,
+          workerHeartbeatAt: 1234,
+        },
+        captureDiagnostics: {
+          recentFrames: [
+            {
+              at: 1230,
+              size: 2048,
+              cdpTimestamp: 12.5,
+            },
+          ],
+          recentFrameCadenceMs: [33],
+          nonMonotonicCdpTimestampCount: 0,
+          backpressureTransitions: [
+            {
+              at: 1231,
+              backpressured: true,
+            },
+          ],
+          firstFatalWriteError: {
+            at: 1229,
+            message: "Broken pipe",
+            frameCount: 4,
+            droppedFrames: 1,
+            bytesReceived: 8192,
+            backpressured: false,
+            cdpDirectMode: true,
+            uptimeMs: 900,
+          },
+          lastFatalWriteError: {
+            at: 1232,
+            message: "Input/output error",
+            frameCount: 5,
+            droppedFrames: 2,
+            bytesReceived: 12288,
+            backpressured: true,
+            cdpDirectMode: true,
+            uptimeMs: 1000,
+          },
+          pageStallBeforeLastFatalWrite: false,
+          lastFrameAgeMs: 4,
+          captureSessionGeneration: "capture-123",
+          manifestStatus: "ok",
+        },
+        unexpected: {
+          foo: "bar",
+        },
+      }),
+      15_000,
+      { allowStale: true },
+    );
+
+    expect(parsed?.captureMode).toBe("cdp");
+    expect(parsed?.smoke).toEqual({
+      currentSceneUrl: "https://staging.example/stream",
+      activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+      deliveryMode: "external_hls",
+      captureFpsP50: 29.5,
+      captureFpsP95: 30,
+      encodeFpsP50: 28.5,
+      encodeFpsP95: 29,
+      updatedAt: 1234,
+      ingest: {
+        profile: "cloudflare_live",
+        transport: "rtmps",
+        audioSampleRate: 48_000,
+        gopFrames: 60,
+        probeOnly: true,
+      },
+    });
+    expect(parsed?.ingest).toEqual({
+      profile: "cloudflare_live",
+      transport: "rtmps",
+      audioSampleRate: 48_000,
+      gopFrames: 60,
+      probeOnly: true,
+    });
+    expect(parsed?.sourceRuntime).toEqual({
+      ready: true,
+      statusSource: "external_worker",
+      captureMode: "cdp",
+      degradedReason: null,
+      currentSceneUrl: "https://staging.example/stream",
+      activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+      lastFrameAt: 1230,
+      lastRenderTickAt: 1231,
+      lastVisualChangeAt: 1232,
+      lastRecoveryAt: 1000,
+      recoveryCount: 2,
+      workerHeartbeatAt: 1234,
+    });
+    expect(parsed?.captureDiagnostics).toEqual({
+      recentFrames: [
+        {
+          at: 1230,
+          size: 2048,
+          cdpTimestamp: 12.5,
+        },
+      ],
+      recentFrameCadenceMs: [33],
+      nonMonotonicCdpTimestampCount: 0,
+      backpressureTransitions: [
+        {
+          at: 1231,
+          backpressured: true,
+        },
+      ],
+      firstFatalWriteError: {
+        at: 1229,
+        message: "Broken pipe",
+        frameCount: 4,
+        droppedFrames: 1,
+        bytesReceived: 8192,
+        backpressured: false,
+        cdpDirectMode: true,
+        uptimeMs: 900,
+      },
+      lastFatalWriteError: {
+        at: 1232,
+        message: "Input/output error",
+        frameCount: 5,
+        droppedFrames: 2,
+        bytesReceived: 12288,
+        backpressured: true,
+        cdpDirectMode: true,
+        uptimeMs: 1000,
+      },
+      pageStallBeforeLastFatalWrite: false,
+      lastFrameAgeMs: 4,
+      captureSessionGeneration: "capture-123",
+      manifestStatus: "ok",
+    });
+    expect(parsed).not.toHaveProperty("unexpected");
+  });
+
+  it("validates stats field-by-field and drops malformed values", () => {
+    const parsed = parseExternalRtmpStatusSnapshot(
+      JSON.stringify({
+        destinations: [],
+        stats: {
+          bitrate: 4_000,
+          fps: "30",
+          uptime: 12,
+          bytesReceived: 8_192,
+          droppedFrames: "2",
+          healthy: true,
+          injected: "nope",
+        },
+        updatedAt: Date.now(),
+      }),
+      15_000,
+      { allowStale: true },
+    );
+
+    expect(parsed?.stats).toEqual({
+      bitrate: 4_000,
+      uptime: 12,
+      bytesReceived: 8_192,
+      healthy: true,
+    });
+  });
+
+  it("accepts x11_nvenc capture mode from external worker snapshots", () => {
+    const parsed = parseExternalRtmpStatusSnapshot(
+      JSON.stringify({
+        destinations: [],
+        stats: {},
+        updatedAt: Date.now(),
+        captureMode: "x11_nvenc",
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "x11_nvenc",
+          degradedReason: null,
+        },
+      }),
+      15_000,
+      { allowStale: true },
+    );
+
+    expect(parsed?.captureMode).toBe("x11_nvenc");
+    expect(parsed?.sourceRuntime?.captureMode).toBe("x11_nvenc");
+  });
+
+  it("drops malformed nested fields while preserving valid siblings", () => {
+    const parsed = parseExternalRtmpStatusSnapshot(
+      JSON.stringify({
+        destinations: [],
+        stats: {},
+        updatedAt: Date.now(),
+        rendererHealth: {
+          ready: true,
+          degradedReason: 123,
+          updatedAt: "late",
+          phase: "fight",
+        },
+        delivery: {
+          mode: "external_hls",
+          provider: "cloudflare_stream",
+          playbackUrl: "https://customer.example/live.m3u8",
+          ingestUrl: 42,
+        },
+        sourceRuntime: {
+          ready: true,
+          captureMode: "cdp",
+          recoveryCount: "two",
+          workerHeartbeatAt: 5000,
+        },
+        captureDiagnostics: {
+          recentFrames: [
+            {
+              at: 10,
+              size: "bad",
+              cdpTimestamp: 11.5,
+            },
+            "bad-frame",
+          ],
+          recentFrameCadenceMs: [33, "slow", null],
+          lastFatalWriteError: {
+            at: 12,
+            message: "Broken pipe",
+            frameCount: "bad",
+            backpressured: false,
+          },
+          manifestStatus: "ok",
+        },
+      }),
+      15_000,
+      { allowStale: true },
+    );
+
+    expect(parsed?.rendererHealth).toEqual({
+      ready: true,
+      degradedReason: null,
+      updatedAt: null,
+      phase: "fight",
+    });
+    expect(parsed?.delivery).toEqual({
+      mode: "external_hls",
+      provider: "cloudflare_stream",
+      playbackUrl: "https://customer.example/live.m3u8",
+      hlsUrl: null,
+      llhlsUrl: null,
+      ingestUrl: null,
+    });
+    expect(parsed?.sourceRuntime).toEqual({
+      ready: true,
+      statusSource: "none",
+      captureMode: "cdp",
+      degradedReason: null,
+      currentSceneUrl: null,
+      activeBundle: null,
+      lastFrameAt: null,
+      lastRenderTickAt: null,
+      lastVisualChangeAt: null,
+      lastRecoveryAt: null,
+      recoveryCount: 0,
+      workerHeartbeatAt: 5000,
+    });
+    expect(parsed?.captureDiagnostics).toEqual({
+      recentFrames: [
+        {
+          at: 10,
+          size: null,
+          cdpTimestamp: 11.5,
+        },
+      ],
+      recentFrameCadenceMs: [33, null],
+      lastFatalWriteError: {
+        at: 12,
+        message: "Broken pipe",
+        frameCount: null,
+        backpressured: false,
+      },
+      manifestStatus: "ok",
+    });
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-results-route.test.ts
+++ b/packages/server/tests/unit/routes/streaming-results-route.test.ts
@@ -1,0 +1,156 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerStreamingRoutes } from "../../../src/routes/streaming.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+type StreamingHistoryRow = {
+  cycleId: string;
+  damageLoser: number | null;
+  damageWinner: number | null;
+  duelEndTime: number | null;
+  duelId: string;
+  duelKeyHex: string | null;
+  finishedAt: Date | null;
+  loserId: string | null;
+  loserName: string | null;
+  replayHash: string | null;
+  seed: string | null;
+  winReason: string | null;
+  winnerId: string | null;
+  winnerName: string | null;
+};
+
+function createHistoryDb(rows: StreamingHistoryRow[]) {
+  const limit = vi.fn(async () => rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  return {
+    db: { select },
+    spies: { from, limit, select, where },
+  };
+}
+
+function createApp(rows: StreamingHistoryRow[]) {
+  const app = Fastify();
+  app.decorate("rateLimit", (() =>
+    async () => {}) as FastifyInstance["rateLimit"]);
+
+  const { db, spies } = createHistoryDb(rows);
+  const world = {
+    getSystem: (name: string) =>
+      name === "database"
+        ? {
+            getDb: () => db,
+          }
+        : null,
+  };
+
+  registerStreamingRoutes(app, world as never);
+  return { app, spies };
+}
+
+describe("streaming results route", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("requires the oracle proof bearer token", async () => {
+    process.env.HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN = "result-secret";
+    const { app } = createApp([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/streaming/results/streaming-1",
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({
+      error: "Unauthorized",
+    });
+    await app.close();
+  });
+
+  it("does not serve oracle proof material unauthenticated in dev mode", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.BETTING_FEED_SKIP_AUTH = "true";
+    process.env.ALLOW_UNAUTHENTICATED_ORACLE_PROOF = "true";
+    const { app } = createApp([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/streaming/results/streaming-1",
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.json()).toMatchObject({
+      error: "Service unavailable",
+      message: "Oracle proof auth token is not configured",
+    });
+    await app.close();
+  });
+
+  it("rejects malformed duel ids", async () => {
+    process.env.HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN = "result-secret";
+    const { app } = createApp([]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/streaming/results/streaming%201",
+      headers: {
+        authorization: "Bearer result-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      error: "Bad request",
+      message: "Invalid duelId format",
+    });
+    await app.close();
+  });
+
+  it("returns oracle proof material for authenticated resolved duels", async () => {
+    process.env.HYPERSCAPES_RESULT_LOOKUP_BEARER_TOKEN = "result-secret";
+    const finishedAt = new Date("2026-04-20T00:00:00.000Z");
+    const row: StreamingHistoryRow = {
+      cycleId: "cycle-1",
+      damageLoser: 4,
+      damageWinner: 9,
+      duelEndTime: 1776643200000,
+      duelId: "streaming-1",
+      duelKeyHex: "a".repeat(64),
+      finishedAt,
+      loserId: "agent-b",
+      loserName: "Agent B",
+      replayHash: "b".repeat(64),
+      seed: "c".repeat(64),
+      winReason: "KO",
+      winnerId: "agent-a",
+      winnerName: "Agent A",
+    };
+    const { app } = createApp([row]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/streaming/results/streaming-1",
+      headers: {
+        authorization: "Bearer result-secret",
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      cycleId: "cycle-1",
+      duelId: "streaming-1",
+      duelKeyHex: "a".repeat(64),
+      replayHash: "b".repeat(64),
+      seed: "c".repeat(64),
+      winnerId: "agent-a",
+    });
+    await app.close();
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-route-helpers.test.ts
+++ b/packages/server/tests/unit/routes/streaming-route-helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  allocateNextStreamingSseClientId,
+  buildStreamingResultNotFoundPayload,
+  isValidStreamingResultDuelId,
+  normalizeStreamingThoughtLimit,
+} from "../../../src/routes/streaming.js";
+import { normalizeGameAssetPath } from "../../../src/startup/http-server.js";
+
+describe("streaming route helpers", () => {
+  it("normalizes monologue limits with finite bounded fallbacks", () => {
+    expect(normalizeStreamingThoughtLimit(undefined)).toBe(20);
+    expect(normalizeStreamingThoughtLimit("abc")).toBe(20);
+    expect(normalizeStreamingThoughtLimit("-5")).toBe(1);
+    expect(normalizeStreamingThoughtLimit("0")).toBe(1);
+    expect(normalizeStreamingThoughtLimit("55")).toBe(50);
+    expect(normalizeStreamingThoughtLimit("12")).toBe(12);
+  });
+
+  it("allocates SSE client ids with wraparound and collision skipping", () => {
+    const clients = new Map<number, unknown>([
+      [Number.MAX_SAFE_INTEGER, {}],
+      [1, {}],
+      [2, {}],
+    ]);
+
+    const wrapped = allocateNextStreamingSseClientId(
+      Number.MAX_SAFE_INTEGER,
+      clients,
+    );
+    expect(wrapped).toEqual({
+      clientId: 3,
+      nextClientId: 4,
+    });
+  });
+
+  it("builds a generic results lookup 404 payload", () => {
+    expect(buildStreamingResultNotFoundPayload()).toEqual({
+      error: "Not found",
+      message: "Resolved duel not found",
+    });
+  });
+
+  it("validates streaming results duel ids without requiring UUIDs", () => {
+    expect(isValidStreamingResultDuelId("streaming-123")).toBe(true);
+    expect(isValidStreamingResultDuelId("duel-123")).toBe(true);
+    expect(isValidStreamingResultDuelId("abc_123:456")).toBe(true);
+    expect(isValidStreamingResultDuelId("")).toBe(false);
+    expect(isValidStreamingResultDuelId("-streaming-123")).toBe(false);
+    expect(isValidStreamingResultDuelId("streaming 123")).toBe(false);
+    expect(isValidStreamingResultDuelId("streaming/123")).toBe(false);
+    expect(isValidStreamingResultDuelId("a".repeat(129))).toBe(false);
+  });
+
+  it("rejects game asset paths containing a null byte", () => {
+    expect(normalizeGameAssetPath("/assets/world.glb")).toBe(
+      "assets/world.glb",
+    );
+    expect(normalizeGameAssetPath("/assets/%00world.glb")).toBeNull();
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-source-runtime.test.ts
+++ b/packages/server/tests/unit/routes/streaming-source-runtime.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { deriveStreamSourceRuntime } from "../../../src/routes/streaming-source-runtime.js";
+import { resolveBrowserCaptureLastFrameAt } from "../../../src/streaming/source-runtime.js";
+
+describe("deriveStreamSourceRuntime", () => {
+  it("fails closed when an external worker is required but no snapshot is available", () => {
+    const runtime = deriveStreamSourceRuntime({
+      externalStatusSnapshot: null,
+      externalStatusMaxAgeMs: 15_000,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 123,
+      },
+      requireExternalWorker: true,
+      nowMs: 1_000,
+    });
+
+    expect(runtime).toEqual({
+      ready: false,
+      statusSource: "external_worker",
+      captureMode: "none",
+      degradedReason: "worker_missing",
+      currentSceneUrl: null,
+      activeBundle: null,
+      lastFrameAt: null,
+      lastRenderTickAt: null,
+      lastVisualChangeAt: null,
+      lastRecoveryAt: null,
+      recoveryCount: 0,
+      workerHeartbeatAt: null,
+    });
+  });
+
+  it("preserves a healthy external worker runtime even when destinations are disconnected", () => {
+    const runtime = deriveStreamSourceRuntime({
+      externalStatusSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        captureMode: "cdp",
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            connected: false,
+            error: "delivery_disconnected",
+          },
+        ],
+        stats: {
+          healthy: false,
+        },
+        updatedAt: 1_000,
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "bundle-a",
+          lastFrameAt: 999,
+          lastRenderTickAt: 998,
+          lastVisualChangeAt: 997,
+          lastRecoveryAt: 900,
+          recoveryCount: 2,
+          workerHeartbeatAt: 1_000,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 1_000,
+      },
+      requireExternalWorker: true,
+      nowMs: 1_500,
+    });
+
+    expect(runtime.ready).toBe(true);
+    expect(runtime.degradedReason).toBeNull();
+    expect(runtime.statusSource).toBe("external_worker");
+    expect(runtime.captureMode).toBe("cdp");
+  });
+
+  it("preserves x11_nvenc capture mode from the external worker snapshot", () => {
+    const runtime = deriveStreamSourceRuntime({
+      externalStatusSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        captureMode: "x11_nvenc",
+        destinations: [],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: 1_000,
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "x11_nvenc",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "bundle-a",
+          lastFrameAt: 999,
+          lastRenderTickAt: 998,
+          lastVisualChangeAt: 997,
+          lastRecoveryAt: 900,
+          recoveryCount: 2,
+          workerHeartbeatAt: 1_000,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 1_000,
+      },
+      requireExternalWorker: true,
+      nowMs: 1_500,
+    });
+
+    expect(runtime.ready).toBe(true);
+    expect(runtime.captureMode).toBe("x11_nvenc");
+  });
+
+  it("does not downgrade source runtime solely because a delivery destination is disconnected", () => {
+    const runtime = deriveStreamSourceRuntime({
+      externalStatusSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        captureMode: "cdp",
+        destinations: [
+          {
+            id: "fallback-cloudflare",
+            connected: false,
+            error: "delivery_disconnected",
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: 1_000,
+        delivery: {
+          mode: "self_hls",
+          provider: "self_hls",
+          playbackUrl: "https://self.example/live/stream.m3u8",
+          hlsUrl: "https://self.example/live/stream.m3u8",
+          llhlsUrl: null,
+          ingestUrl: null,
+        },
+      },
+      externalStatusMaxAgeMs: 15_000,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 1_000,
+      },
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+      nowMs: 1_500,
+    });
+
+    expect(runtime.ready).toBe(true);
+    expect(runtime.degradedReason).toBeNull();
+    expect(runtime.statusSource).toBe("external_worker");
+    expect(runtime.captureMode).toBe("cdp");
+  });
+
+  it("fails closed when renderer health reports a scene blocker", () => {
+    const runtime = deriveStreamSourceRuntime({
+      externalStatusSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        captureMode: "cdp",
+        destinations: [],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: 1_000,
+      },
+      externalStatusMaxAgeMs: 15_000,
+      rendererHealth: {
+        ready: false,
+        degradedReason: "terrain_not_ready",
+        updatedAt: 1_000,
+      },
+      captureStats: {
+        clientConnected: true,
+        ffmpegRunning: true,
+      },
+      nowMs: 1_500,
+    });
+
+    expect(runtime.ready).toBe(false);
+    expect(runtime.degradedReason).toBe("page_not_ready");
+    expect(runtime.statusSource).toBe("external_worker");
+    expect(runtime.captureMode).toBe("cdp");
+  });
+});
+
+describe("resolveBrowserCaptureLastFrameAt", () => {
+  it("prefers an absolute lastChunkAt timestamp when present", () => {
+    expect(
+      resolveBrowserCaptureLastFrameAt(
+        {
+          lastChunkAt: 9_750,
+          lastChunkAgeMs: 250,
+          lastChunkMs: 250,
+        },
+        10_000,
+      ),
+    ).toBe(9_750);
+  });
+
+  it("falls back to lastChunkAgeMs when lastChunkAt is unavailable", () => {
+    expect(
+      resolveBrowserCaptureLastFrameAt(
+        {
+          lastChunkAgeMs: 300,
+        },
+        10_000,
+      ),
+    ).toBe(9_700);
+  });
+
+  it("falls back to legacy lastChunkMs for mixed-version rollouts", () => {
+    expect(
+      resolveBrowserCaptureLastFrameAt(
+        {
+          lastChunkMs: 450,
+        },
+        10_000,
+      ),
+    ).toBe(9_550);
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-source-timeline.test.ts
+++ b/packages/server/tests/unit/routes/streaming-source-timeline.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachRawSourceTime,
+  buildSourceTimeline,
+  isRawSourceTimeEmissionEnabled,
+} from "../../../src/routes/streaming.js";
+import type { StreamingStateUpdate } from "../../../src/systems/StreamingDuelScheduler/types.js";
+
+/**
+ * Commit 1 contract tests for the canonical stream-state rail
+ * (`/api/streaming/state` + `/api/streaming/state/events`). These prove
+ * the additive `STREAMING_EMIT_RAW_SOURCE_TIME` flag does not change the
+ * wire shape when disabled, and produces a strictly additive raw
+ * source-time overlay when enabled. Commits 2–5 depend on this contract.
+ */
+
+function makeCycle(
+  overrides: Partial<StreamingStateUpdate["cycle"]> = {},
+): StreamingStateUpdate["cycle"] {
+  return {
+    cycleId: "cycle-1",
+    phase: "ANNOUNCEMENT",
+    cycleStartTime: 1_000,
+    phaseStartTime: 1_000,
+    phaseEndTime: 61_000,
+    phaseVersion: 1,
+    timeRemaining: 60,
+    agent1: null,
+    agent2: null,
+    duelId: "duel-1",
+    duelKeyHex: null,
+    betOpenTime: 2_000,
+    betCloseTime: 12_000,
+    countdown: null,
+    fightStartTime: null,
+    duelEndTime: null,
+    arenaPositions: null,
+    winnerId: null,
+    winnerName: null,
+    winReason: null,
+    seed: null,
+    replayHash: null,
+    ...overrides,
+  };
+}
+
+function makeState(
+  cycle: StreamingStateUpdate["cycle"] = makeCycle(),
+): StreamingStateUpdate {
+  return {
+    type: "STREAMING_STATE_UPDATE",
+    cycle,
+    leaderboard: [],
+    cameraTarget: null,
+  };
+}
+
+describe("isRawSourceTimeEmissionEnabled", () => {
+  it("returns false when the env var is unset", () => {
+    expect(isRawSourceTimeEmissionEnabled({})).toBe(false);
+  });
+
+  it("returns false when the env var is explicitly 'false'", () => {
+    expect(
+      isRawSourceTimeEmissionEnabled({
+        STREAMING_EMIT_RAW_SOURCE_TIME: "false",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the env var is 'true'", () => {
+    expect(
+      isRawSourceTimeEmissionEnabled({
+        STREAMING_EMIT_RAW_SOURCE_TIME: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(
+      isRawSourceTimeEmissionEnabled({
+        STREAMING_EMIT_RAW_SOURCE_TIME: "  TRUE  ",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects ambiguous values (1, yes, on) to avoid accidental emission", () => {
+    // Only the explicit string "true" enables the contract. This keeps
+    // rollout opt-in clear and prevents an unrelated env-convention change
+    // from flipping the wire shape.
+    expect(
+      isRawSourceTimeEmissionEnabled({ STREAMING_EMIT_RAW_SOURCE_TIME: "1" }),
+    ).toBe(false);
+    expect(
+      isRawSourceTimeEmissionEnabled({ STREAMING_EMIT_RAW_SOURCE_TIME: "yes" }),
+    ).toBe(false);
+    expect(
+      isRawSourceTimeEmissionEnabled({ STREAMING_EMIT_RAW_SOURCE_TIME: "on" }),
+    ).toBe(false);
+  });
+});
+
+describe("buildSourceTimeline", () => {
+  it("mirrors raw cycle timing fields verbatim (no projection)", () => {
+    const cycle = makeCycle({
+      phase: "COUNTDOWN",
+      betOpenTime: 100,
+      betCloseTime: 200,
+      fightStartTime: 300,
+      duelEndTime: 400,
+    });
+
+    const timeline = buildSourceTimeline(cycle, 5_000);
+
+    expect(timeline).toEqual({
+      phase: "COUNTDOWN",
+      betOpenTime: 100,
+      betCloseTime: 200,
+      fightStartTime: 300,
+      duelEndTime: 400,
+      updatedAt: 5_000,
+    });
+  });
+
+  it("preserves nulls for optional timing fields", () => {
+    const cycle = makeCycle({
+      phase: "IDLE",
+      betOpenTime: null,
+      betCloseTime: null,
+      fightStartTime: null,
+      duelEndTime: null,
+    });
+
+    const timeline = buildSourceTimeline(cycle, 42);
+
+    expect(timeline).toEqual({
+      phase: "IDLE",
+      betOpenTime: null,
+      betCloseTime: null,
+      fightStartTime: null,
+      duelEndTime: null,
+      updatedAt: 42,
+    });
+  });
+
+  it("does not apply any presentation-delay shift", () => {
+    // This is the load-bearing property: the selector in commit 3
+    // operates in source time and must not receive projected values from
+    // this rail. If anyone later "helpfully" adds a delay term here,
+    // this test should fail and so should commit 3's double-delay guard.
+    const cycle = makeCycle({ betCloseTime: 10_000 });
+
+    const timeline = buildSourceTimeline(cycle, 5_000);
+
+    expect(timeline.betCloseTime).toBe(10_000);
+  });
+});
+
+describe("attachRawSourceTime", () => {
+  it("is a no-op when disabled — wire shape unchanged", () => {
+    const state = makeState();
+    const result = attachRawSourceTime(state, 1_234, {
+      stampEmittedAt: true,
+      enabled: false,
+    });
+
+    // Identity check: literally the same object returned so downstream
+    // JSON.stringify produces byte-identical output vs. the pre-flag
+    // release. This is what lets commit 1 ship dark safely.
+    expect(result).toBe(state);
+    expect((result as Record<string, unknown>).emittedAt).toBeUndefined();
+    expect(result.cycle).not.toHaveProperty("sourceTimeline");
+  });
+
+  it("attaches cycle.sourceTimeline when enabled", () => {
+    const state = makeState();
+    const result = attachRawSourceTime(state, 7_777, {
+      stampEmittedAt: false,
+      enabled: true,
+    });
+
+    expect(result.cycle).toHaveProperty("sourceTimeline");
+    expect(result.cycle.sourceTimeline).toEqual({
+      phase: state.cycle.phase,
+      betOpenTime: state.cycle.betOpenTime,
+      betCloseTime: state.cycle.betCloseTime,
+      fightStartTime: state.cycle.fightStartTime,
+      duelEndTime: state.cycle.duelEndTime,
+      updatedAt: 7_777,
+    });
+    // stampEmittedAt=false means SSE envelope path — emittedAt is added
+    // elsewhere by the SSE framer, not by this helper.
+    expect((result as Record<string, unknown>).emittedAt).toBeUndefined();
+  });
+
+  it("stamps top-level emittedAt when stampEmittedAt=true (REST path)", () => {
+    const state = makeState();
+    const result = attachRawSourceTime(state, 9_000, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect((result as { emittedAt?: number }).emittedAt).toBe(9_000);
+    expect(result.cycle.sourceTimeline?.updatedAt).toBe(9_000);
+  });
+
+  it("builds sourceTimeline from the explicit raw source cycle when provided", () => {
+    const redactedCycle = makeCycle({
+      duelEndTime: null,
+    });
+    const rawCycle = makeCycle({
+      duelEndTime: 44_000,
+    });
+    const state = makeState(redactedCycle);
+
+    const result = attachRawSourceTime(state, 9_000, {
+      stampEmittedAt: true,
+      enabled: true,
+      sourceCycle: rawCycle,
+    });
+
+    expect(result.cycle.duelEndTime).toBeNull();
+    expect(result.cycle.sourceTimeline).toEqual({
+      phase: rawCycle.phase,
+      betOpenTime: rawCycle.betOpenTime,
+      betCloseTime: rawCycle.betCloseTime,
+      fightStartTime: rawCycle.fightStartTime,
+      duelEndTime: 44_000,
+      updatedAt: 9_000,
+    });
+  });
+
+  it("preserves a pre-existing sourceTimeline instead of rebuilding it from the public cycle", () => {
+    const existingSourceTimeline = {
+      phase: "RESOLUTION" as const,
+      betOpenTime: 1_000,
+      betCloseTime: 2_000,
+      fightStartTime: 3_000,
+      duelEndTime: 4_000,
+      updatedAt: 5_000,
+    };
+    const state = makeState({
+      ...makeCycle({
+        phase: "RESOLUTION",
+      }),
+      sourceTimeline: existingSourceTimeline,
+    });
+
+    const result = attachRawSourceTime(state, 9_999, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect(result.cycle.sourceTimeline).toEqual(existingSourceTimeline);
+  });
+
+  it("leaves all existing fields untouched (additive only)", () => {
+    const state = makeState(
+      makeCycle({
+        phase: "FIGHTING",
+        cycleId: "keep-me",
+        timeRemaining: 42,
+      }),
+    );
+    const result = attachRawSourceTime(state, 100, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect(result.type).toBe("STREAMING_STATE_UPDATE");
+    expect(result.cycle.cycleId).toBe("keep-me");
+    expect(result.cycle.phase).toBe("FIGHTING");
+    expect(result.cycle.timeRemaining).toBe(42);
+    expect(result.cycle.betOpenTime).toBe(state.cycle.betOpenTime);
+    expect(result.cycle.betCloseTime).toBe(state.cycle.betCloseTime);
+    expect(result.leaderboard).toEqual([]);
+    expect(result.cameraTarget).toBeNull();
+  });
+
+  it("does not mutate the input state", () => {
+    const cycle = makeCycle();
+    const state = makeState(cycle);
+    const result = attachRawSourceTime(state, 1, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect(state).not.toBe(result);
+    expect(state.cycle).not.toBe(result.cycle);
+    expect(state.cycle).not.toHaveProperty("sourceTimeline");
+    expect(cycle).not.toHaveProperty("sourceTimeline");
+  });
+
+  it("does not re-introduce oracle-proof fields on a redacted cycle", () => {
+    // The canonical rail calls `redactOracleProofFromCycle` upstream,
+    // which strips `duelKeyHex / duelEndTime / seed / replayHash` from
+    // public payloads. attachRawSourceTime must not resurrect any of
+    // those fields via its spread.
+    const cycle = makeCycle({ duelKeyHex: null, seed: null, replayHash: null });
+    const state = makeState(cycle);
+    const result = attachRawSourceTime(state, 1, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect(result.cycle.duelKeyHex).toBeNull();
+    expect(result.cycle.seed).toBeNull();
+    expect(result.cycle.replayHash).toBeNull();
+    // `duelEndTime` is intentionally kept as-is on the cycle (the
+    // redactor nullifies it via `delete` on the bet-sync rail; on the
+    // canonical rail it's already null when the duel hasn't ended).
+    // What sourceTimeline exposes of it is the CYCLE's value, not
+    // anything new.
+    expect(result.cycle.sourceTimeline?.duelEndTime).toBe(cycle.duelEndTime);
+  });
+
+  it("projected-vs-source separation: same cycle yields same sourceTimeline regardless of emit time", () => {
+    // Key invariant for commit 3's selector: the source timestamps in
+    // sourceTimeline are the RAW underlying scheduler values. Two calls
+    // with different `sourceEmittedAt` should produce identical
+    // sourceTimeline timing fields (only `updatedAt` changes).
+    const cycle = makeCycle();
+    const state = makeState(cycle);
+    const a = attachRawSourceTime(state, 1_000, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+    const b = attachRawSourceTime(state, 5_000, {
+      stampEmittedAt: true,
+      enabled: true,
+    });
+
+    expect(a.cycle.sourceTimeline?.betOpenTime).toBe(
+      b.cycle.sourceTimeline?.betOpenTime,
+    );
+    expect(a.cycle.sourceTimeline?.betCloseTime).toBe(
+      b.cycle.sourceTimeline?.betCloseTime,
+    );
+    expect(a.cycle.sourceTimeline?.updatedAt).toBe(1_000);
+    expect(b.cycle.sourceTimeline?.updatedAt).toBe(5_000);
+  });
+});

--- a/packages/server/tests/unit/routes/streaming-status-payload.test.ts
+++ b/packages/server/tests/unit/routes/streaming-status-payload.test.ts
@@ -1,0 +1,620 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildStreamingStatusPayload } from "../../../src/routes/streaming.js";
+
+const ORIGINAL_ENV = {
+  STREAM_DELIVERY_MODE: process.env.STREAM_DELIVERY_MODE,
+  STREAM_DELIVERY_PROVIDER: process.env.STREAM_DELIVERY_PROVIDER,
+  STREAM_PLAYBACK_URL: process.env.STREAM_PLAYBACK_URL,
+  STREAM_PLAYBACK_HLS_URL: process.env.STREAM_PLAYBACK_HLS_URL,
+  STREAM_PLAYBACK_LLHLS_URL: process.env.STREAM_PLAYBACK_LLHLS_URL,
+  STREAM_INGEST_PROFILE: process.env.STREAM_INGEST_PROFILE,
+  STREAM_INGEST_TRANSPORT: process.env.STREAM_INGEST_TRANSPORT,
+  STREAM_AUDIO_SAMPLE_RATE: process.env.STREAM_AUDIO_SAMPLE_RATE,
+  STREAM_GOP_SIZE: process.env.STREAM_GOP_SIZE,
+  STREAM_CLOUDFLARE_PROBE_ONLY: process.env.STREAM_CLOUDFLARE_PROBE_ONLY,
+  STREAM_FPS: process.env.STREAM_FPS,
+};
+
+function restoreEnv(
+  key: keyof typeof ORIGINAL_ENV,
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    restoreEnv(key as keyof typeof ORIGINAL_ENV, value);
+  }
+});
+
+describe("buildStreamingStatusPayload", () => {
+  it("mirrors authoritative external metrics and ingest state at nested fields", () => {
+    const payload = buildStreamingStatusPayload({
+      base: { running: true },
+      externalSnapshot: {
+        destinations: [],
+        stats: {},
+        updatedAt: 1_000,
+        metrics: {
+          captureFps: 30,
+          encodeFps: 29,
+          droppedFrames: 2,
+          latestFrameAt: 900,
+          latestRenderTickAt: 901,
+          latestVisualChangeAt: 902,
+          visualChangeAgeMs: 120,
+        },
+        hlsManifest: {
+          updatedAt: 950,
+          mediaSequence: 77,
+        },
+        delivery: {
+          mode: "external_hls",
+          provider: "cloudflare_stream",
+          playbackUrl: "https://customer.example/live.m3u8",
+          hlsUrl: "https://customer.example/live.m3u8",
+          llhlsUrl: "https://customer.example/live.m3u8?protocol=llhls",
+          ingestUrl: "rtmps://live.cloudflare.example/input",
+        },
+        ingest: {
+          profile: "cloudflare_live",
+          transport: "rtmps",
+          audioSampleRate: 48_000,
+          gopFrames: 60,
+          probeOnly: true,
+        },
+        smoke: {
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+          deliveryMode: "external_hls",
+          captureFpsP50: 29.5,
+          captureFpsP95: 30,
+          encodeFpsP50: 28.5,
+          encodeFpsP95: 29,
+          updatedAt: 998,
+          ingest: {
+            profile: "cloudflare_live",
+            transport: "rtmps",
+            audioSampleRate: 48_000,
+            gopFrames: 60,
+            probeOnly: true,
+          },
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: 997,
+          lastRenderTickAt: 996,
+          lastVisualChangeAt: 995,
+          lastRecoveryAt: 900,
+          recoveryCount: 2,
+          workerHeartbeatAt: 1_000,
+        },
+      },
+      bridgeStats: {
+        encoderFps: 12,
+        droppedFrames: 99,
+      },
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 999,
+      },
+    });
+
+    expect(payload.metrics).toMatchObject({
+      captureFps: 30,
+      encodeFps: 29,
+      droppedFrames: 2,
+      latestFrameAt: 900,
+      latestRenderTickAt: 901,
+      latestVisualChangeAt: 902,
+      visualChangeAgeMs: 120,
+    });
+    expect(payload.captureFps).toBe(30);
+    expect(payload.encodeFps).toBe(29);
+    expect(payload.droppedFrames).toBe(2);
+    expect(payload.hlsManifest).toEqual({
+      updatedAt: 950,
+      mediaSequence: 77,
+    });
+    expect(payload.deliveryMode).toBe("external_hls");
+    expect(payload.deliveryProvider).toBe("cloudflare_stream");
+    expect(payload.playbackUrl).toBe("https://customer.example/live.m3u8");
+    expect(payload.delivery).toMatchObject({
+      mode: "external_hls",
+      provider: "cloudflare_stream",
+      playbackUrl: "https://customer.example/live.m3u8",
+      hlsUrl: "https://customer.example/live.m3u8",
+      llhlsUrl: "https://customer.example/live.m3u8?protocol=llhls",
+      ingestUrl: null,
+    });
+    expect(payload.destinations).toEqual([]);
+    expect(payload.ingest).toEqual({
+      profile: "cloudflare_live",
+      transport: "rtmps",
+      audioSampleRate: 48_000,
+      gopFrames: 60,
+      probeOnly: true,
+    });
+    expect(payload.sourceRuntime).toEqual({
+      ready: true,
+      statusSource: "external_worker",
+      captureMode: "cdp",
+      degradedReason: null,
+      currentSceneUrl: "https://staging.example/stream",
+      activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+      lastFrameAt: 997,
+      lastRenderTickAt: 996,
+      lastVisualChangeAt: 995,
+      lastRecoveryAt: 900,
+      recoveryCount: 2,
+      workerHeartbeatAt: 1_000,
+    });
+    expect(payload.smoke).toEqual({
+      currentSceneUrl: "https://staging.example/stream",
+      activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+      deliveryMode: "external_hls",
+      captureFpsP50: 29.5,
+      captureFpsP95: 30,
+      encodeFpsP50: 28.5,
+      encodeFpsP95: 29,
+      updatedAt: 998,
+      ingest: {
+        profile: "cloudflare_live",
+        transport: "rtmps",
+        audioSampleRate: 48_000,
+        gopFrames: 60,
+        probeOnly: true,
+      },
+    });
+  });
+
+  it("falls back to configured delivery and ingest info when the external snapshot is unavailable", () => {
+    process.env.STREAM_DELIVERY_MODE = "external_hls";
+    process.env.STREAM_DELIVERY_PROVIDER = "cloudflare_stream";
+    process.env.STREAM_PLAYBACK_URL = "https://env.example/live.m3u8";
+    process.env.STREAM_PLAYBACK_HLS_URL = "https://env.example/live.m3u8";
+    process.env.STREAM_PLAYBACK_LLHLS_URL =
+      "https://env.example/live.m3u8?protocol=llhls";
+    process.env.STREAM_INGEST_PROFILE = "cloudflare_live";
+    process.env.STREAM_INGEST_TRANSPORT = "rtmps";
+    process.env.STREAM_AUDIO_SAMPLE_RATE = "48000";
+    process.env.STREAM_GOP_SIZE = "60";
+    process.env.STREAM_CLOUDFLARE_PROBE_ONLY = "true";
+    process.env.STREAM_FPS = "30";
+
+    const payload = buildStreamingStatusPayload({
+      base: { running: true },
+      externalSnapshot: null,
+      bridgeStats: null,
+      rendererHealth: {
+        ready: false,
+        degradedReason: "renderer_health_stale",
+        updatedAt: 123,
+      },
+    });
+
+    expect(payload.delivery).toMatchObject({
+      mode: "external_hls",
+      provider: "cloudflare_stream",
+      playbackUrl: "https://env.example/live.m3u8?protocol=llhls",
+      hlsUrl: "https://env.example/live.m3u8",
+      llhlsUrl: "https://env.example/live.m3u8?protocol=llhls",
+      ingestUrl: null,
+    });
+    expect(payload.ingest).toEqual({
+      profile: "cloudflare_live",
+      transport: "rtmps",
+      audioSampleRate: 48_000,
+      gopFrames: 60,
+      probeOnly: true,
+    });
+    expect(payload.smoke).toMatchObject({
+      currentSceneUrl: null,
+      activeBundle: null,
+      deliveryMode: "external_hls",
+      captureFpsP50: null,
+      captureFpsP95: null,
+      encodeFpsP50: null,
+      encodeFpsP95: null,
+      ingest: {
+        profile: "cloudflare_live",
+        transport: "rtmps",
+        audioSampleRate: 48_000,
+        gopFrames: 60,
+        probeOnly: true,
+      },
+    });
+    expect(payload.sourceRuntime).toMatchObject({
+      ready: false,
+      statusSource: "in_process_bridge",
+      captureMode: "none",
+      degradedReason: "encoder_stalled",
+    });
+  });
+
+  it("falls back to the local HLS manifest when the external snapshot is unavailable", () => {
+    const payload = buildStreamingStatusPayload({
+      base: { running: false },
+      externalSnapshot: null,
+      localHlsManifest: {
+        updatedAt: 4_321,
+        mediaSequence: 88,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: false,
+        degradedReason: "capture_client_disconnected",
+        updatedAt: 123,
+      },
+    });
+
+    expect(payload.hlsManifest).toEqual({
+      updatedAt: 4_321,
+      mediaSequence: 88,
+    });
+    expect(payload.hlsManifestUpdatedAt).toBe(4_321);
+    expect(payload.hlsMediaSequence).toBe(88);
+  });
+
+  it("prefers external runtime booleans over local base capture flags", () => {
+    const payload = buildStreamingStatusPayload({
+      base: {
+        running: false,
+        bridgeActive: false,
+        ffmpegRunning: false,
+        clientConnected: false,
+      },
+      externalSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [],
+        stats: {},
+        updatedAt: 2_000,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 1_999,
+      },
+    });
+
+    expect(payload.running).toBe(true);
+    expect(payload.bridgeActive).toBe(true);
+    expect(payload.ffmpegRunning).toBe(true);
+    expect(payload.clientConnected).toBe(true);
+  });
+
+  it("treats a fresh canonical playback probe as authoritative over stale worker flags", () => {
+    const payload = buildStreamingStatusPayload({
+      base: { running: true, bridgeActive: true },
+      externalSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "External Delivery",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: false,
+            error: "All tee outputs failed",
+            startedAt: 3_000,
+          },
+        ],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: 4_000,
+        delivery: {
+          mode: "external_hls",
+          provider: "cloudflare_stream",
+          playbackUrl: "https://customer.example/live.m3u8",
+          hlsUrl: "https://customer.example/live.m3u8",
+          llhlsUrl: "https://customer.example/live.m3u8?protocol=llhls",
+          ingestUrl: "srt://live.cloudflare.example/input",
+        },
+        captureDiagnostics: {
+          lastFatalWriteError: {
+            at: 3_100,
+            message: "All tee outputs failed",
+            frameCount: 12,
+            droppedFrames: 1,
+            bytesReceived: 2_048,
+            backpressured: false,
+            cdpDirectMode: true,
+            uptimeMs: 500,
+          },
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: 4_050,
+          lastRenderTickAt: 4_040,
+          lastVisualChangeAt: 4_030,
+          lastRecoveryAt: 3_500,
+          recoveryCount: 1,
+          workerHeartbeatAt: 4_100,
+        },
+      },
+      canonicalProbeSnapshot: {
+        playbackUrl: "https://customer.example/live.m3u8",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 4_200,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 4_199,
+      },
+    });
+
+    expect(payload.canonicalStatus).toEqual({
+      sourceReady: true,
+      canonicalTransportConnected: true,
+      canonicalPlaybackReady: true,
+      manifestStatus: "ok",
+      lastError: null,
+      updatedAt: 4_200,
+    });
+    expect(payload.destinations).toHaveLength(1);
+    expect(payload.destinations[0]).toMatchObject({
+      id: "canonical-cloudflare",
+      ingestUrl: null,
+      connected: true,
+      transportHealthy: true,
+      playbackReady: true,
+      manifestStatus: "ok",
+      lastError: null,
+    });
+    expect(payload.captureDiagnostics).toBeNull();
+  });
+
+  it("keeps canonical playback visible but marks transport unhealthy after a fresher source incident", () => {
+    const payload = buildStreamingStatusPayload({
+      base: { running: false, bridgeActive: false },
+      externalSnapshot: {
+        active: false,
+        ffmpegRunning: false,
+        clientConnected: true,
+        destinations: [
+          {
+            id: "canonical-cloudflare",
+            role: "canonical",
+            provider: "cloudflare_stream",
+            name: "External Delivery",
+            transport: "srt",
+            playbackUrl: "https://customer.example/live.m3u8",
+            connected: false,
+            error: "encoder_stalled",
+            startedAt: 3_000,
+          },
+        ],
+        stats: {
+          healthy: false,
+        },
+        updatedAt: 5_100,
+        delivery: {
+          mode: "external_hls",
+          provider: "cloudflare_stream",
+          playbackUrl: "https://customer.example/live.m3u8",
+          hlsUrl: "https://customer.example/live.m3u8",
+          llhlsUrl: "https://customer.example/live.m3u8?protocol=llhls",
+          ingestUrl: "srt://live.cloudflare.example/input",
+        },
+        captureDiagnostics: {
+          lastFatalWriteError: {
+            at: 5_050,
+            message: "av_interleaved_write_frame(): Input/output error",
+            frameCount: 42,
+            droppedFrames: 3,
+            bytesReceived: 8_192,
+            backpressured: true,
+            cdpDirectMode: true,
+            uptimeMs: 4_000,
+          },
+        },
+        sourceRuntime: {
+          ready: false,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: "encoder_stalled",
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: "https://staging.example/assets/StreamingMode-abc123.js",
+          lastFrameAt: 5_000,
+          lastRenderTickAt: 4_990,
+          lastVisualChangeAt: 4_980,
+          lastRecoveryAt: 4_500,
+          recoveryCount: 2,
+          workerHeartbeatAt: 5_100,
+        },
+      },
+      canonicalProbeSnapshot: {
+        playbackUrl: "https://customer.example/live.m3u8",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 4_900,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: false,
+        degradedReason: "encoder_stalled",
+        updatedAt: 5_100,
+      },
+    });
+
+    expect(payload.canonicalStatus).toEqual({
+      sourceReady: false,
+      canonicalTransportConnected: false,
+      canonicalPlaybackReady: true,
+      manifestStatus: "ok",
+      lastError: "encoder_stalled",
+      updatedAt: 4_900,
+    });
+    expect(payload.destinations[0]).toMatchObject({
+      ingestUrl: null,
+      connected: true,
+      transportHealthy: false,
+      playbackReady: true,
+      manifestStatus: "ok",
+      lastError: "encoder_stalled",
+    });
+  });
+
+  it("synthesizes canonical self-hls status from a fresh local manifest", () => {
+    process.env.STREAM_DELIVERY_MODE = "self_hls";
+    process.env.STREAM_PLAYBACK_URL = "https://stream.example/live/stream.m3u8";
+
+    const payload = buildStreamingStatusPayload({
+      base: { running: true, bridgeActive: true },
+      externalSnapshot: {
+        active: true,
+        ffmpegRunning: true,
+        clientConnected: true,
+        destinations: [],
+        stats: {
+          healthy: true,
+        },
+        updatedAt: 10_000,
+        delivery: {
+          mode: "self_hls",
+          provider: null,
+          playbackUrl: "https://stream.example/live/stream.m3u8",
+          hlsUrl: null,
+          llhlsUrl: null,
+          ingestUrl: null,
+        },
+        sourceRuntime: {
+          ready: true,
+          statusSource: "external_worker",
+          captureMode: "cdp",
+          degradedReason: null,
+          currentSceneUrl: "https://staging.example/stream",
+          activeBundle: null,
+          lastFrameAt: 9_980,
+          lastRenderTickAt: 9_970,
+          lastVisualChangeAt: 9_960,
+          lastRecoveryAt: null,
+          recoveryCount: 0,
+          workerHeartbeatAt: 10_000,
+        },
+      },
+      localHlsManifest: {
+        updatedAt: Date.now(),
+        mediaSequence: 321,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: true,
+        degradedReason: null,
+        updatedAt: 10_000,
+      },
+    });
+
+    expect(payload.canonicalStatus).toMatchObject({
+      sourceReady: true,
+      canonicalTransportConnected: true,
+      canonicalPlaybackReady: true,
+      manifestStatus: "ok",
+      lastError: null,
+    });
+    expect(payload.destinations).toContainEqual(
+      expect.objectContaining({
+        id: "canonical-self-hls",
+        provider: "self_hls",
+        role: "canonical",
+        transport: "hls",
+        playbackUrl: "https://stream.example/live/stream.m3u8",
+        connected: true,
+        transportHealthy: true,
+        playbackReady: true,
+        manifestStatus: "ok",
+        lastError: null,
+      }),
+    );
+  });
+
+  it("includes persisted authority and Cloudflare diagnostics when available", () => {
+    const payload = buildStreamingStatusPayload({
+      base: { running: true },
+      externalSnapshot: null,
+      canonicalProbeSnapshot: {
+        ready: false,
+        manifestStatus: "missing",
+        lastError: "playback_unconfigured",
+        updatedAt: 4_200,
+      },
+      bridgeStats: null,
+      rendererHealth: {
+        ready: false,
+        degradedReason: "encoder_stalled",
+        updatedAt: 123,
+      },
+      persistedAuthorityState: {
+        canonicalProviderState: {
+          activeProvider: "self_hls",
+          primaryHealthySince: 3_000,
+          updatedAt: 3_500,
+        },
+        cloudflareLifecycle: {
+          eventType: "stream_live_input.disconnected",
+          eventName: "Stream Live Input Disconnected",
+          liveInputId: "live-input-123",
+          videoId: "video-456",
+          status: "disconnected",
+          errorCode: "publish_disconnected",
+          errorMessage: "Publisher disconnected unexpectedly",
+          occurredAt: 4_000,
+          receivedAt: 4_100,
+        },
+        cloudflareLastWebhook: {
+          eventType: "stream_live_input.disconnected",
+          eventName: "Stream Live Input Disconnected",
+          liveInputId: "live-input-123",
+          videoId: "video-456",
+          occurredAt: 4_000,
+          receivedAt: 4_100,
+        },
+      },
+      cloudflareLiveInputId: "live-input-123",
+    });
+
+    expect(payload.authority).toEqual({
+      activeCanonicalProvider: "self_hls",
+      primaryHealthySince: 3_000,
+      updatedAt: 3_500,
+    });
+    expect(payload.cloudflare).toEqual({
+      liveInputId: null,
+      lifecycle: null,
+      lastWebhook: null,
+      lastPlaybackProbe: null,
+      lastExternalTransportError: null,
+    });
+  });
+});

--- a/packages/server/tests/unit/startup/http-server.test.ts
+++ b/packages/server/tests/unit/startup/http-server.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPagesPreviewOriginPatterns,
+  createOriginValidator,
+} from "../../../src/startup/http-server.js";
+
+describe("buildPagesPreviewOriginPatterns", () => {
+  it("matches preview origins for the configured Pages project", () => {
+    const patterns = buildPagesPreviewOriginPatterns(
+      "https://hyperscape-enoomian-staging.pages.dev",
+    );
+
+    expect(patterns).toHaveLength(1);
+    expect(
+      patterns[0]?.test(
+        "https://enoomian-staging.hyperscape-enoomian-staging.pages.dev",
+      ),
+    ).toBe(true);
+    expect(
+      patterns[0]?.test(
+        "https://preview-123.hyperscape-enoomian-staging.pages.dev",
+      ),
+    ).toBe(true);
+    expect(
+      patterns[0]?.test("https://foo.hyperscape.pages.dev"),
+    ).toBe(false);
+  });
+
+  it("normalizes an existing preview origin back to its Pages project host", () => {
+    const patterns = buildPagesPreviewOriginPatterns(
+      "https://enoomian-staging.hyperscape-enoomian-staging.pages.dev",
+    );
+
+    expect(patterns).toHaveLength(1);
+    expect(
+      patterns[0]?.test(
+        "https://branch.hyperscape-enoomian-staging.pages.dev",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores non-Pages origins", () => {
+    expect(
+      buildPagesPreviewOriginPatterns("https://46.4.80.150.sslip.io"),
+    ).toEqual([]);
+  });
+});
+
+describe("createOriginValidator", () => {
+  it("accepts preview origins derived from the configured Pages project", () => {
+    const validator = createOriginValidator([
+      "https://hyperscape-enoomian-staging.pages.dev",
+      ...buildPagesPreviewOriginPatterns(
+        "https://hyperscape-enoomian-staging.pages.dev",
+      ),
+    ]);
+
+    expect(
+      validator(
+        "https://enoomian-staging.hyperscape-enoomian-staging.pages.dev",
+      ),
+    ).toBe(true);
+    expect(validator("https://foo.hyperscape.pages.dev")).toBe(false);
+  });
+});

--- a/packages/server/tests/unit/streaming/cloudflare-authority.test.ts
+++ b/packages/server/tests/unit/streaming/cloudflare-authority.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  reconcileCloudflareAuthority,
+  summarizeCloudflareLiveWebhook,
+  verifyCloudflareWebhookSecret,
+} from "../../../src/streaming/cloudflare-authority.js";
+
+describe("cloudflare-authority", () => {
+  it("verifies the Cloudflare notification secret header", () => {
+    expect(
+      verifyCloudflareWebhookSecret(
+        {
+          "cf-webhook-auth": "super-secret",
+        },
+        "super-secret",
+      ),
+    ).toBe(true);
+    expect(
+      verifyCloudflareWebhookSecret(
+        {
+          "cf-webhook-auth": "wrong-secret",
+        },
+        "super-secret",
+      ),
+    ).toBe(false);
+  });
+
+  it("summarizes live webhook payloads into webhook and lifecycle snapshots", () => {
+    const summary = summarizeCloudflareLiveWebhook({
+      payload: {
+        alert_type: "stream_live_input.disconnected",
+        name: "Stream Live Input Disconnected",
+        event: {
+          input_id: "live-input-123",
+          video_id: "video-456",
+          timestamp: "2026-04-09T02:00:00.000Z",
+          error_code: "publish_disconnected",
+          error_message: "Publisher disconnected unexpectedly",
+        },
+      },
+      receivedAt: 1_234_567,
+    });
+
+    expect(summary.webhook).toEqual({
+      eventType: "stream_live_input.disconnected",
+      eventName: "Stream Live Input Disconnected",
+      liveInputId: "live-input-123",
+      videoId: "video-456",
+      occurredAt: Date.parse("2026-04-09T02:00:00.000Z"),
+      receivedAt: 1_234_567,
+    });
+    expect(summary.lifecycle).toEqual({
+      eventType: "stream_live_input.disconnected",
+      eventName: "Stream Live Input Disconnected",
+      liveInputId: "live-input-123",
+      videoId: "video-456",
+      status: "disconnected",
+      errorCode: "publish_disconnected",
+      errorMessage: "Publisher disconnected unexpectedly",
+      occurredAt: Date.parse("2026-04-09T02:00:00.000Z"),
+      receivedAt: 1_234_567,
+    });
+  });
+
+  it("prefers the freshest provider evidence when reconciling readiness", () => {
+    const reconciliation = reconcileCloudflareAuthority({
+      sourceRuntimeReady: true,
+      lifecycle: {
+        eventType: "stream_live_input.disconnected",
+        eventName: "Disconnected",
+        liveInputId: "live-input-123",
+        videoId: "video-stale",
+        status: "disconnected",
+        errorCode: null,
+        errorMessage: null,
+        occurredAt: 100,
+        receivedAt: 100,
+      },
+      lifecyclePoll: {
+        liveInputId: "live-input-456",
+        videoUid: "video-fresh",
+        status: "connected",
+        providerLive: true,
+        statusSummary: "connected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        occurredAt: 950,
+        receivedAt: 950,
+      },
+      playbackProbe: {
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 960,
+      },
+      previous: null,
+      nowMs: 1_000,
+      freshnessMs: 200,
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+    });
+
+    expect(reconciliation).toMatchObject({
+      revision: 1,
+      decision: "ready",
+      reason: null,
+      liveInputId: "live-input-456",
+      videoUid: "video-fresh",
+      lifecycleStatus: "connected",
+      providerLive: true,
+      playbackProbeReady: true,
+      playbackProbeStatusCode: 200,
+      playbackManifestStatus: "ok",
+    });
+  });
+
+  it("blocks as authority_stale when provider or probe evidence is stale", () => {
+    const reconciliation = reconcileCloudflareAuthority({
+      sourceRuntimeReady: true,
+      lifecycle: {
+        eventType: "stream_live_input.connected",
+        eventName: "Connected",
+        liveInputId: "live-input-123",
+        videoId: "video-456",
+        status: "connected",
+        errorCode: null,
+        errorMessage: null,
+        occurredAt: 100,
+        receivedAt: 100,
+      },
+      lifecyclePoll: null,
+      playbackProbe: {
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 100,
+      },
+      previous: null,
+      nowMs: 1_000,
+      freshnessMs: 200,
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+    });
+
+    expect(reconciliation).toMatchObject({
+      revision: 1,
+      decision: "blocked",
+      reason: "authority_stale",
+      providerLive: false,
+      playbackProbeReady: false,
+      playbackManifestStatus: "unknown",
+    });
+  });
+
+  it("preserves reconciliation revision when the decision is semantically unchanged", () => {
+    const previous = reconcileCloudflareAuthority({
+      sourceRuntimeReady: true,
+      lifecycle: null,
+      lifecyclePoll: {
+        liveInputId: "live-input-123",
+        videoUid: "video-456",
+        status: "connected",
+        providerLive: true,
+        statusSummary: "connected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        occurredAt: 950,
+        receivedAt: 950,
+      },
+      playbackProbe: {
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 960,
+      },
+      previous: null,
+      nowMs: 1_000,
+      freshnessMs: 200,
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+    });
+
+    const next = reconcileCloudflareAuthority({
+      sourceRuntimeReady: true,
+      lifecycle: null,
+      lifecyclePoll: {
+        liveInputId: "live-input-123",
+        videoUid: "video-456",
+        status: "connected",
+        providerLive: true,
+        statusSummary: "still connected",
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        occurredAt: 1_050,
+        receivedAt: 1_050,
+      },
+      playbackProbe: {
+        playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+        ready: true,
+        manifestStatus: "ok",
+        statusCode: 200,
+        lastError: null,
+        updatedAt: 1_060,
+      },
+      previous,
+      nowMs: 1_100,
+      freshnessMs: 200,
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+    });
+
+    expect(previous.revision).toBe(1);
+    expect(next.revision).toBe(1);
+    expect(next.decision).toBe("ready");
+    expect(next.reason).toBeNull();
+  });
+});

--- a/packages/server/tests/unit/streaming/delivery-config.test.ts
+++ b/packages/server/tests/unit/streaming/delivery-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveExternalStreamDeliveryInfo,
+  resolveStreamDeliveryInfo,
+} from "../../../src/streaming/delivery-config.js";
+
+describe("resolveStreamDeliveryInfo", () => {
+  it("does not infer external playback from ingest alone", () => {
+    const delivery = resolveStreamDeliveryInfo({
+      STREAM_DELIVERY_MODE: "external_hls",
+      STREAM_DELIVERY_PROVIDER: "cloudflare_stream",
+      STREAM_INGEST_RTMPS_URL: "rtmps://live.cloudflare.com:443/live",
+    });
+
+    expect(delivery).toEqual({
+      mode: "external_hls",
+      provider: "cloudflare_stream",
+      playbackUrl: null,
+      hlsUrl: null,
+      llhlsUrl: null,
+      ingestUrl: "rtmps://live.cloudflare.com:443/live",
+    });
+  });
+
+  it("prefers Cloudflare LL-HLS playback when external playback URLs are configured", () => {
+    const delivery = resolveStreamDeliveryInfo({
+      STREAM_DELIVERY_MODE: "external_hls",
+      STREAM_DELIVERY_PROVIDER: "cloudflare_stream",
+      STREAM_INGEST_RTMPS_URL: "rtmps://live.cloudflare.com:443/live",
+      STREAM_PLAYBACK_HLS_URL: "https://video.example/live.m3u8",
+      STREAM_PLAYBACK_LLHLS_URL:
+        "https://video.example/live.m3u8?protocol=llhls",
+    });
+
+    expect(delivery).toEqual({
+      mode: "external_hls",
+      provider: "cloudflare_stream",
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+      hlsUrl: "https://video.example/live.m3u8",
+      llhlsUrl: "https://video.example/live.m3u8?protocol=llhls",
+      ingestUrl: "rtmps://live.cloudflare.com:443/live",
+    });
+  });
+
+  it("keeps self-HLS playback separate from external playback URLs", () => {
+    const delivery = resolveStreamDeliveryInfo({
+      STREAM_DELIVERY_MODE: "self_hls",
+      STREAM_PLAYBACK_URL: "https://self.example/live/stream.m3u8",
+      STREAM_PLAYBACK_HLS_URL: "https://video.example/live.m3u8",
+      STREAM_PLAYBACK_LLHLS_URL:
+        "https://video.example/live.m3u8?protocol=llhls",
+      STREAM_INGEST_RTMPS_URL: "rtmps://live.cloudflare.com:443/live",
+    });
+
+    expect(delivery).toEqual({
+      mode: "self_hls",
+      provider: null,
+      playbackUrl: "https://self.example/live/stream.m3u8",
+      hlsUrl: null,
+      llhlsUrl: null,
+      ingestUrl: null,
+    });
+  });
+
+  it("preserves external playback config even when self-hls is canonical", () => {
+    const delivery = resolveExternalStreamDeliveryInfo({
+      STREAM_DELIVERY_MODE: "self_hls",
+      STREAM_PLAYBACK_URL: "https://self.example/live/stream.m3u8",
+      STREAM_PLAYBACK_HLS_URL: "https://video.example/live.m3u8",
+      STREAM_PLAYBACK_LLHLS_URL:
+        "https://video.example/live.m3u8?protocol=llhls",
+      STREAM_INGEST_RTMPS_URL: "rtmps://live.cloudflare.com:443/live",
+      STREAM_DELIVERY_PROVIDER: "cloudflare_stream",
+    });
+
+    expect(delivery).toEqual({
+      provider: "cloudflare_stream",
+      playbackUrl: "https://video.example/live.m3u8?protocol=llhls",
+      hlsUrl: "https://video.example/live.m3u8",
+      llhlsUrl: "https://video.example/live.m3u8?protocol=llhls",
+      ingestUrl: "rtmps://live.cloudflare.com:443/live",
+    });
+  });
+});

--- a/packages/server/tests/unit/streaming/destination-probe.test.ts
+++ b/packages/server/tests/unit/streaming/destination-probe.test.ts
@@ -1,0 +1,126 @@
+import type * as dnsPromises from "node:dns/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { probePlaybackUrl } from "../../../src/streaming/destination-probe.js";
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = globalThis.fetch;
+
+describe("probePlaybackUrl", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it("rejects unsupported playback protocols before fetching", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await probePlaybackUrl("file:///tmp/stream.m3u8");
+
+    expect(result.ready).toBe(false);
+    expect(result.lastError).toBe("unsupported_playback_protocol");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks private hosts in production by default", async () => {
+    process.env.NODE_ENV = "production";
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await probePlaybackUrl("http://127.0.0.1/live.m3u8");
+
+    expect(result.ready).toBe(false);
+    expect(result.lastError).toBe("private_playback_host_blocked");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks private hosts in staging even when bypass is configured", async () => {
+    process.env.NODE_ENV = "staging";
+    process.env.STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES = "true";
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await probePlaybackUrl("http://169.254.169.254/latest");
+
+    expect(result.ready).toBe(false);
+    expect(result.lastError).toBe("private_playback_host_blocked");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks public hostnames that resolve to private addresses in production", async () => {
+    process.env.NODE_ENV = "production";
+    const lookupSpy = vi
+      .fn()
+      .mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+    const fetchSpy = vi.fn();
+
+    const result = await probePlaybackUrl(
+      "https://example.com/live.m3u8",
+      4_000,
+      {
+        lookup: lookupSpy as unknown as typeof dnsPromises.lookup,
+        fetch: fetchSpy as unknown as typeof fetch,
+      },
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.lastError).toBe("private_playback_host_blocked");
+    expect(lookupSpy).toHaveBeenCalledWith("example.com", {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows private hosts in explicit development mode", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES = "true";
+    const response = new Response("#EXTM3U", { status: 200 });
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+
+    const result = await probePlaybackUrl("http://127.0.0.1/live.m3u8", 4_000, {
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.manifestStatus).toBe("ok");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("ignores the private-host bypass in production", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.STREAM_ALLOW_PRIVATE_PLAYBACK_PROBES = "true";
+    const fetchSpy = vi.fn();
+
+    const result = await probePlaybackUrl("http://127.0.0.1/live.m3u8", 4_000, {
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.lastError).toBe("private_playback_host_blocked");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("probes with redirect following disabled", async () => {
+    const response = new Response("", {
+      status: 302,
+      headers: { location: "https://elsewhere.example/live.m3u8" },
+    });
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await probePlaybackUrl("https://stream.example/live.m3u8");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        redirect: "manual",
+      }),
+    );
+  });
+});

--- a/packages/server/tests/unit/streaming/hls-cdn-sync.test.ts
+++ b/packages/server/tests/unit/streaming/hls-cdn-sync.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { __hlsCdnSyncTestInternals as internals } from "../../../src/streaming/hls-cdn-sync.js";
+
+describe("hls-cdn-sync SigV4 signing", () => {
+  it("builds a deterministic AWS SigV4 PUT signature for HLS playlists", () => {
+    const signed = internals.signS3PutRequest({
+      endpoint: "https://example.r2.cloudflarestorage.com",
+      bucket: "arena",
+      key: "live/hls.m3u8",
+      body: Buffer.from("#EXTM3U\n"),
+      contentType: "application/vnd.apple.mpegurl",
+      accessKeyId: "AKIDEXAMPLE",
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+      region: "auto",
+      now: new Date("2026-04-20T12:34:56.000Z"),
+    });
+
+    expect(signed.url).toBe(
+      "https://example.r2.cloudflarestorage.com/arena/live/hls.m3u8",
+    );
+    expect(signed.headers["x-amz-date"]).toBe("20260420T123456Z");
+    expect(signed.headers["x-amz-content-sha256"]).toBe(
+      "144659b48f342d02b9298907ab32fcf0479ac9c99a0d293c7c2ebf8df313dd12",
+    );
+    expect(signed.headers.Authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260420/auto/s3/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=49bcfb5d59481866e4b283957ff232948007487eaa367cb331e93dd0ecd942f5",
+    );
+    expect(signed.headers["Cache-Control"]).toBe(
+      "no-cache, no-store, must-revalidate",
+    );
+  });
+
+  it("marks immutable cache headers for media segments", () => {
+    const signed = internals.signS3PutRequest({
+      endpoint: "https://example.r2.cloudflarestorage.com",
+      bucket: "arena",
+      key: "live/seg-1.ts",
+      body: Buffer.from("segment"),
+      contentType: "video/mp2t",
+      accessKeyId: "AKIDEXAMPLE",
+      secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+      region: "auto",
+      now: new Date("2026-04-20T12:34:56.000Z"),
+    });
+
+    expect(signed.headers["Cache-Control"]).toBe(
+      "public, max-age=31536000, immutable",
+    );
+  });
+});

--- a/packages/server/tests/unit/systems/DuelScheduler/BettingPoolManager.test.ts
+++ b/packages/server/tests/unit/systems/DuelScheduler/BettingPoolManager.test.ts
@@ -1,0 +1,182 @@
+import { Keypair } from "@solana/web3.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const databaseMock = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+}));
+
+vi.mock("../../../../src/database/client.js", () => ({
+  getDatabase: databaseMock.getDatabase,
+}));
+
+import {
+  BettingPoolManager,
+  __bettingPoolManagerTestInternals as internals,
+} from "../../../../src/systems/DuelScheduler/BettingPoolManager.js";
+
+describe("BettingPoolManager input validation", () => {
+  beforeEach(() => {
+    databaseMock.getDatabase.mockReset();
+  });
+
+  it("accepts bounded positive decimal bet amounts", () => {
+    expect(internals.isValidPositiveDecimalAmount("1")).toBe(true);
+    expect(internals.isValidPositiveDecimalAmount("0.00000001")).toBe(true);
+    expect(
+      internals.isValidPositiveDecimalAmount("999999999999999999.12345678"),
+    ).toBe(true);
+  });
+
+  it("rejects zero, negative, over-precision, and oversized bet amounts", () => {
+    for (const amount of [
+      "0",
+      "0.0",
+      "-1",
+      "1.123456789",
+      "1000000000000000000",
+      "1e6",
+      "NaN",
+      "Infinity",
+      "",
+    ]) {
+      expect(internals.isValidPositiveDecimalAmount(amount), amount).toBe(
+        false,
+      );
+    }
+  });
+
+  it("validates Solana-style wallet addresses without accepting malformed strings", () => {
+    expect(
+      internals.isValidSolanaWalletAddress(
+        Keypair.generate().publicKey.toBase58(),
+      ),
+    ).toBe(true);
+
+    for (const wallet of [
+      "",
+      "0".repeat(32),
+      "O".repeat(32),
+      "I".repeat(32),
+      "l".repeat(32),
+      "short",
+      "1".repeat(45),
+    ]) {
+      expect(internals.isValidSolanaWalletAddress(wallet), wallet).toBe(false);
+    }
+  });
+});
+
+describe("BettingPoolManager.placeBet", () => {
+  beforeEach(() => {
+    databaseMock.getDatabase.mockReset();
+  });
+
+  function createManager(walletBetCount: number) {
+    const emitted: Array<{ event: string; payload: unknown }> = [];
+    const insertedBets: unknown[] = [];
+    const tx = {
+      execute: vi.fn(async () => ({
+        rows: [
+          {
+            id: "round-1",
+            bettingClosesAt: Date.now() + 60_000,
+            duelEndsAt: null,
+            winnerId: null,
+          },
+        ],
+      })),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: async () => [{ count: walletBetCount }],
+        }),
+      })),
+      insert: vi.fn(() => ({
+        values: async (value: unknown) => {
+          insertedBets.push(value);
+        },
+      })),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (txArg: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => ({
+            groupBy: async () => [],
+          }),
+        }),
+      })),
+    };
+    databaseMock.getDatabase.mockReturnValue(db);
+    const world = {
+      duelBettingBridge: {
+        getMarket: vi.fn(() => ({ status: "betting" })),
+      },
+      emit: (event: string, payload: unknown) => {
+        emitted.push({ event, payload });
+      },
+    };
+    const manager = new BettingPoolManager(world as never);
+    return { db, emitted, insertedBets, manager, tx };
+  }
+
+  it("places a bet inside the locked round transaction and emits a pool update", async () => {
+    const { emitted, insertedBets, manager, tx } = createManager(0);
+    const walletAddress = Keypair.generate().publicKey.toBase58();
+
+    const result = await manager.placeBet({
+      roundId: "round-1",
+      side: "A",
+      amount: "1.25",
+      walletAddress,
+    });
+
+    expect(result.success).toBe(true);
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(tx.select).toHaveBeenCalledOnce();
+    expect(insertedBets).toHaveLength(1);
+    expect(insertedBets[0]).toMatchObject({
+      roundId: "round-1",
+      bettorWallet: walletAddress,
+      side: "A",
+      sourceAmount: "1.25",
+      goldAmount: "1.25",
+      status: "CONFIRMED",
+    });
+    expect(emitted).toEqual([
+      {
+        event: "betting:pool:updated",
+        payload: {
+          roundId: "round-1",
+          sideATotal: "0",
+          sideBTotal: "0",
+          sideACount: 0,
+          sideBCount: 0,
+        },
+      },
+    ]);
+  });
+
+  it("rejects per-wallet round spam before inserting another bet", async () => {
+    const { insertedBets, manager, tx } = createManager(
+      internals.MAX_BETS_PER_WALLET_PER_ROUND,
+    );
+
+    const result = await manager.placeBet({
+      roundId: "round-1",
+      side: "A",
+      amount: "1",
+      walletAddress: Keypair.generate().publicKey.toBase58(),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Too many bets for this wallet on this round",
+    });
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+    expect(tx.select).toHaveBeenCalledOnce();
+    expect(tx.insert).not.toHaveBeenCalled();
+    expect(insertedBets).toHaveLength(0);
+  });
+});

--- a/packages/server/tests/unit/systems/DuelScheduler/PayoutKeeper.test.ts
+++ b/packages/server/tests/unit/systems/DuelScheduler/PayoutKeeper.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __payoutKeeperTestInternals as internals,
+  claimDuePayoutJobIds,
+} from "../../../../src/systems/DuelScheduler/PayoutKeeper.js";
+
+function extractSqlText(query: unknown): string {
+  if (!query || typeof query !== "object" || !("queryChunks" in query)) {
+    return "";
+  }
+
+  const chunks = (query as { queryChunks?: unknown[] }).queryChunks;
+  if (!Array.isArray(chunks)) {
+    return "";
+  }
+
+  return chunks
+    .flatMap((chunk) => {
+      if (!chunk || typeof chunk !== "object" || !("value" in chunk)) {
+        return [];
+      }
+      const value = (chunk as { value?: unknown }).value;
+      return Array.isArray(value)
+        ? value.filter((entry): entry is string => typeof entry === "string")
+        : [];
+    })
+    .join(" ");
+}
+
+describe("claimDuePayoutJobIds", () => {
+  it("builds a locking claim query with FOR UPDATE SKIP LOCKED", async () => {
+    const capturedQueries: string[] = [];
+    const tx = {
+      execute: async (query: unknown) => {
+        capturedQueries.push(extractSqlText(query));
+        return { rows: [{ id: "job-1" }] };
+      },
+    } as Parameters<typeof claimDuePayoutJobIds>[0];
+
+    const claimed = await claimDuePayoutJobIds(tx, 1_000, 1);
+
+    expect(claimed).toEqual(["job-1"]);
+    expect(capturedQueries[0]).toContain("FOR UPDATE SKIP LOCKED");
+    expect(capturedQueries[0]).toContain('"solana_payout_jobs"');
+  });
+
+  it("does not claim the same pending row twice across workers", async () => {
+    const dueJobIds = ["job-1", "job-2"];
+    const lockedJobIds = new Set<string>();
+
+    const createTx = (): Parameters<typeof claimDuePayoutJobIds>[0] =>
+      ({
+        execute: async () => {
+          const available = dueJobIds.filter((id) => !lockedJobIds.has(id));
+          const claimed = available.slice(0, 1);
+          for (const id of claimed) {
+            lockedJobIds.add(id);
+          }
+          return {
+            rows: claimed.map((id) => ({ id })),
+          };
+        },
+      }) as Parameters<typeof claimDuePayoutJobIds>[0];
+
+    expect(await claimDuePayoutJobIds(createTx(), 1_000, 1)).toEqual(["job-1"]);
+    expect(await claimDuePayoutJobIds(createTx(), 1_000, 1)).toEqual(["job-2"]);
+    expect(await claimDuePayoutJobIds(createTx(), 1_000, 1)).toEqual([]);
+  });
+});
+
+describe("processOneJob", () => {
+  function createDb(params: { betSide: "A" | "B"; winnerId: string }): {
+    db: Parameters<typeof internals.processOneJob>[0];
+    updates: unknown[];
+  } {
+    let selectCall = 0;
+    const updates: unknown[] = [];
+    const db = {
+      execute: vi.fn(async () => ({
+        rows: [{ acquired: true }],
+      })),
+      select: vi.fn(() => {
+        const call = selectCall;
+        selectCall += 1;
+        if (call === 0) {
+          return {
+            from: () => ({
+              where: () => ({
+                limit: async () => [
+                  {
+                    id: "round-1",
+                    agentAId: "agent-a",
+                    agentBId: "agent-b",
+                    winnerId: params.winnerId,
+                  },
+                ],
+              }),
+            }),
+          };
+        }
+        return {
+          from: () => ({
+            where: async () => [
+              {
+                side: params.betSide,
+              },
+            ],
+          }),
+        };
+      }),
+      update: vi.fn(() => ({
+        set: (value: unknown) => {
+          updates.push(value);
+          return {
+            where: () => ({
+              returning: async () => [{ id: "job-1" }],
+            }),
+          };
+        },
+      })),
+    } as Parameters<typeof internals.processOneJob>[0];
+    return { db, updates };
+  }
+
+  const job = {
+    id: "job-1",
+    roundId: "round-1",
+    bettorWallet: "wallet-1",
+    attempts: 0,
+  } as Parameters<typeof internals.processOneJob>[1];
+
+  it("marks a winning confirmed bet ready for payout", async () => {
+    const { db, updates } = createDb({ betSide: "A", winnerId: "agent-a" });
+
+    await internals.processOneJob(db, job);
+
+    expect(db.execute).toHaveBeenCalledOnce();
+    expect(updates).toContainEqual(
+      expect.objectContaining({ status: "READY_FOR_PAYOUT" }),
+    );
+  });
+
+  it("marks losing confirmed bets as no-payout", async () => {
+    const { db, updates } = createDb({ betSide: "B", winnerId: "agent-a" });
+
+    await internals.processOneJob(db, job);
+
+    expect(db.execute).toHaveBeenCalledOnce();
+    expect(updates).toContainEqual(
+      expect.objectContaining({ status: "NO_PAYOUT" }),
+    );
+  });
+
+  it("skips processing when another worker holds the advisory lock", async () => {
+    const { db, updates } = createDb({ betSide: "A", winnerId: "agent-a" });
+    db.execute = vi.fn(async () => ({
+      rows: [{ acquired: false }],
+    })) as typeof db.execute;
+
+    await internals.processOneJob(db, job);
+
+    expect(db.select).not.toHaveBeenCalled();
+    expect(updates).toEqual([]);
+  });
+});

--- a/packages/server/tests/unit/systems/DuelScheduler/SolanaArenaOperator.test.ts
+++ b/packages/server/tests/unit/systems/DuelScheduler/SolanaArenaOperator.test.ts
@@ -1,0 +1,124 @@
+import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
+import { describe, expect, it } from "vitest";
+import { __solanaArenaOperatorTestInternals as internals } from "../../../../src/systems/DuelScheduler/SolanaArenaOperator.js";
+
+const hex32 = (byte: string): string => byte.repeat(32);
+
+describe("SolanaArenaOperator serialization", () => {
+  it("serializes report_result with the expected Anchor/Borsh byte layout", () => {
+    const reporter = Keypair.generate().publicKey;
+    const oracleConfig = Keypair.generate().publicKey;
+    const duelState = Keypair.generate().publicKey;
+    const programId = Keypair.generate().publicKey;
+    const metadataUri = "ipfs://result";
+    const seed = 0x0102030405060708n;
+    const duelEndTs = 1_777_777_777n;
+
+    const instruction = internals.buildReportResultInstruction({
+      reporter,
+      oracleConfig,
+      duelState,
+      programId,
+      duelKeyBytes: internals.hexToBytes32(hex32("01")),
+      winner: internals.MARKET_SIDE.A,
+      seed,
+      replayHash: internals.hexToBytes32(hex32("02")),
+      resultHash: internals.hexToBytes32(hex32("03")),
+      duelEndTs,
+      metadataUri,
+    });
+
+    const data = instruction.data;
+    expect(instruction.programId.equals(programId)).toBe(true);
+    expect(instruction.keys.map((key) => key.pubkey.toBase58())).toEqual([
+      reporter.toBase58(),
+      oracleConfig.toBase58(),
+      duelState.toBase58(),
+    ]);
+    expect(data.subarray(0, 8)).toEqual(internals.REPORT_RESULT_DISCRIMINATOR);
+    expect(data.subarray(8, 40)).toEqual(Buffer.alloc(32, 0x01));
+    expect(data.readUInt8(40)).toBe(internals.MARKET_SIDE.A);
+    expect(data.readBigUInt64LE(41)).toBe(seed);
+    expect(data.subarray(49, 81)).toEqual(Buffer.alloc(32, 0x02));
+    expect(data.subarray(81, 113)).toEqual(Buffer.alloc(32, 0x03));
+    expect(data.readBigInt64LE(113)).toBe(duelEndTs);
+    expect(data.readUInt32LE(121)).toBe(Buffer.byteLength(metadataUri));
+    expect(data.subarray(125).toString("utf8")).toBe(metadataUri);
+    expect(data.length).toBe(125 + Buffer.byteLength(metadataUri));
+  });
+
+  it("serializes upsert_duel with deterministic key ordering and timestamps", () => {
+    const reporter = Keypair.generate().publicKey;
+    const oracleConfig = Keypair.generate().publicKey;
+    const duelState = Keypair.generate().publicKey;
+    const programId = Keypair.generate().publicKey;
+    const metadataUri = "ipfs://duel";
+
+    const instruction = internals.buildUpsertDuelInstruction({
+      reporter,
+      oracleConfig,
+      duelState,
+      programId,
+      duelKeyBytes: internals.hexToBytes32(hex32("0a")),
+      participantAHash: internals.hexToBytes32(hex32("0b")),
+      participantBHash: internals.hexToBytes32(hex32("0c")),
+      betOpenTs: 11n,
+      betCloseTs: 22n,
+      duelStartTs: 33n,
+      metadataUri,
+      status: internals.DUEL_STATUS.BettingOpen,
+    });
+
+    const data = instruction.data;
+    expect(instruction.keys.map((key) => key.pubkey.toBase58())).toEqual([
+      reporter.toBase58(),
+      oracleConfig.toBase58(),
+      duelState.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ]);
+    expect(data.subarray(0, 8)).toEqual(internals.UPSERT_DUEL_DISCRIMINATOR);
+    expect(data.subarray(8, 40)).toEqual(Buffer.alloc(32, 0x0a));
+    expect(data.subarray(40, 72)).toEqual(Buffer.alloc(32, 0x0b));
+    expect(data.subarray(72, 104)).toEqual(Buffer.alloc(32, 0x0c));
+    expect(data.readBigInt64LE(104)).toBe(11n);
+    expect(data.readBigInt64LE(112)).toBe(22n);
+    expect(data.readBigInt64LE(120)).toBe(33n);
+    expect(data.readUInt32LE(128)).toBe(Buffer.byteLength(metadataUri));
+    expect(data.subarray(132, 132 + metadataUri.length).toString("utf8")).toBe(
+      metadataUri,
+    );
+    expect(data.readUInt8(132 + metadataUri.length)).toBe(
+      internals.DUEL_STATUS.BettingOpen,
+    );
+  });
+
+  it("rejects malformed proof hex instead of silently truncating", () => {
+    expect(() => internals.hexToBytes32("abc")).toThrow(/32-byte/);
+    expect(() => internals.hexToBytes32(hex32("gg"))).toThrow(/32-byte/);
+  });
+
+  it("parses reporter keypairs without byte coercion", () => {
+    const keypair = Keypair.generate();
+    const parsed = internals.parseKeypair(
+      JSON.stringify([...keypair.secretKey]),
+    );
+
+    expect(parsed.publicKey.toBase58()).toBe(keypair.publicKey.toBase58());
+    expect(() =>
+      internals.parseKeypair(JSON.stringify([256, ...Array(63).fill(0)])),
+    ).toThrow(/integers in \[0, 255\]/);
+    expect(() =>
+      internals.parseKeypair(JSON.stringify(Array(63).fill(1))),
+    ).toThrow(/64 bytes/);
+  });
+
+  it("hashes participant IDs to stable 32-byte digests", () => {
+    const first = internals.hashParticipant("agent-a");
+    const second = internals.hashParticipant("agent-a");
+    const other = internals.hashParticipant("agent-b");
+
+    expect(first).toHaveLength(32);
+    expect(Buffer.from(first).equals(Buffer.from(second))).toBe(true);
+    expect(Buffer.from(first).equals(Buffer.from(other))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
This draft replaces the earlier server-side split attempts with a package-cohesive lane cut directly on `packages/server` plus the required `bun.lock` and server package dependency changes.

## Scope
- streaming authority and public-surface hardening
- duel scheduler and payout correctness work
- raw `sourceTimeline` contract production
- agent route and Eliza guardrails
- server package dependency/runtime changes required for these surfaces

## Includes the active review fixes
- thoughts limit normalization in `agent-routes.ts`

## Excludes
- `packages/client/**`
- `packages/shared/**`
- shared/client compute and runtime work

## Why this supersedes the earlier split
The previous three-way Hyperscape split was file-disjoint but not package-cohesive, which caused CI bleed across server boundaries. This branch re-cuts the work around the actual `packages/server` compile boundary.

## Supersedes
- #1184
- #1186
- server-owned portions previously mixed into #1185
